### PR TITLE
Improve error messages from API calls #5

### DIFF
--- a/algonaut_client/src/algod/v1/mod.rs
+++ b/algonaut_client/src/algod/v1/mod.rs
@@ -1,4 +1,5 @@
 use crate::error::AlgorandError;
+use crate::extensions::reqwest::ResponseExt;
 use algonaut_core::Round;
 use algonaut_transaction::SignedTransaction;
 use message::{
@@ -28,7 +29,7 @@ impl Client {
             .get(&format!("{}health", self.url))
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?;
+            .http_error_for_status()?;
         Ok(())
     }
 
@@ -40,7 +41,7 @@ impl Client {
             .headers(self.headers.clone())
             .header(AUTH_HEADER, &self.token)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -53,7 +54,7 @@ impl Client {
             .header(AUTH_HEADER, &self.token)
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -69,7 +70,7 @@ impl Client {
             .header(AUTH_HEADER, &self.token)
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -82,7 +83,7 @@ impl Client {
             .header(AUTH_HEADER, &self.token)
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -95,7 +96,7 @@ impl Client {
             .header(AUTH_HEADER, &self.token)
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -107,7 +108,7 @@ impl Client {
             .header(AUTH_HEADER, &self.token)
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -123,7 +124,7 @@ impl Client {
             .headers(self.headers.clone())
             .query(&[("max", limit.to_string())])
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -149,7 +150,7 @@ impl Client {
             .header(AUTH_HEADER, &self.token)
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -187,7 +188,7 @@ impl Client {
             .headers(self.headers.clone())
             .query(&query)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -211,7 +212,7 @@ impl Client {
             .headers(self.headers.clone())
             .body(raw.to_vec())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -224,7 +225,7 @@ impl Client {
             .header(AUTH_HEADER, &self.token)
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -244,7 +245,7 @@ impl Client {
             .header(AUTH_HEADER, &self.token)
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -257,7 +258,7 @@ impl Client {
             .header(AUTH_HEADER, &self.token)
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -270,7 +271,7 @@ impl Client {
             .header(AUTH_HEADER, &self.token)
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }

--- a/algonaut_client/src/algod/v2/mod.rs
+++ b/algonaut_client/src/algod/v2/mod.rs
@@ -1,4 +1,5 @@
 use crate::error::AlgorandError;
+use crate::extensions::reqwest::ResponseExt;
 use algonaut_core::Round;
 use message::*;
 use reqwest::header::HeaderMap;
@@ -24,7 +25,7 @@ impl Client {
             .get(&format!("{}genesis", self.url))
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -37,7 +38,7 @@ impl Client {
             .get(&format!("{}health", self.url))
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?;
+            .http_error_for_status()?;
 
         Ok(())
     }
@@ -50,7 +51,7 @@ impl Client {
             .headers(self.headers.clone())
             .header(AUTH_HEADER, &self.token)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .text()?;
 
         Ok(response)
@@ -66,7 +67,7 @@ impl Client {
             .headers(self.headers.clone())
             .header(AUTH_HEADER, &self.token)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -90,7 +91,7 @@ impl Client {
             .headers(self.headers.clone())
             .query(&[("max", max.to_string())])
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -106,7 +107,7 @@ impl Client {
             .headers(self.headers.clone())
             .header(AUTH_HEADER, &self.token)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -123,7 +124,7 @@ impl Client {
             .headers(self.headers.clone())
             .header(AUTH_HEADER, &self.token)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -137,7 +138,7 @@ impl Client {
             .headers(self.headers.clone())
             .header(AUTH_HEADER, &self.token)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -151,7 +152,7 @@ impl Client {
             .headers(self.headers.clone())
             .header(AUTH_HEADER, &self.token)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -165,7 +166,7 @@ impl Client {
             .headers(self.headers.clone())
             .header(AUTH_HEADER, &self.token)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -179,7 +180,7 @@ impl Client {
             .headers(self.headers.clone())
             .header(AUTH_HEADER, &self.token)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -224,7 +225,7 @@ impl Client {
             .headers(self.headers.clone())
             .query(&query)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -239,7 +240,7 @@ impl Client {
             .header(AUTH_HEADER, &self.token)
             .query(&[("timeout", timeout.to_string())])
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(())
@@ -253,7 +254,7 @@ impl Client {
             .header(AUTH_HEADER, &self.token)
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -270,7 +271,7 @@ impl Client {
             .header(AUTH_HEADER, &self.token)
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -290,7 +291,7 @@ impl Client {
             .header("Content-Type", "application/x-binary")
             .body(teal)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -310,7 +311,7 @@ impl Client {
             .header("Content-Type", "application/json")
             .json(req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -329,7 +330,7 @@ impl Client {
             .header("Content-Type", "application/x-binary")
             .body(rawtxn.to_vec())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -343,7 +344,7 @@ impl Client {
             .header(AUTH_HEADER, &self.token)
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -361,7 +362,7 @@ impl Client {
             .headers(self.headers.clone())
             .query(&[("max", max.to_string())])
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -387,7 +388,7 @@ impl Client {
             .header(AUTH_HEADER, &self.token)
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -401,7 +402,7 @@ impl Client {
             .headers(self.headers.clone())
             .header(AUTH_HEADER, &self.token)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)

--- a/algonaut_client/src/error.rs
+++ b/algonaut_client/src/error.rs
@@ -6,22 +6,22 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum AlgorandError {
     /// A builder error.
-    #[error("builder error {0}")]
+    #[error("builder error: {0}")]
     BuilderError(#[from] BuilderError),
     /// An api error.
-    #[error("api error {0}")]
+    #[error("api error: {0}")]
     ApiError(#[from] ApiError),
     /// A url parsing error
-    #[error("parse error {0}")]
+    #[error("parse error: {0}")]
     BadUrl(#[from] url::ParseError),
     /// Http error
-    #[error("http error {0}")]
+    #[error("http error: {0}")]
     HttpError(#[from] HttpError),
     /// Serialization error
-    #[error("serde encode error {0}")]
+    #[error("serde encode error: {0}")]
     RmpSerdeError(#[from] rmp_serde::encode::Error),
     /// Serialization error
-    #[error("serde encode error {0}")]
+    #[error("serde encode error: {0}")]
     SerdeJsonError(#[from] serde_json::Error),
 }
 

--- a/algonaut_client/src/error.rs
+++ b/algonaut_client/src/error.rs
@@ -16,13 +16,29 @@ pub enum AlgorandError {
     BadUrl(#[from] url::ParseError),
     /// Http error
     #[error("http error {0}")]
-    HttpError(#[from] reqwest::Error),
+    HttpError(#[from] HttpError),
     /// Serialization error
     #[error("serde encode error {0}")]
     RmpSerdeError(#[from] rmp_serde::encode::Error),
     /// Serialization error
     #[error("serde encode error {0}")]
     SerdeJsonError(#[from] serde_json::Error),
+}
+
+#[derive(Error, Debug, Display)]
+#[display(fmt = "{}, {}", message, reqwest_error)]
+pub struct HttpError {
+    pub message: String,
+    pub reqwest_error: reqwest::Error,
+}
+
+impl From<reqwest::Error> for AlgorandError {
+    fn from(error: reqwest::Error) -> Self {
+        AlgorandError::HttpError(HttpError {
+            reqwest_error: error,
+            message: "".to_owned(),
+        })
+    }
 }
 
 #[derive(Debug, Display, Error, From)]

--- a/algonaut_client/src/extensions/mod.rs
+++ b/algonaut_client/src/extensions/mod.rs
@@ -1,0 +1,1 @@
+pub(super) mod reqwest;

--- a/algonaut_client/src/extensions/reqwest.rs
+++ b/algonaut_client/src/extensions/reqwest.rs
@@ -1,0 +1,31 @@
+use crate::error::HttpError;
+use reqwest::blocking::Response;
+use serde::Deserialize;
+
+pub(crate) trait ResponseExt {
+    fn http_error_for_status(self) -> Result<Response, HttpError>;
+}
+
+impl ResponseExt for Response {
+    fn http_error_for_status(self) -> Result<Response, HttpError> {
+        match self.error_for_status_ref() {
+            Ok(_) => Ok(self),
+            Err(error) => match self.json::<HttpErrorPayload>() {
+                Ok(error_payload) => Err(HttpError {
+                    reqwest_error: error,
+                    message: error_payload.message,
+                }),
+                // JSON error is optional: if parsing fails we assume it's not present and return the call error.
+                Err(_) => Err(HttpError {
+                    reqwest_error: error,
+                    message: "".to_owned(),
+                }),
+            },
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct HttpErrorPayload {
+    message: String,
+}

--- a/algonaut_client/src/indexer/v2/mod.rs
+++ b/algonaut_client/src/indexer/v2/mod.rs
@@ -1,5 +1,6 @@
 use self::message::*;
 use crate::error::AlgorandError;
+use crate::extensions::reqwest::ResponseExt;
 use algonaut_core::Round;
 use reqwest::header::HeaderMap;
 
@@ -21,7 +22,7 @@ impl Client {
             .get(&format!("{}health", self.url))
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?;
+            .http_error_for_status()?;
         Ok(())
     }
 
@@ -34,7 +35,7 @@ impl Client {
             .header("Content-Type", "application/json")
             .json(query)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -53,7 +54,7 @@ impl Client {
             .header("Content-Type", "application/json")
             .json(&(round.map(|r| QueryRound { round: r })))
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -72,7 +73,7 @@ impl Client {
             .header("Content-Type", "application/json")
             .json(query)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -90,7 +91,7 @@ impl Client {
             .header("Content-Type", "application/json")
             .json(query)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -104,7 +105,7 @@ impl Client {
             .headers(self.headers.clone())
             .header("Content-Type", "application/json")
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -119,7 +120,7 @@ impl Client {
             .header("Content-Type", "application/json")
             .json(query)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -133,7 +134,7 @@ impl Client {
             .headers(self.headers.clone())
             .header("Content-Type", "application/json")
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -152,7 +153,7 @@ impl Client {
             .header("Content-Type", "application/json")
             .json(query)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -171,7 +172,7 @@ impl Client {
             .header("Content-Type", "application/json")
             .json(query)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -184,7 +185,7 @@ impl Client {
             .get(&format!("{}v2/blocks/{}", self.url, round))
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -202,7 +203,7 @@ impl Client {
             .header("Content-Type", "application/json")
             .json(query)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)
@@ -215,7 +216,7 @@ impl Client {
             .get(&format!("{}v2/transactions/{}", self.url, id))
             .headers(self.headers.clone())
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
 
         Ok(response)

--- a/algonaut_client/src/kmd/v1/mod.rs
+++ b/algonaut_client/src/kmd/v1/mod.rs
@@ -1,4 +1,5 @@
 use crate::error::AlgorandError;
+use crate::extensions::reqwest::ResponseExt;
 use algonaut_core::MultisigSignature;
 use algonaut_crypto::{Ed25519PublicKey, MasterDerivationKey};
 use algonaut_transaction::Transaction;
@@ -33,7 +34,7 @@ impl Client {
             .header(KMD_TOKEN_HEADER, &self.token)
             .header("Accept", "application/json")
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -46,7 +47,7 @@ impl Client {
             .header(KMD_TOKEN_HEADER, &self.token)
             .header("Accept", "application/json")
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -73,7 +74,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -100,7 +101,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -120,7 +121,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -140,7 +141,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -164,7 +165,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -184,7 +185,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -206,7 +207,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -228,7 +229,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -254,7 +255,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -272,7 +273,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -296,7 +297,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -313,7 +314,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -338,7 +339,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -358,7 +359,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -384,7 +385,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -406,7 +407,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -430,7 +431,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }
@@ -461,7 +462,7 @@ impl Client {
             .header("Accept", "application/json")
             .json(&req)
             .send()?
-            .error_for_status()?
+            .http_error_for_status()?
             .json()?;
         Ok(response)
     }

--- a/algonaut_client/src/lib.rs
+++ b/algonaut_client/src/lib.rs
@@ -2,6 +2,8 @@
 pub mod algod;
 ///
 pub mod error;
+///
+mod extensions;
 /// Algorand's indexer
 pub mod indexer;
 /// Key management daemon


### PR DESCRIPTION
The api messages now show in `AlgorandError`: 

Debug:
> Err(HttpError(HttpError { message: "failed to parse the address", reqwest_error: reqwest::Error { kind: Status(400), url: Url { scheme: "http", username: "", password: None, host: Some(Domain("localhost")), port: Some(4001), path: "/v2/accounts/a", query: None, fragment: None } } }))

Display:
> http error: failed to parse the address, HTTP status client error (400 Bad Request) for url (http://localhost:4001/v2/accounts/a)

Basically, `reqwest::Error` is mapped to `HttpError`, which contains the error and a message. If the api doesn't return any message, or it's not a http status error, message is an empty string.

Closes #5 