### PR TITLE
Create dedicated api transaction and fix serialization

### DIFF
--- a/algonaut_client/src/algod/v1/mod.rs
+++ b/algonaut_client/src/algod/v1/mod.rs
@@ -1,7 +1,7 @@
 use crate::error::AlgorandError;
 use crate::extensions::reqwest::ResponseExt;
 use algonaut_core::Round;
-use algonaut_transaction::api_transaction::ApiSignedTransaction;
+use algonaut_core::ToMsgPack;
 use algonaut_transaction::SignedTransaction;
 use message::{
     Account, Block, NodeStatus, PendingTransactions, QueryAccountTransactions, Supply, Transaction,
@@ -179,9 +179,7 @@ impl Client {
         &self,
         signed_transaction: &SignedTransaction,
     ) -> Result<TransactionId, AlgorandError> {
-        let bytes =
-            rmp_serde::to_vec_named(&ApiSignedTransaction::from(signed_transaction.to_owned()))?;
-        self.raw_transaction(&bytes)
+        self.raw_transaction(&signed_transaction.to_msg_pack()?)
     }
 
     /// Broadcasts a raw transaction to the network

--- a/algonaut_client/src/algod/v1/mod.rs
+++ b/algonaut_client/src/algod/v1/mod.rs
@@ -1,6 +1,7 @@
 use crate::error::AlgorandError;
 use crate::extensions::reqwest::ResponseExt;
 use algonaut_core::Round;
+use algonaut_transaction::api_transaction::ApiSignedTransaction;
 use algonaut_transaction::SignedTransaction;
 use message::{
     Account, Block, NodeStatus, PendingTransactions, QueryAccountTransactions, Supply, Transaction,
@@ -178,7 +179,8 @@ impl Client {
         &self,
         signed_transaction: &SignedTransaction,
     ) -> Result<TransactionId, AlgorandError> {
-        let bytes = rmp_serde::to_vec_named(signed_transaction)?;
+        let bytes =
+            rmp_serde::to_vec_named(&ApiSignedTransaction::from(signed_transaction.to_owned()))?;
         self.raw_transaction(&bytes)
     }
 

--- a/algonaut_client/src/kmd/v1/mod.rs
+++ b/algonaut_client/src/kmd/v1/mod.rs
@@ -1,8 +1,8 @@
 use crate::error::AlgorandError;
 use crate::extensions::reqwest::ResponseExt;
 use algonaut_core::MultisigSignature;
+use algonaut_core::ToMsgPack;
 use algonaut_crypto::{Ed25519PublicKey, MasterDerivationKey};
-use algonaut_transaction::api_transaction::ApiTransaction;
 use algonaut_transaction::Transaction;
 use message::*;
 
@@ -327,11 +327,9 @@ impl Client {
         wallet_password: &str,
         transaction: &Transaction,
     ) -> Result<SignTransactionResponse, AlgorandError> {
-        let transaction_bytes =
-            rmp_serde::to_vec_named(&ApiTransaction::from(transaction.clone()))?;
         let req = SignTransactionRequest {
             wallet_handle_token: wallet_handle.to_string(),
-            transaction: transaction_bytes,
+            transaction: transaction.to_msg_pack()?,
             wallet_password: wallet_password.to_string(),
         };
         let response = self
@@ -449,11 +447,9 @@ impl Client {
         public_key: Ed25519PublicKey,
         partial_multisig: Option<MultisigSignature>,
     ) -> Result<SignMultisigTransactionResponse, AlgorandError> {
-        let transaction_bytes =
-            rmp_serde::to_vec_named(&ApiTransaction::from(transaction.clone()))?;
         let req = SignMultisigTransactionRequest {
             wallet_handle_token: wallet_handle.to_string(),
-            transaction: transaction_bytes,
+            transaction: transaction.to_msg_pack()?,
             public_key,
             partial_multisig,
             wallet_password: wallet_password.to_string(),

--- a/algonaut_client/src/kmd/v1/mod.rs
+++ b/algonaut_client/src/kmd/v1/mod.rs
@@ -2,6 +2,7 @@ use crate::error::AlgorandError;
 use crate::extensions::reqwest::ResponseExt;
 use algonaut_core::MultisigSignature;
 use algonaut_crypto::{Ed25519PublicKey, MasterDerivationKey};
+use algonaut_transaction::api_transaction::ApiTransaction;
 use algonaut_transaction::Transaction;
 use message::*;
 
@@ -326,7 +327,8 @@ impl Client {
         wallet_password: &str,
         transaction: &Transaction,
     ) -> Result<SignTransactionResponse, AlgorandError> {
-        let transaction_bytes = rmp_serde::to_vec_named(transaction)?;
+        let transaction_bytes =
+            rmp_serde::to_vec_named(&ApiTransaction::from(transaction.clone()))?;
         let req = SignTransactionRequest {
             wallet_handle_token: wallet_handle.to_string(),
             transaction: transaction_bytes,
@@ -447,7 +449,8 @@ impl Client {
         public_key: Ed25519PublicKey,
         partial_multisig: Option<MultisigSignature>,
     ) -> Result<SignMultisigTransactionResponse, AlgorandError> {
-        let transaction_bytes = rmp_serde::to_vec_named(transaction)?;
+        let transaction_bytes =
+            rmp_serde::to_vec_named(&ApiTransaction::from(transaction.clone()))?;
         let req = SignMultisigTransactionRequest {
             wallet_handle_token: wallet_handle.to_string(),
             transaction: transaction_bytes,

--- a/algonaut_client/tests/test_trasactions.rs
+++ b/algonaut_client/tests/test_trasactions.rs
@@ -2,6 +2,7 @@ use algonaut_client::algod::v1::message::QueryAccountTransactions;
 use algonaut_client::{Algod, Kmd};
 use algonaut_core::{Address, LogicSignature, MicroAlgos, MultisigAddress};
 use algonaut_crypto::MasterDerivationKey;
+use algonaut_transaction::ApiSignedTransaction;
 use algonaut_transaction::{account::Account, ConfigureAsset, Pay, SignedTransaction, Txn};
 use data_encoding::BASE64;
 use dotenv::dotenv;
@@ -151,7 +152,8 @@ byte 0xFF
         transaction_id: "".to_owned(),
     };
 
-    let transaction_bytes = rmp_serde::to_vec_named(&signed_transaction)?;
+    let transaction_bytes =
+        rmp_serde::to_vec_named(&ApiSignedTransaction::from(signed_transaction))?;
 
     // Broadcast the transaction to the network
     // Note this transaction will get rejected because the accounts do not have any tokens
@@ -221,7 +223,8 @@ int 1
         transaction_id: "".to_owned(),
     };
 
-    let transaction_bytes = rmp_serde::to_vec_named(&signed_transaction)?;
+    let transaction_bytes =
+        rmp_serde::to_vec_named(&ApiSignedTransaction::from(signed_transaction))?;
 
     // Broadcast the transaction to the network
     // Note this transaction will get rejected because the accounts do not have any tokens
@@ -297,7 +300,8 @@ int 1
         transaction_id: "".to_owned(),
     };
 
-    let transaction_bytes = rmp_serde::to_vec_named(&signed_transaction)?;
+    let transaction_bytes =
+        rmp_serde::to_vec_named(&ApiSignedTransaction::from(signed_transaction))?;
 
     // Broadcast the transaction to the network
     // Note this transaction will get rejected because the accounts do not have any tokens
@@ -351,7 +355,6 @@ fn test_create_asset_transaction() -> Result<(), Box<dyn Error>> {
             ConfigureAsset::new()
                 .asset_name("Foo".to_owned())
                 .decimals(2)
-                .config_asset(0)
                 .total(1000000)
                 .unit_name("FOO".to_owned())
                 .build(),

--- a/algonaut_client/tests/test_trasactions.rs
+++ b/algonaut_client/tests/test_trasactions.rs
@@ -1,8 +1,7 @@
 use algonaut_client::algod::v1::message::QueryAccountTransactions;
 use algonaut_client::{Algod, Kmd};
-use algonaut_core::{Address, LogicSignature, MicroAlgos, MultisigAddress};
+use algonaut_core::{Address, LogicSignature, MicroAlgos, MultisigAddress, ToMsgPack};
 use algonaut_crypto::MasterDerivationKey;
-use algonaut_transaction::ApiSignedTransaction;
 use algonaut_transaction::{account::Account, ConfigureAsset, Pay, SignedTransaction, Txn};
 use data_encoding::BASE64;
 use dotenv::dotenv;
@@ -152,8 +151,7 @@ byte 0xFF
         transaction_id: "".to_owned(),
     };
 
-    let transaction_bytes =
-        rmp_serde::to_vec_named(&ApiSignedTransaction::from(signed_transaction))?;
+    let transaction_bytes = signed_transaction.to_msg_pack()?;
 
     // Broadcast the transaction to the network
     // Note this transaction will get rejected because the accounts do not have any tokens
@@ -223,8 +221,7 @@ int 1
         transaction_id: "".to_owned(),
     };
 
-    let transaction_bytes =
-        rmp_serde::to_vec_named(&ApiSignedTransaction::from(signed_transaction))?;
+    let transaction_bytes = signed_transaction.to_msg_pack()?;
 
     // Broadcast the transaction to the network
     // Note this transaction will get rejected because the accounts do not have any tokens
@@ -300,8 +297,7 @@ int 1
         transaction_id: "".to_owned(),
     };
 
-    let transaction_bytes =
-        rmp_serde::to_vec_named(&ApiSignedTransaction::from(signed_transaction))?;
+    let transaction_bytes = signed_transaction.to_msg_pack()?;
 
     // Broadcast the transaction to the network
     // Note this transaction will get rejected because the accounts do not have any tokens

--- a/algonaut_core/Cargo.toml
+++ b/algonaut_core/Cargo.toml
@@ -17,3 +17,4 @@ derive_more = "0.99.13"
 serde = {version = "1.0", features = ["derive"]}
 sha2 = "0.8.0"
 static_assertions = "0.3.4"
+rmp-serde = "0.14.0"

--- a/algonaut_core/src/lib.rs
+++ b/algonaut_core/src/lib.rs
@@ -369,6 +369,12 @@ impl Serialize for LogicSignature {
     }
 }
 
+pub trait ToMsgPack: Serialize {
+    fn to_msg_pack(&self) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+        rmp_serde::to_vec_named(&self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/algonaut_transaction/src/account.rs
+++ b/algonaut_transaction/src/account.rs
@@ -91,10 +91,8 @@ impl Account {
         &self,
         transaction: &Transaction,
     ) -> Result<SignedTransaction, AlgorandError> {
-        let encoded_tx = rmp_serde::to_vec_named(transaction)?;
-        let mut prefix_encoded_tx = b"TX".to_vec();
-        prefix_encoded_tx.extend_from_slice(&encoded_tx);
-        let signature = self.sign(&prefix_encoded_tx);
+        let transaction_bytes = &transaction.bytes_to_sign()?;
+        let signature = self.sign(&transaction_bytes);
         let id = BASE32_NOPAD.encode(&ChecksumAlg::digest(&signature.0));
         Ok(SignedTransaction {
             transaction: transaction.clone(),

--- a/algonaut_transaction/src/account.rs
+++ b/algonaut_transaction/src/account.rs
@@ -3,6 +3,7 @@ use crate::error::{AlgorandError, ApiError};
 use crate::transaction::{SignedTransaction, Transaction};
 use algonaut_core::{
     Address, LogicSignature, MultisigAddress, MultisigSignature, MultisigSubsig, Signature,
+    ToMsgPack,
 };
 use algonaut_crypto::mnemonic;
 use algonaut_crypto::Ed25519PublicKey;
@@ -76,7 +77,7 @@ impl Account {
 
     /// Sign a bid with the account's private key
     pub fn sign_bid(&self, bid: Bid) -> Result<SignedBid, AlgorandError> {
-        let encoded_bid = rmp_serde::to_vec_named(&bid)?;
+        let encoded_bid = bid.to_msg_pack()?;
         let mut prefix_encoded_bid = b"aB".to_vec();
         prefix_encoded_bid.extend_from_slice(&encoded_bid);
         let signature = self.sign(&prefix_encoded_bid);

--- a/algonaut_transaction/src/api_transaction.rs
+++ b/algonaut_transaction/src/api_transaction.rs
@@ -1,5 +1,6 @@
 use algonaut_core::{
-    Address, LogicSignature, MicroAlgos, MultisigSignature, Round, Signature, VotePk, VrfPk,
+    Address, LogicSignature, MicroAlgos, MultisigSignature, Round, Signature, ToMsgPack, VotePk,
+    VrfPk,
 };
 use algonaut_crypto::HashDigest;
 use serde::Serialize;
@@ -351,5 +352,32 @@ impl From<StateSchema> for ApiStateSchema {
             number_ints: state_schema.number_ints,
             number_byteslices: state_schema.number_byteslices,
         }
+    }
+}
+
+impl ToMsgPack for ApiTransaction {}
+impl ToMsgPack for ApiSignedTransaction {}
+impl ToMsgPack for Transaction {}
+impl ToMsgPack for SignedTransaction {}
+
+/// Convenience to call to_msg_pack() directly on Transaction
+impl Serialize for Transaction {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let api_transaction: ApiTransaction = self.to_owned().into();
+        api_transaction.serialize(serializer)
+    }
+}
+
+/// Convenience to call to_msg_pack() directly on SignedTransaction
+impl Serialize for SignedTransaction {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let api_transaction: ApiSignedTransaction = self.to_owned().into();
+        api_transaction.serialize(serializer)
     }
 }

--- a/algonaut_transaction/src/api_transaction.rs
+++ b/algonaut_transaction/src/api_transaction.rs
@@ -1,0 +1,355 @@
+use algonaut_core::{
+    Address, LogicSignature, MicroAlgos, MultisigSignature, Round, Signature, VotePk, VrfPk,
+};
+use algonaut_crypto::HashDigest;
+use serde::Serialize;
+
+use crate::{transaction::StateSchema, SignedTransaction, Transaction, TransactionType};
+
+// Important: When signing:
+// - Fields have to be sorted alphabetically.
+// - Keys must be excluded if they've no value.
+// The signature validation fails otherwise.
+#[derive(Debug, Serialize)]
+pub struct ApiTransaction {
+    #[serde(rename = "aamt", skip_serializing_if = "Option::is_none")]
+    pub asset_amount: Option<u64>,
+
+    #[serde(rename = "aclose", skip_serializing_if = "Option::is_none")]
+    pub asset_close_to: Option<Address>,
+
+    #[serde(rename = "afrz", skip_serializing_if = "Option::is_none")]
+    pub frozen: Option<bool>,
+
+    #[serde(rename = "amt", skip_serializing_if = "Option::is_none")]
+    pub amount: Option<u64>,
+
+    #[serde(rename = "apaa", skip_serializing_if = "Option::is_none")]
+    pub app_arguments: Option<Vec<u8>>,
+
+    #[serde(rename = "apan", skip_serializing_if = "Option::is_none")]
+    pub on_complete: Option<u64>,
+
+    #[serde(rename = "apap", skip_serializing_if = "Option::is_none")]
+    pub approval_program: Option<Address>,
+
+    #[serde(rename = "apar", skip_serializing_if = "Option::is_none")]
+    pub asset_params: Option<ApiAssetParams>,
+
+    #[serde(rename = "apas", skip_serializing_if = "Option::is_none")]
+    pub foreign_assets: Option<Address>,
+
+    #[serde(rename = "apat", skip_serializing_if = "Option::is_none")]
+    pub accounts: Option<Vec<Address>>,
+
+    #[serde(rename = "apfa", skip_serializing_if = "Option::is_none")]
+    pub foreign_apps: Option<Address>,
+
+    #[serde(rename = "apgs", skip_serializing_if = "Option::is_none")]
+    pub global_state_schema: Option<ApiStateSchema>,
+
+    #[serde(rename = "apid", skip_serializing_if = "Option::is_none")]
+    pub app_id: Option<u64>,
+
+    #[serde(rename = "apls", skip_serializing_if = "Option::is_none")]
+    pub local_state_schema: Option<ApiStateSchema>,
+
+    #[serde(rename = "apsu", skip_serializing_if = "Option::is_none")]
+    pub clear_state_program: Option<Address>,
+
+    #[serde(rename = "arcv", skip_serializing_if = "Option::is_none")]
+    pub asset_receiver: Option<Address>,
+
+    #[serde(rename = "asnd", skip_serializing_if = "Option::is_none")]
+    pub asset_sender: Option<Address>,
+
+    #[serde(rename = "caid", skip_serializing_if = "Option::is_none")]
+    pub config_asset: Option<u64>,
+
+    #[serde(rename = "close", skip_serializing_if = "Option::is_none")]
+    pub close_reminder_to: Option<Address>,
+
+    #[serde(rename = "fadd", skip_serializing_if = "Option::is_none")]
+    pub freeze_account: Option<Address>,
+
+    #[serde(rename = "faid", skip_serializing_if = "Option::is_none")]
+    pub asset_id: Option<u64>,
+
+    #[serde(rename = "fee")]
+    pub fee: MicroAlgos,
+
+    #[serde(rename = "fv")]
+    pub first_valid: Round,
+
+    #[serde(rename = "gen", skip_serializing_if = "Option::is_none")]
+    pub genesis_id: Option<String>,
+
+    #[serde(rename = "gh")]
+    pub genesis_hash: HashDigest,
+
+    #[serde(rename = "grp", skip_serializing_if = "Option::is_none")]
+    pub group: Option<HashDigest>,
+
+    #[serde(rename = "lv")]
+    pub last_valid: Round,
+
+    #[serde(rename = "lx", skip_serializing_if = "Option::is_none")]
+    pub lease: Option<HashDigest>,
+
+    #[serde(rename = "nonpart", skip_serializing_if = "Option::is_none")]
+    pub nonparticipating: Option<bool>,
+
+    #[serde(
+        rename = "note",
+        with = "serde_bytes",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub note: Option<Vec<u8>>,
+
+    #[serde(rename = "rcv", skip_serializing_if = "Option::is_none")]
+    pub receiver: Option<Address>,
+
+    #[serde(rename = "rekey", skip_serializing_if = "Option::is_none")]
+    pub rekey_to: Option<Address>,
+
+    #[serde(rename = "selkey", skip_serializing_if = "Option::is_none")]
+    pub selection_pk: Option<VrfPk>,
+
+    #[serde(rename = "snd")]
+    pub sender: Address,
+
+    #[serde(rename = "type")]
+    pub type_: String,
+
+    #[serde(rename = "votefst", skip_serializing_if = "Option::is_none")]
+    pub vote_first: Option<Round>,
+
+    #[serde(rename = "votekd", skip_serializing_if = "Option::is_none")]
+    pub vote_key_dilution: Option<u64>,
+
+    #[serde(rename = "votekey", skip_serializing_if = "Option::is_none")]
+    pub vote_pk: Option<VotePk>,
+
+    #[serde(rename = "votelst", skip_serializing_if = "Option::is_none")]
+    pub vote_last: Option<Round>,
+
+    #[serde(rename = "xaid", skip_serializing_if = "Option::is_none")]
+    pub xfer: Option<u64>,
+}
+
+impl From<Transaction> for ApiTransaction {
+    fn from(t: Transaction) -> Self {
+        let mut api_t = ApiTransaction {
+            // Common fields
+            fee: t.fee,
+            first_valid: t.first_valid,
+            genesis_id: Some(t.genesis_id),
+            genesis_hash: t.genesis_hash,
+            group: t.group,
+            last_valid: t.last_valid,
+            lease: t.lease,
+            note: t.note,
+            rekey_to: t.rekey_to,
+            sender: t.sender,
+            type_: to_api_transaction_type(&t.txn_type).to_owned(),
+            ///////////////
+            asset_amount: None,
+            asset_close_to: None,
+            frozen: None,
+            amount: None,
+            app_arguments: None,
+            on_complete: None,
+            approval_program: None,
+            asset_params: None,
+            foreign_assets: None,
+            accounts: None,
+            foreign_apps: None,
+            global_state_schema: None,
+            app_id: None,
+            local_state_schema: None,
+            clear_state_program: None,
+            asset_receiver: None,
+            asset_sender: None,
+            config_asset: None,
+            close_reminder_to: None,
+            freeze_account: None,
+            asset_id: None,
+            receiver: None,
+            selection_pk: None,
+            vote_first: None,
+            vote_key_dilution: None,
+            vote_pk: None,
+            vote_last: None,
+            xfer: None,
+            nonparticipating: None,
+        };
+
+        match &t.txn_type {
+            TransactionType::Payment(payment) => {
+                api_t.receiver = Some(payment.receiver);
+                api_t.amount = Some(payment.amount.0);
+                api_t.close_reminder_to = payment.close_remainder_to;
+            }
+            TransactionType::KeyRegistration(reg) => {
+                api_t.vote_pk = Some(reg.vote_pk);
+                api_t.selection_pk = Some(reg.selection_pk);
+                api_t.vote_first = Some(reg.vote_first);
+                api_t.vote_last = Some(reg.vote_last);
+                api_t.vote_key_dilution = Some(reg.vote_key_dilution);
+                api_t.nonparticipating = reg.nonparticipating;
+            }
+            TransactionType::AssetConfigurationTransaction(config) => {
+                api_t.asset_params = Some(ApiAssetParams {
+                    asset_name: config.params.asset_name.to_owned(),
+                    decimals: config.params.decimals,
+                    default_frozen: config.params.default_frozen,
+                    total: config.params.total,
+                    unit_name: config.params.unit_name.to_owned(),
+                    meta_data_hash: config.params.meta_data_hash.to_owned(),
+                    url: config.params.url.to_owned(),
+                    clawback: config.params.clawback,
+                    freeze: config.params.freeze,
+                    manager: config.params.manager,
+                    reserve: config.params.reserve,
+                });
+                api_t.config_asset = config.config_asset;
+            }
+            TransactionType::AssetTransferTransaction(transfer) => {
+                api_t.xfer = Some(transfer.xfer);
+                api_t.amount = Some(transfer.amount);
+                if let Some(sender) = transfer.sender {
+                    api_t.sender = sender;
+                }
+                api_t.receiver = Some(transfer.receiver);
+                api_t.asset_close_to = Some(transfer.close_to);
+            }
+            TransactionType::AssetAcceptTransaction(accept) => {
+                api_t.xfer = Some(accept.xfer);
+                api_t.asset_sender = Some(accept.sender);
+                api_t.asset_receiver = Some(accept.receiver);
+            }
+            TransactionType::AssetClawbackTransaction(clawback) => {
+                api_t.xfer = Some(clawback.xfer);
+                api_t.asset_amount = Some(clawback.asset_amount);
+                api_t.asset_sender = Some(clawback.asset_sender);
+                api_t.asset_receiver = Some(clawback.asset_receiver);
+                api_t.asset_close_to = Some(clawback.asset_close_to);
+            }
+            TransactionType::AssetFreezeTransaction(freeze) => {
+                api_t.freeze_account = Some(freeze.freeze_account);
+                api_t.asset_id = Some(freeze.asset_id);
+                api_t.frozen = Some(freeze.frozen);
+            }
+            TransactionType::ApplicationCallTransaction(call) => {
+                api_t.app_id = Some(call.app_id);
+                api_t.on_complete = Some(call.on_complete);
+                api_t.accounts = call.accounts.to_owned();
+                api_t.approval_program = call.approval_program;
+                api_t.app_arguments = call.app_arguments.to_owned();
+                api_t.clear_state_program = call.clear_state_program;
+                api_t.foreign_apps = call.foreign_apps;
+                api_t.foreign_assets = call.foreign_assets;
+                api_t.global_state_schema = call.to_owned().global_state_schema.map(|s| s.into());
+                api_t.local_state_schema = call.to_owned().local_state_schema.map(|s| s.into());
+            }
+        }
+        api_t
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize)]
+pub struct ApiAssetParams {
+    #[serde(rename = "an", skip_serializing_if = "Option::is_none")]
+    pub asset_name: Option<String>,
+
+    #[serde(rename = "dc")]
+    pub decimals: u32,
+
+    #[serde(rename = "df", skip_serializing)]
+    pub default_frozen: bool,
+
+    #[serde(rename = "t")]
+    pub total: u64,
+
+    #[serde(rename = "un", skip_serializing_if = "Option::is_none")]
+    pub unit_name: Option<String>,
+
+    #[serde(rename = "am", skip_serializing_if = "Option::is_none")]
+    pub meta_data_hash: Option<Vec<u8>>,
+
+    #[serde(rename = "au", skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+
+    #[serde(rename = "c", skip_serializing_if = "Option::is_none")]
+    pub clawback: Option<Address>,
+
+    #[serde(rename = "f", skip_serializing_if = "Option::is_none")]
+    pub freeze: Option<Address>,
+
+    #[serde(rename = "m", skip_serializing_if = "Option::is_none")]
+    pub manager: Option<Address>,
+
+    #[serde(rename = "r", skip_serializing_if = "Option::is_none")]
+    pub reserve: Option<Address>,
+}
+
+fn to_api_transaction_type<'a>(type_: &TransactionType) -> &'a str {
+    match type_ {
+        TransactionType::Payment(_) => "pay",
+        TransactionType::KeyRegistration(_) => "keyreg",
+        TransactionType::AssetConfigurationTransaction(_) => "acfg",
+        TransactionType::AssetTransferTransaction(_) => "axfer",
+        TransactionType::AssetAcceptTransaction(_) => "axfer",
+        TransactionType::AssetClawbackTransaction(_) => "axfer",
+        TransactionType::AssetFreezeTransaction(_) => "afrz",
+        TransactionType::ApplicationCallTransaction(_) => "appl",
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ApiSignedTransaction {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sig: Option<Signature>,
+
+    #[serde(rename = "msig", skip_serializing_if = "Option::is_none")]
+    pub multisig: Option<MultisigSignature>,
+
+    #[serde(rename = "lsig", skip_serializing_if = "Option::is_none")]
+    pub logicsig: Option<LogicSignature>,
+
+    #[serde(rename = "txn")]
+    pub transaction: ApiTransaction,
+
+    #[serde(skip)]
+    pub transaction_id: String,
+}
+
+impl From<SignedTransaction> for ApiSignedTransaction {
+    fn from(t: SignedTransaction) -> Self {
+        ApiSignedTransaction {
+            sig: t.sig,
+            multisig: t.multisig,
+            logicsig: t.logicsig,
+            transaction: t.transaction.into(),
+            transaction_id: t.transaction_id,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ApiStateSchema {
+    #[serde(rename = "nui")]
+    pub number_ints: u64,
+
+    #[serde(rename = "nbs")]
+    pub number_byteslices: u64,
+}
+
+impl From<StateSchema> for ApiStateSchema {
+    fn from(state_schema: StateSchema) -> Self {
+        ApiStateSchema {
+            number_ints: state_schema.number_ints,
+            number_byteslices: state_schema.number_byteslices,
+        }
+    }
+}

--- a/algonaut_transaction/src/auction.rs
+++ b/algonaut_transaction/src/auction.rs
@@ -1,4 +1,4 @@
-use algonaut_core::{Address, Signature};
+use algonaut_core::{Address, Signature, ToMsgPack};
 use serde::{Deserialize, Serialize};
 
 /// A bid by a user as part of an auction.
@@ -34,3 +34,5 @@ pub struct SignedBid {
     /// A signature by the bidder, as identified in the bid ([Bid.bidder_key]) over the hash of the Bid.
     pub sig: Signature,
 }
+
+impl ToMsgPack for Bid {}

--- a/algonaut_transaction/src/builder.rs
+++ b/algonaut_transaction/src/builder.rs
@@ -18,7 +18,7 @@ pub struct Txn {
     genesis_id: String,
     group: Option<HashDigest>,
     lease: Option<HashDigest>,
-    note: Vec<u8>,
+    note: Option<Vec<u8>>,
     rekey_to: Option<Address>,
 }
 
@@ -72,6 +72,11 @@ impl Txn {
         self
     }
 
+    pub fn asset_transfer(mut self, txn: AssetTransferTransaction) -> Self {
+        self.txn_type = Some(TransactionType::AssetTransferTransaction(txn));
+        self
+    }
+
     pub fn genesis_id(mut self, genesis_id: String) -> Self {
         self.genesis_id = genesis_id;
         self
@@ -88,7 +93,7 @@ impl Txn {
     }
 
     pub fn note(mut self, note: Vec<u8>) -> Self {
-        self.note = note;
+        self.note = Some(note);
         self
     }
 
@@ -212,7 +217,7 @@ impl RegisterKey {
 /// A builder for [AssetConfigurationTransaction].
 #[derive(Default)]
 pub struct ConfigureAsset {
-    config_asset: u64,
+    config_asset: Option<u64>,
     total: u64,
     decimals: u32,
     default_frozen: bool,
@@ -232,7 +237,7 @@ impl ConfigureAsset {
     }
 
     pub fn config_asset(mut self, config_asset: u64) -> Self {
-        self.config_asset = config_asset;
+        self.config_asset = Some(config_asset);
         self
     }
 
@@ -355,7 +360,7 @@ impl TransferAsset {
         AssetTransferTransaction {
             xfer: self.xfer,
             amount: self.amount,
-            sender: self.sender.unwrap(),
+            sender: self.sender,
             receiver: self.receiver.unwrap(),
             close_to: self.close_to.unwrap(),
         }
@@ -447,7 +452,6 @@ impl ClawbackAsset {
 
     pub fn build(self) -> AssetClawbackTransaction {
         AssetClawbackTransaction {
-            sender: self.sender.unwrap(),
             xfer: self.xfer,
             asset_amount: self.asset_amount,
             asset_sender: self.asset_sender.unwrap(),

--- a/algonaut_transaction/src/lib.rs
+++ b/algonaut_transaction/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod account;
+pub mod api_transaction;
 pub mod auction;
 pub mod builder;
 pub mod error;
 pub mod transaction;
 
+pub use api_transaction::ApiSignedTransaction;
 pub use builder::{
     AcceptAsset, CallApplication, ClawbackAsset, ConfigureAsset, FreezeAsset, Pay, RegisterKey,
     TransferAsset, Txn,

--- a/algonaut_transaction/src/transaction.rs
+++ b/algonaut_transaction/src/transaction.rs
@@ -1,74 +1,59 @@
 use crate::account::Account;
+use crate::api_transaction::ApiSignedTransaction;
+use crate::api_transaction::ApiTransaction;
 use crate::error::AlgorandError;
 use algonaut_core::{Address, LogicSignature, MultisigSignature, Signature};
 use algonaut_core::{MicroAlgos, Round, VotePk, VrfPk};
 use algonaut_crypto::HashDigest;
-use serde::{Deserialize, Serialize, Serializer};
 
 const MIN_TXN_FEE: MicroAlgos = MicroAlgos(1000);
 
 /// Enum containing the types of transactions and their specific fields
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TransactionType {
-    #[serde(rename = "pay")]
     Payment(Payment),
-    #[serde(rename = "keyreg")]
     KeyRegistration(KeyRegistration),
-    #[serde(rename = "acfg")]
     AssetConfigurationTransaction(AssetConfigurationTransaction),
-    #[serde(rename = "axfer")]
     AssetTransferTransaction(AssetTransferTransaction),
-    #[serde(rename = "axfer")]
     AssetAcceptTransaction(AssetAcceptTransaction),
-    #[serde(rename = "axfer")]
     AssetClawbackTransaction(AssetClawbackTransaction),
-    #[serde(rename = "afrz")]
     AssetFreezeTransaction(AssetFreezeTransaction),
-    #[serde(rename = "appl")]
     ApplicationCallTransaction(ApplicationCallTransaction),
 }
 
 /// A transaction that can appear in a block
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Transaction {
     /// Paid by the sender to the FeeSink to prevent denial-of-service. The minimum fee on Algorand
     /// is currently 1000 microAlgos.
-    #[serde(rename = "fee")]
     pub fee: MicroAlgos,
 
     /// The first round for when the transaction is valid. If the transaction is sent prior to this
     /// round it will be rejected by the network.
-    #[serde(rename = "fv")]
     pub first_valid: Round,
 
     /// The hash of the genesis block of the network for which the transaction is valid. See the
     /// genesis hash for MainNet, TestNet, and BetaNet.
-    #[serde(rename = "gh")]
     pub genesis_hash: HashDigest,
 
     /// The ending round for which the transaction is valid. After this round, the transaction will
     /// be rejected by the network.
-    #[serde(rename = "lv")]
     pub last_valid: Round,
 
     /// The address of the account that pays the fee and amount.
-    #[serde(rename = "snd")]
     pub sender: Address,
 
     /// Specifies the type of transaction. This value is automatically generated using any of the
     /// developer tools.
-    #[serde(flatten)]
     pub txn_type: TransactionType,
 
     /// The human-readable string that identifies the network for the transaction. The genesis ID is
     /// found in the genesis block. See the genesis ID for MainNet, TestNet, and BetaNet.
-    #[serde(rename = "gen", default)]
     pub genesis_id: String,
 
     /// The group specifies that the transaction is part of a group and, if so, specifies the hash of
     /// the transaction group. Assign a group ID to a transaction through the workflow described in
     /// the Atomic Transfers Guide.
-    #[serde(rename = "grp", default)]
     pub group: Option<HashDigest>,
 
     /// A lease enforces mutual exclusion of transactions. If this field is nonzero, then once the
@@ -81,16 +66,13 @@ pub struct Transaction {
     /// spends. For example, if I send a transaction to the network and later realize my fee was too
     /// low, I could send another transaction with a higher fee, but the same lease value. This would
     /// ensure that only one of those transactions ends up getting confirmed during the validity period.
-    #[serde(rename = "lx", default)]
     pub lease: Option<HashDigest>,
 
     /// Any data up to 1000 bytes.
-    #[serde(with = "serde_bytes", default)]
-    pub note: Vec<u8>,
+    pub note: Option<Vec<u8>>,
 
     /// Specifies the authorized address. This address will be used to authorize all future transactions.
     /// Learn more about Rekeying accounts.
-    #[serde(rename = "rekey", default)]
     pub rekey_to: Option<Address>,
 }
 
@@ -101,437 +83,259 @@ impl Transaction {
         Ok(self)
     }
 
+    pub fn bytes_to_sign(&self) -> Result<Vec<u8>, AlgorandError> {
+        let encoded_tx = rmp_serde::to_vec_named(&ApiTransaction::from(self.to_owned()))?;
+        let mut prefix_encoded_tx = b"TX".to_vec();
+        prefix_encoded_tx.extend_from_slice(&encoded_tx);
+        Ok(prefix_encoded_tx)
+    }
+
     // Estimates the size of the encoded transaction, used in calculating the fee
     fn estimate_size(&self) -> Result<u64, AlgorandError> {
         let account = Account::generate();
-        let len = rmp_serde::to_vec_named(&account.sign_transaction(self)?)?.len() as u64;
+        let len = rmp_serde::to_vec_named(
+            &account
+                .sign_transaction(self)
+                .map(ApiSignedTransaction::from)?,
+        )?
+        .len() as u64;
         Ok(len)
     }
 }
 
-impl Serialize for Transaction {
-    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
-    where
-        S: Serializer,
-    {
-        use serde::ser::SerializeStruct;
-
-        // transaction the number of fields in the transaction
-        let type_len = match &self.txn_type {
-            TransactionType::Payment(payment) => {
-                1 + if payment.close_remainder_to.is_some() {
-                    1
-                } else {
-                    0
-                } + if payment.amount.0 != 0 { 1 } else { 0 }
-            }
-            TransactionType::KeyRegistration(_) => 5,
-            TransactionType::AssetConfigurationTransaction(_) => 2,
-            TransactionType::AssetTransferTransaction(_) => 5,
-            TransactionType::AssetAcceptTransaction(_) => 3,
-            TransactionType::AssetClawbackTransaction(_) => 6,
-            TransactionType::AssetFreezeTransaction(_) => 3,
-            TransactionType::ApplicationCallTransaction(_) => 10,
-        };
-
-        let len = 6
-            + type_len
-            + if self.note.is_empty() { 0 } else { 1 }
-            + if self.genesis_id.is_empty() { 0 } else { 1 };
-
-        // serialize fields common to all transactions
-        let mut state = serializer.serialize_struct("Transaction", len)?;
-        state.serialize_field("fee", &self.fee)?;
-        state.serialize_field("fv", &self.first_valid)?;
-        if !self.genesis_id.is_empty() {
-            state.serialize_field("gen", &self.genesis_id)?;
-        }
-        state.serialize_field("gh", &self.genesis_hash)?;
-        state.serialize_field("lv", &self.last_valid)?;
-        if !self.note.is_empty() {
-            state.serialize_field("note", &serde_bytes::ByteBuf::from(self.note.clone()))?;
-        }
-        state.serialize_field("snd", &self.sender)?;
-
-        // serialize different transaction types
-        match &self.txn_type {
-            TransactionType::Payment(p) => {
-                state.serialize_field("type", "pay")?;
-                // transaction's specific fields
-                if p.amount.0 != 0 {
-                    state.serialize_field("amt", &p.amount)?;
-                }
-                if p.close_remainder_to.is_some() {
-                    state.serialize_field("close", &p.close_remainder_to)?;
-                }
-                state.serialize_field("rcv", &p.receiver)?;
-            }
-            TransactionType::KeyRegistration(kr) => {
-                state.serialize_field("type", "keyreg")?;
-                // transaction's specific fields
-                state.serialize_field("selkey", &kr.selection_pk)?;
-                state.serialize_field("votefst", &kr.vote_first)?;
-                state.serialize_field("votekd", &kr.vote_key_dilution)?;
-                state.serialize_field("votekey", &kr.vote_pk)?;
-                state.serialize_field("votelst", &kr.vote_last)?;
-            }
-            TransactionType::AssetConfigurationTransaction(asa_conf) => {
-                state.serialize_field("type", "acfg")?;
-                // transaction's specific fields
-                state.serialize_field("caid", &asa_conf.config_asset)?;
-                state.serialize_field("apar", &asa_conf.params)?;
-            }
-            TransactionType::AssetTransferTransaction(asa_transf) => {
-                state.serialize_field("type", "axfer")?;
-                // transaction's specific fields
-                state.serialize_field("xaid", &asa_transf.xfer)?;
-                state.serialize_field("aamt", &asa_transf.amount)?;
-                state.serialize_field("asnd", &asa_transf.sender)?;
-                state.serialize_field("arcv", &asa_transf.receiver)?;
-                state.serialize_field("aclose", &asa_transf.close_to)?;
-            }
-            TransactionType::AssetAcceptTransaction(asa_accept) => {
-                state.serialize_field("type", "axfer")?;
-                // transaction's specific fields
-                state.serialize_field("xaid", &asa_accept.xfer)?;
-                state.serialize_field("asnd", &asa_accept.sender)?;
-                state.serialize_field("arcv", &asa_accept.receiver)?;
-            }
-            TransactionType::AssetClawbackTransaction(asa_claw) => {
-                state.serialize_field("type", "axfer")?;
-                // transaction's specific fields
-                state.serialize_field("snd", &asa_claw.sender)?;
-                state.serialize_field("xaid", &asa_claw.xfer)?;
-                state.serialize_field("aamt", &asa_claw.asset_amount)?;
-                state.serialize_field("asnd", &asa_claw.asset_sender)?;
-                state.serialize_field("arcv", &asa_claw.asset_receiver)?;
-                state.serialize_field("aclose", &asa_claw.asset_close_to)?;
-            }
-            TransactionType::AssetFreezeTransaction(asa_frz) => {
-                state.serialize_field("type", "afrz")?;
-                // transaction's specific fields
-                state.serialize_field("fadd", &asa_frz.freeze_account)?;
-                state.serialize_field("faid", &asa_frz.asset_id)?;
-                state.serialize_field("afrz", &asa_frz.frozen)?;
-            }
-            TransactionType::ApplicationCallTransaction(app_call) => {
-                state.serialize_field("type", "appl")?;
-                // transaction's specific fields
-                state.serialize_field("apid", &app_call.app_id)?;
-                state.serialize_field("apan", &app_call.on_complete)?;
-                state.serialize_field("apat", &app_call.accounts)?;
-                state.serialize_field("apap", &app_call.approval_program)?;
-                state.serialize_field("apaa", &app_call.app_arguments)?;
-                state.serialize_field("apsu", &app_call.clear_state_program)?;
-                state.serialize_field("apfa", &app_call.foreign_apps)?;
-                state.serialize_field("apas", &app_call.foreign_assets)?;
-                state.serialize_field("apgs", &app_call.global_state_schema)?;
-                state.serialize_field("apls", &app_call.local_state_schema)?;
-            }
-        }
-
-        state.end()
-    }
-}
-
 /// Fields for a payment transaction
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Payment {
     /// The address of the account that receives the amount.
-    #[serde(rename = "rcv")]
     pub receiver: Address,
 
     /// The total amount to be sent in microAlgos.
-    #[serde(rename = "amt", default)]
     pub amount: MicroAlgos,
 
     /// When set, it indicates that the transaction is requesting that the Sender account should
     /// be closed, and all remaining funds, after the fee and amount are paid, be transferred to
     /// this address.
-    #[serde(rename = "close")]
     pub close_remainder_to: Option<Address>,
 }
 
 /// Fields for a key registration transaction
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct KeyRegistration {
     /// The root participation public key. See Generate a Participation Key to learn more.
-    #[serde(rename = "votekey")]
     pub vote_pk: VotePk,
 
     /// The VRF public key.
-    #[serde(rename = "selkey")]
     pub selection_pk: VrfPk,
 
     /// The first round that the participation key is valid. Not to be confused with the FirstValid
     /// round of the keyreg transaction.
-    #[serde(rename = "votefst")]
     pub vote_first: Round,
 
     /// The last round that the participation key is valid. Not to be confused with the LastValid
     /// round of the keyreg transaction.
-    #[serde(rename = "votelst")]
     pub vote_last: Round,
 
     /// This is the dilution for the 2-level participation key.
-    #[serde(rename = "votekd")]
     pub vote_key_dilution: u64,
 
     /// All new Algorand accounts are participating by default. This means that they earn rewards.
     /// Mark an account nonparticipating by setting this value to true and this account will no
     /// longer earn rewards. It is unlikely that you will ever need to do this and exists mainly
     /// for economic-related functions on the network.
-    #[serde(rename = "nonpart", skip_serializing_if = "Option::is_none")]
     pub nonparticipating: Option<bool>,
 }
 
 /// This is used to create, configure and destroy an asset depending on which fields are set.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct AssetConfigurationTransaction {
+    /// See AssetParams table for all available fields.
+    pub params: AssetParams,
     /// For re-configure or destroy transactions, this is the unique asset ID. On asset creation,
     /// the ID is set to zero.
-    #[serde(rename = "caid")]
-    pub config_asset: u64,
-
-    /// See AssetParams table for all available fields.
-    #[serde(rename = "apar")]
-    pub params: AssetParams,
+    /// NOTE: Algorand's REST documentation seems incorrect. The ID has to be not set for creation to work.
+    pub config_asset: Option<u64>,
 }
 
 /// This is used to create or configure an asset.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct AssetParams {
-    /// The total number of base units of the asset to create. This number cannot be changed.
-    #[serde(rename = "t")]
-    pub total: u64,
-
+    /// The name of the asset. Supplied on creation. Example: Tether
+    pub asset_name: Option<String>,
     /// The number of digits to use after the decimal point when displaying the asset. If 0,
     /// the asset is not divisible. If 1, the base unit of the asset is in tenths. If 2,
     /// the base unit of the asset is in hundredths.
-    #[serde(rename = "dc")]
     pub decimals: u32,
-
     /// True to freeze holdings for this asset by default.
-    #[serde(rename = "df")]
+    // #[serde(rename = "df", skip_serializing_if = "is_false")]
     pub default_frozen: bool,
 
+    /// The total number of base units of the asset to create. This number cannot be changed.
+    pub total: u64,
+
     /// The name of a unit of this asset. Supplied on creation. Example: USDT
-    #[serde(rename = "un", skip_serializing_if = "Option::is_none")]
     pub unit_name: Option<String>,
-
-    /// The name of the asset. Supplied on creation. Example: Tether
-    #[serde(rename = "an", skip_serializing_if = "Option::is_none")]
-    pub asset_name: Option<String>,
-
-    /// Specifies a URL where more information about the asset can be retrieved. Max size is 32 bytes.
-    #[serde(rename = "au", skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
 
     /// This field is intended to be a 32-byte hash of some metadata that is relevant to your asset
     /// and/or asset holders. The format of this metadata is up to the application. This field can only
     /// be specified upon creation. An example might be the hash of some certificate that acknowledges
     /// the digitized asset as the official representation of a particular real-world asset.
-    #[serde(rename = "am", skip_serializing_if = "Option::is_none")]
     pub meta_data_hash: Option<Vec<u8>>,
 
-    /// The address of the account that can manage the configuration of the asset and destroy it.
-    #[serde(rename = "m", skip_serializing_if = "Option::is_none")]
-    pub manager: Option<Address>,
+    /// Specifies a URL where more information about the asset can be retrieved. Max size is 32 bytes.
+    pub url: Option<String>,
 
+    /// The address of the account that can clawback holdings of this asset. If empty, clawback is
+    /// not permitted.
+    pub clawback: Option<Address>,
+
+    /// The address of the account used to freeze holdings of this asset. If empty, freezing is not
+    /// permitted.
+    pub freeze: Option<Address>,
+
+    /// The address of the account that can manage the configuration of the asset and destroy it.
+    pub manager: Option<Address>,
     /// The address of the account that holds the reserve (non-minted) units of the asset. This address
     /// has no specific authority in the protocol itself. It is used in the case where you want to
     /// signal to holders of your asset that the non-minted units of the asset reside in an account
     /// that is different from the default creator account (the sender).
-    #[serde(rename = "r", skip_serializing_if = "Option::is_none")]
     pub reserve: Option<Address>,
-
-    /// The address of the account used to freeze holdings of this asset. If empty, freezing is not
-    /// permitted.
-    #[serde(rename = "f", skip_serializing_if = "Option::is_none")]
-    pub freeze: Option<Address>,
-
-    /// The address of the account that can clawback holdings of this asset. If empty, clawback is
-    /// not permitted.
-    #[serde(rename = "c", skip_serializing_if = "Option::is_none")]
-    pub clawback: Option<Address>,
 }
 
 /// This is used to transfer an asset.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AssetTransferTransaction {
     /// The unique ID of the asset to be transferred.
-    #[serde(rename = "xaid")]
     pub xfer: u64,
 
     /// The amount of the asset to be transferred. A zero amount transferred to self allocates that
     /// asset in the account's Asset map.
-    #[serde(rename = "aamt")]
     pub amount: u64,
 
     /// The sender of the transfer. The regular sender field should be used and this one set to the
     /// zero value for regular transfers between accounts. If this value is nonzero, it indicates a
     /// clawback transaction where the sender is the asset's clawback address and the asset sender
     /// is the address from which the funds will be withdrawn.
-    #[serde(rename = "asnd")]
-    pub sender: Address,
+    pub sender: Option<Address>,
 
     /// The recipient of the asset transfer.
-    #[serde(rename = "arcv")]
     pub receiver: Address,
 
     /// Specify this field to remove the asset holding from the sender account and reduce the
     /// account's minimum balance.
-    #[serde(rename = "aclose")]
     pub close_to: Address,
 }
 
 /// This is a special form of an Asset Transfer Transaction.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AssetAcceptTransaction {
     /// The unique ID of the asset to be transferred.
-    #[serde(rename = "xaid")]
     pub xfer: u64,
 
     /// The account which is allocating the asset to their account's Asset map.
-    #[serde(rename = "asnd")]
     pub sender: Address,
 
     /// The account which is allocating the asset to their account's Asset map.
-    #[serde(rename = "arcv")]
     pub receiver: Address,
 }
 
 /// This is a special form of an Asset Transfer Transaction.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AssetClawbackTransaction {
-    /// The sender of this transaction must be the clawback account specified in the asset
-    /// configuration.
-    #[serde(rename = "snd")]
-    pub sender: Address,
-
     /// The unique ID of the asset to be transferred.
-    #[serde(rename = "xaid")]
     pub xfer: u64,
 
     /// The amount of the asset to be transferred.
-    #[serde(rename = "aamt")]
     pub asset_amount: u64,
 
     /// The address from which the funds will be withdrawn.
-    #[serde(rename = "asnd")]
     pub asset_sender: Address,
 
     /// The recipient of the asset transfer.
-    #[serde(rename = "arcv")]
     pub asset_receiver: Address,
 
     /// Specify this field to remove the entire asset holding balance from the AssetSender
     /// account. It will not remove the asset holding.
-    #[serde(rename = "aclose")]
     pub asset_close_to: Address,
 }
 
 /// This is a special form of an Asset Transfer Transaction.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AssetFreezeTransaction {
     /// The address of the account whose asset is being frozen or unfrozen.
-    #[serde(rename = "fadd")]
     pub freeze_account: Address,
 
     /// The asset ID being frozen or unfrozen.
-    #[serde(rename = "faid")]
     pub asset_id: u64,
 
     /// True to freeze the asset.
-    #[serde(rename = "afrz")]
     pub frozen: bool,
 }
 
 ///
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ApplicationCallTransaction {
     /// ID of the application being configured or empty if creating.
-    #[serde(rename = "apid")]
     pub app_id: u64,
 
     /// Defines what additional actions occur with the transaction. See the OnComplete section of
     /// the TEAL spec for details.
-    #[serde(rename = "apan")]
     pub on_complete: u64,
 
     /// List of accounts in addition to the sender that may be accessed from the application's
     /// approval-program and clear-state-program.
-    #[serde(rename = "apat")]
     pub accounts: Option<Vec<Address>>,
 
     /// Logic executed for every application transaction, except when on-completion is set to
     /// "clear". It can read and write global state for the application, as well as account-specific
     /// local state. Approval programs may reject the transaction.
-    #[serde(rename = "apap")]
     pub approval_program: Option<Address>,
 
     /// Transaction specific arguments accessed from the application's approval-program and
     /// clear-state-program.
-    #[serde(rename = "apaa")]
     pub app_arguments: Option<Vec<u8>>,
 
     /// Logic executed for application transactions with on-completion set to "clear". It can read
     /// and write global state for the application, as well as account-specific local state. Clear
     /// state programs cannot reject the transaction.
-    #[serde(rename = "apsu")]
     pub clear_state_program: Option<Address>,
 
     /// Lists the applications in addition to the application-id whose global states may be accessed
     /// by this application's approval-program and clear-state-program. The access is read-only.
-    #[serde(rename = "apfa")]
     pub foreign_apps: Option<Address>,
 
     /// Lists the assets whose AssetParams may be accessed by this application's approval-program and
     /// clear-state-program. The access is read-only.
-    #[serde(rename = "apas")]
     pub foreign_assets: Option<Address>,
 
     /// Holds the maximum number of global state values defined within a StateSchema object.
-    #[serde(rename = "apgs")]
     pub global_state_schema: Option<StateSchema>,
 
     /// Holds the maximum number of local state values defined within a StateSchema object.
-    #[serde(rename = "apls")]
     pub local_state_schema: Option<StateSchema>,
 }
 
 /// Storage state schema. The StateSchema object is only required for the create application call
 /// transaction. The StateSchema object must be fully populated for both the GlobalStateSchema and
 /// LocalStateSchema objects.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StateSchema {
     /// Maximum number of integer values that may be stored in the [global || local] application
     /// key/value store. Immutable.
-    #[serde(rename = "nui")]
     pub number_ints: u64,
 
     /// Maximum number of byte slices values that may be stored in the [global || local] application
     /// key/value store. Immutable.
-    #[serde(rename = "nbs")]
     pub number_byteslices: u64,
 }
 
 /// Wraps a transaction in a signature. The encoding of this struct is suitable to be broadcast
 /// on the network
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+// #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SignedTransaction {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sig: Option<Signature>,
-
-    #[serde(rename = "msig", skip_serializing_if = "Option::is_none")]
     pub multisig: Option<MultisigSignature>,
-
-    #[serde(rename = "lsig", skip_serializing_if = "Option::is_none")]
     pub logicsig: Option<LogicSignature>,
-
-    #[serde(rename = "txn")]
     pub transaction: Transaction,
-
-    #[serde(skip)]
     pub transaction_id: String,
 }

--- a/examples/sign_offline.rs
+++ b/examples/sign_offline.rs
@@ -3,6 +3,7 @@ use algonaut::crypto::mnemonic;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::{Pay, Txn};
 use algonaut::Algod;
+use algonaut_transaction::ApiSignedTransaction;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;
@@ -49,7 +50,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // sign the transaction
     let signed_transaction = account.sign_transaction(&t)?;
-    let bytes = rmp_serde::to_vec_named(&signed_transaction)?;
+    let bytes = rmp_serde::to_vec_named(&ApiSignedTransaction::from(signed_transaction))?;
 
     let filename = "./signed.tx";
     let mut f = File::create(filename)?;


### PR DESCRIPTION
Closes https://github.com/manuelmauro/algonaut/issues/29

Removed too some ambiguity with optional values, if fields are not set it's always `None`, independently of the type. Removed the `Deserialize` implementation, as we're not using it yet. When we add `Deserialize` we don't have to add the `default` serde attribute again, because it works automatically for `Option`.