### PR TITLE
Improve debug representation of transactions

### DIFF
--- a/algonaut_crypto/src/lib.rs
+++ b/algonaut_crypto/src/lib.rs
@@ -2,6 +2,7 @@ use std::fmt::{self, Formatter};
 
 use algonaut_encoding::{deserialize_bytes32, U8_32Visitor};
 use data_encoding::{BASE32_NOPAD, BASE64};
+use fmt::Debug;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Support for turning 32 byte keys into human-readable mnemonics and back
@@ -38,7 +39,7 @@ impl<'de> Deserialize<'de> for HashDigest {
     }
 }
 
-impl fmt::Debug for HashDigest {
+impl Debug for HashDigest {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", BASE32_NOPAD.encode(&self.0))
     }
@@ -64,13 +65,13 @@ impl<'de> Deserialize<'de> for Ed25519PublicKey {
     }
 }
 
-impl fmt::Debug for Ed25519PublicKey {
+impl Debug for Ed25519PublicKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", BASE32_NOPAD.encode(&self.0))
     }
 }
 
-impl fmt::Debug for MasterDerivationKey {
+impl Debug for MasterDerivationKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", BASE32_NOPAD.encode(&self.0))
     }

--- a/algonaut_crypto/src/lib.rs
+++ b/algonaut_crypto/src/lib.rs
@@ -1,5 +1,7 @@
+use std::fmt::{self, Formatter};
+
 use algonaut_encoding::{deserialize_bytes32, U8_32Visitor};
-use data_encoding::BASE64;
+use data_encoding::{BASE32_NOPAD, BASE64};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Support for turning 32 byte keys into human-readable mnemonics and back
@@ -9,13 +11,13 @@ pub mod mnemonic;
 pub mod error;
 
 /// A SHA512_256 hash
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub struct HashDigest(pub [u8; 32]);
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Ed25519PublicKey(pub [u8; 32]);
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MasterDerivationKey(pub [u8; 32]);
 
 impl Serialize for HashDigest {
@@ -36,6 +38,12 @@ impl<'de> Deserialize<'de> for HashDigest {
     }
 }
 
+impl fmt::Debug for HashDigest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", BASE32_NOPAD.encode(&self.0))
+    }
+}
+
 impl Serialize for Ed25519PublicKey {
     fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
     where
@@ -53,6 +61,18 @@ impl<'de> Deserialize<'de> for Ed25519PublicKey {
         Ok(Ed25519PublicKey(
             deserializer.deserialize_bytes(U8_32Visitor)?,
         ))
+    }
+}
+
+impl fmt::Debug for Ed25519PublicKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", BASE32_NOPAD.encode(&self.0))
+    }
+}
+
+impl fmt::Debug for MasterDerivationKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", BASE32_NOPAD.encode(&self.0))
     }
 }
 


### PR DESCRIPTION
The current debug representation shows everywhere byte arrays and that makes it difficult to work with and compare with goal and other SDKs. With this PR hashes are displayed as base32 encoded strings and the signature as base64:
```
SignedTransaction {
    sig: Some(
        RQOF4OazISb9AMUtcr4A1F/mpph+JeLQVCGiCQymSeRxWukKzNZuSgJzMDRPixlswhHseXOuvgt8FJN2DGkGDQ==,
    ),
    multisig: None,
    logicsig: None,
    transaction: Transaction {
        fee: MicroAlgos(
            10000,
        ),
        first_valid: Round(
            9025,
        ),
        genesis_hash: 2YKA7K2Z5JDSTNMWHEC65NVL7UEL5TDUHFZQMLCBHWLYXPGSLQOA,
        last_valid: Round(
            9035,
        ),
        sender: GIZTTA56FAJNAN7ACK3T6YG34FH32ETDULBZ6ENC4UV7EEHPXJGGSPCMVU,
        txn_type: Payment(
            Payment {
                receiver: BFRTECKTOOE7A5LHCF3TTEOH2A7BW46IYT2SX5VP6ANKEXHZYJY77SJTVM,
                amount: MicroAlgos(
                    123456,
                ),
                close_remainder_to: None,
            },
        ),
        genesis_id: "tn50e-v1",
        group: None,
        lease: None,
        note: None,
        rekey_to: None,
    },
    transaction_id: "MMTXWOGGPCH6BISS5IXXZSYFFOL7AZKQRK3U3645RV52YF73XCLQ",
}
```

Also, separated from/to string in `Account` from the encoding/decoding, which seems a bit better.

I wonder whether we should make `Account`, `Ed25519PublicKey`, etc. contain `HashDigest` instead of `[u8; 32]`? Then we'd have to write the base32 debug representation only once. `Account` would override it as it uses base32 + checksum. Only issue I see against this is the assumption that they represent a hash, which can be considered an implementation detail of the system. But e.g. the group id is implemented as a hash..

Considered implementing `Display` instead, but it's a bit complicated/verbose when using `Option`, as it's not enough to implement it for the contained types.