### PR TITLE
Fix incorrect transaction ids

### DIFF
--- a/algonaut_transaction/src/account.rs
+++ b/algonaut_transaction/src/account.rs
@@ -93,8 +93,8 @@ impl Account {
         transaction: &Transaction,
     ) -> Result<SignedTransaction, AlgorandError> {
         let transaction_bytes = &transaction.bytes_to_sign()?;
-        let signature = self.sign(&transaction_bytes);
-        let id = BASE32_NOPAD.encode(&ChecksumAlg::digest(&transaction.bytes_to_sign()?));
+        let signature = self.sign(transaction_bytes);
+        let id = BASE32_NOPAD.encode(&ChecksumAlg::digest(transaction_bytes));
         Ok(SignedTransaction {
             transaction: transaction.clone(),
             sig: Some(signature),

--- a/algonaut_transaction/src/account.rs
+++ b/algonaut_transaction/src/account.rs
@@ -94,7 +94,7 @@ impl Account {
     ) -> Result<SignedTransaction, AlgorandError> {
         let transaction_bytes = &transaction.bytes_to_sign()?;
         let signature = self.sign(&transaction_bytes);
-        let id = BASE32_NOPAD.encode(&ChecksumAlg::digest(&signature.0));
+        let id = BASE32_NOPAD.encode(&ChecksumAlg::digest(&transaction.bytes_to_sign()?));
         Ok(SignedTransaction {
             transaction: transaction.clone(),
             sig: Some(signature),


### PR DESCRIPTION
I noticed that the transaction ids here don't match the ones generated in the Java SDK. It seems that we've to hash the bytes used to generate the signature and not the signature. See [Java](https://github.com/algorand/java-algorand-sdk/blob/34b27834770e8cc18240b78589f8d7c7ebce215f/src/main/java/com/algorand/algosdk/transaction/Transaction.java#L1230) and [Go](https://github.com/algorand/go-algorand-sdk/blob/adb6d4be485483d4b95d5eb7742943dc2f2109e9/crypto/crypto.go#L140)