### PR TITLE
derive Default for all Query* structs

### DIFF
--- a/algonaut_client/src/algod/v1/message.rs
+++ b/algonaut_client/src/algod/v1/message.rs
@@ -325,7 +325,7 @@ pub struct PendingTransactions {
 }
 
 ///
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct QueryAccountTransactions {
     /// Do not fetch any transactions before this round.
     #[serde(rename = "firstRound")]

--- a/algonaut_client/src/indexer/v2/message.rs
+++ b/algonaut_client/src/indexer/v2/message.rs
@@ -4,7 +4,7 @@ use algonaut_encoding::deserialize_bytes;
 use serde::{Deserialize, Serialize};
 
 ///
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct QueryAccount {
     /// Application ID.
     #[serde(rename = "application-id")]
@@ -56,7 +56,7 @@ pub struct AccountResponse {
 }
 
 ///
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct QueryAccountInfo {
     /// Include all items including closed accounts, deleted applications, destroyed assets,
     /// opted-out asset holdings, and closed-out application localstates.
@@ -79,7 +79,7 @@ pub struct AccountInfoResponse {
 }
 
 /// Query account transactions.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct QueryAccountTransaction {
     /// Include results after the given time. Must be an RFC 3339 formatted string.
     #[serde(rename = "after-time", skip_serializing_if = "Option::is_none")]
@@ -167,7 +167,7 @@ pub struct AccountTransactionResponse {
 }
 
 /// Query applications.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct QueryApplications {
     /// Application ID.
     #[serde(rename = "application-id", skip_serializing_if = "Option::is_none")]
@@ -197,7 +197,7 @@ pub struct ApplicationResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct QueryApplicationInfo {
     /// Include all items including closed accounts, deleted applications, destroyed assets,
     /// opted-out asset holdings, and closed-out application localstates.
@@ -217,7 +217,7 @@ pub struct ApplicationInfoResponse {
 }
 
 /// Query assets.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct QueryAssets {
     /// Asset ID.
     #[serde(rename = "asset-id", skip_serializing_if = "Option::is_none")]
@@ -259,7 +259,7 @@ pub struct AssetResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct QueryAssetsInfo {
     /// Include all items including closed accounts, deleted applications, destroyed assets,
     /// opted-out asset holdings, and closed-out application localstates.
@@ -279,7 +279,7 @@ pub struct AssetsInfoResponse {
 }
 
 /// Query assets.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct QueryBalances {
     /// Results should have an amount greater than this value. MicroAlgos are the default currency
     /// unless an asset-id is provided, in which case the asset will be used.
@@ -323,7 +323,7 @@ pub struct BalancesResponse {
 }
 
 /// Query assets transactions.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct QueryAssetTransaction {
     /// Only include transactions with this address in one of the transaction fields.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -421,7 +421,7 @@ pub struct AssetTransactionResponse {
 }
 
 /// Query transactions.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct QueryTransaction {
     /// Only include transactions with this address in one of the transaction fields.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -1,0 +1,28 @@
+use algonaut_client::indexer::v2::message::QueryAccount;
+use algonaut_client::Indexer;
+use dotenv::dotenv;
+use std::env;
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // load variables in .env
+    dotenv().ok();
+
+    let indexer = Indexer::new()
+        .bind(env::var("INDEXER_URL")?.as_ref())
+        .client_v2()?;
+
+    // query Account using default query parameters (all None).
+    let accounts = indexer.accounts(&QueryAccount::default())?.accounts;
+    println!("found {} accounts", accounts.len());
+
+    // query Applications with custom query parameters.
+    let mut accounts_query = QueryAccount::default();
+    accounts_query.limit = Some(2); // why 2? see: https://github.com/algorand/indexer/issues/516
+
+    let accounts = indexer.accounts(&accounts_query)?.accounts;
+    println!("found {} accounts", accounts.len());
+
+    Ok(())
+}
+

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -25,4 +25,3 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
-


### PR DESCRIPTION
`Query*` struct fields are all optional, setting them all to `None` is how you'd represent a request to an endpoint without queries like `http://$INDEXER_URL/accounts`.

Methods like this require a `Query*` struct even if the structs fields are entirely `None`:

https://github.com/manuelmauro/algonaut/blob/8a3526390de4d5f9a79e399b0c8b8f2e2d0d6f01/algonaut_client/src/indexer/v2/mod.rs#L30

This commit derives the `Default` trait for all `Query*` structs which provides a convenient way of constructing queries without needing to write out the entire struct body simply to set values to `None` manually:

```rust
// query Account using default query parameters (all None).
let accounts = indexer.accounts(&QueryAccount::default())?.accounts;

// query Applications with custom query parameters.
let mut accounts_query = QueryAccount::default();
accounts_query.limit = Some(2);
let accounts = indexer.accounts(&accounts_query)?.accounts;
```