### PR TITLE
Account and signing refactoring

### DIFF
--- a/algonaut_client/src/algod/v2/mod.rs
+++ b/algonaut_client/src/algod/v2/mod.rs
@@ -266,7 +266,7 @@ impl Client {
     /// Given TEAL source code in plain text, return base64 encoded program bytes and base32
     /// SHA512_256 hash of program bytes (Address style). This endpoint is only enabled when
     /// a node's configuration file sets EnableDeveloperAPI to true.
-    pub fn compile_teal(&self, teal: String) -> Result<CompiledTeal, AlgorandError> {
+    pub fn compile_teal(&self, teal: String) -> Result<ApiCompiledTeal, AlgorandError> {
         let response = self
             .http_client
             .post(&format!("{}v2/teal/compile", self.url))

--- a/algonaut_client/tests/test_trasactions.rs
+++ b/algonaut_client/tests/test_trasactions.rs
@@ -1,10 +1,13 @@
 use algonaut_client::algod::v1::message::QueryAccountTransactions;
 use algonaut_client::Algod;
+use algonaut_core::CompiledTeal;
+use algonaut_core::SignedLogic;
 use algonaut_core::{LogicSignature, MicroAlgos, MultisigAddress, ToMsgPack};
+use algonaut_transaction::transaction::TransactionSignature;
 use algonaut_transaction::tx_group::TxGroup;
 use algonaut_transaction::{account::Account, ConfigureAsset, Pay, SignedTransaction, Txn};
-use data_encoding::BASE64;
 use dotenv::dotenv;
+use std::convert::TryInto;
 use std::env;
 use std::error::Error;
 
@@ -38,7 +41,7 @@ fn test_transaction() -> Result<(), Box<dyn Error>> {
         )
         .build();
 
-    let sign_response = from.sign_transaction(&t);
+    let sign_response = from.sign_and_generate_signed_transaction(&t);
     println!("{:#?}", sign_response);
     assert!(sign_response.is_ok());
     let sign_response = sign_response.unwrap();
@@ -64,8 +67,9 @@ fn test_transaction_with_contract_account_logic_sig() -> Result<(), Box<dyn Erro
         .auth(env::var("ALGOD_TOKEN")?.as_ref())
         .client_v2()?;
 
-    let compiled_teal = algod.compile_teal(
-        r#"
+    let program: CompiledTeal = algod
+        .compile_teal(
+            r#"
 #pragma version 3
 arg 0
 byte 0x0100
@@ -75,17 +79,11 @@ byte 0xFF
 ==
 &&
 "#
-        .into(),
-    )?;
+            .into(),
+        )?
+        .try_into()?;
 
-    let program_bytes = BASE64.decode(compiled_teal.result.as_bytes())?;
-    let lsig = LogicSignature {
-        logic: program_bytes,
-        sig: None,
-        msig: None,
-        args: vec![vec![1, 0], vec![255]],
-    };
-    let from_address = compiled_teal.hash.parse()?;
+    let from_address = program.hash.parse()?;
 
     let params = algod.transaction_params()?;
 
@@ -105,11 +103,13 @@ byte 0xFF
         .build();
 
     let signed_transaction = SignedTransaction {
-        sig: None,
-        multisig: None,
-        logicsig: Some(lsig),
         transaction: t,
         transaction_id: "".to_owned(),
+        sig: TransactionSignature::Logic(SignedLogic {
+            logic: program,
+            args: vec![vec![1, 0], vec![255]],
+            sig: LogicSignature::ContractAccount,
+        }),
     };
 
     let transaction_bytes = signed_transaction.to_msg_pack()?;
@@ -133,24 +133,17 @@ fn test_transaction_with_delegated_logic_sig() -> Result<(), Box<dyn Error>> {
         .auth(env::var("ALGOD_TOKEN")?.as_ref())
         .client_v2()?;
 
-    let res = algod.compile_teal(
-        r#"
+    let program = algod
+        .compile_teal(
+            r#"
 #pragma version 3
 int 1
 "#
-        .into(),
-    )?;
+            .into(),
+        )?
+        .try_into()?;
 
     let from = account1();
-
-    let program_bytes = BASE64.decode(res.result.as_bytes())?;
-    let signature = from.sign_program(&program_bytes);
-    let lsig = LogicSignature {
-        logic: program_bytes,
-        sig: Some(signature),
-        msig: None,
-        args: vec![],
-    };
 
     let params = algod.transaction_params()?;
 
@@ -169,12 +162,16 @@ int 1
         )
         .build();
 
+    let signature = from.sign_program(&program);
+
     let signed_transaction = SignedTransaction {
-        sig: None,
-        multisig: None,
-        logicsig: Some(lsig),
         transaction: t,
         transaction_id: "".to_owned(),
+        sig: TransactionSignature::Logic(SignedLogic {
+            logic: program,
+            args: vec![],
+            sig: LogicSignature::DelegatedSig(signature),
+        }),
     };
 
     let transaction_bytes = signed_transaction.to_msg_pack()?;
@@ -198,28 +195,20 @@ fn test_transaction_with_delegated_logic_multisig() -> Result<(), Box<dyn Error>
         .auth(env::var("ALGOD_TOKEN")?.as_ref())
         .client_v2()?;
 
-    let res = algod.compile_teal(
-        r#"
+    let program: CompiledTeal = algod
+        .compile_teal(
+            r#"
 #pragma version 3
 int 1
 "#
-        .into(),
-    )?;
+            .into(),
+        )?
+        .try_into()?;
 
     let account1 = account1();
     let account2 = account2();
 
     let multisig_address = MultisigAddress::new(1, 2, &[account1.address(), account2.address()])?;
-
-    let program_bytes = BASE64.decode(res.result.as_bytes())?;
-    let lsig = LogicSignature {
-        logic: program_bytes,
-        sig: None,
-        msig: None,
-        args: vec![],
-    };
-    let lsig = account1.sign_logic_msig(lsig, multisig_address.clone())?;
-    let lsig = account2.append_to_logic_msig(lsig)?;
 
     let params = algod.transaction_params()?;
 
@@ -238,12 +227,19 @@ int 1
         )
         .build();
 
+    let msig = account1.init_logic_msig(&program, multisig_address.clone())?;
+    let msig = account2.append_to_logic_msig(&program, msig)?;
+
+    let sig = TransactionSignature::Logic(SignedLogic {
+        logic: program,
+        args: vec![],
+        sig: LogicSignature::DelegatedMultiSig(msig),
+    });
+
     let signed_transaction = SignedTransaction {
-        sig: None,
-        multisig: None,
-        logicsig: Some(lsig),
         transaction: t,
         transaction_id: "".to_owned(),
+        sig,
     };
 
     let transaction_bytes = signed_transaction.to_msg_pack()?;
@@ -287,7 +283,7 @@ fn test_create_asset_transaction() -> Result<(), Box<dyn Error>> {
                 .build(),
         )
         .build();
-    let signed_t = from.sign_transaction(&t)?;
+    let signed_t = from.sign_and_generate_signed_transaction(&t)?;
     let send_response = algod.broadcast_raw_transaction(&signed_t.to_msg_pack()?);
 
     println!("{:#?}", send_response);
@@ -406,8 +402,8 @@ fn test_atomic_swap() -> Result<(), Box<dyn Error>> {
 
     TxGroup::assign_group_id(vec![t1, t2])?;
 
-    let signed_t1 = account1.sign_transaction(&t1)?;
-    let signed_t2 = account2.sign_transaction(&t2)?;
+    let signed_t1 = account1.sign_and_generate_signed_transaction(&t1)?;
+    let signed_t2 = account2.sign_and_generate_signed_transaction(&t2)?;
 
     let send_response = algod
         .broadcast_raw_transaction(&[signed_t1.to_msg_pack()?, signed_t2.to_msg_pack()?].concat());

--- a/algonaut_client/tests/test_trasactions.rs
+++ b/algonaut_client/tests/test_trasactions.rs
@@ -19,7 +19,7 @@ fn test_transaction() -> Result<(), Box<dyn Error>> {
     let algod = Algod::new()
         .bind(env::var("ALGOD_URL")?.as_ref())
         .auth(env::var("ALGOD_TOKEN")?.as_ref())
-        .client_v1()?;
+        .client_v2()?;
 
     let from = account1();
     let to = account2();
@@ -49,7 +49,7 @@ fn test_transaction() -> Result<(), Box<dyn Error>> {
     let t_bytes = sign_response.to_msg_pack()?;
     // Broadcast the transaction to the network
     // Note this transaction will get rejected because the accounts do not have any tokens
-    let send_response = algod.raw_transaction(&t_bytes);
+    let send_response = algod.broadcast_raw_transaction(&t_bytes);
 
     println!("{:#?}", send_response);
     assert!(send_response.is_err());

--- a/algonaut_transaction/src/tx_group.rs
+++ b/algonaut_transaction/src/tx_group.rs
@@ -40,7 +40,7 @@ impl TxGroup {
         }
         let mut ids: Vec<HashDigest> = vec![];
         for t in txns {
-            ids.push(t.raw_tx_id()?);
+            ids.push(t.raw_id()?);
         }
         let group = TxGroup::new(ids);
         let hashed = sha2::Sha512Trunc256::digest(&group.bytes_to_sign()?);

--- a/examples/sign_offline.rs
+++ b/examples/sign_offline.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("Made unsigned transaction: {:?}", t);
 
     // sign the transaction
-    let signed_transaction = account.sign_transaction(&t)?;
+    let signed_transaction = account.sign_and_generate_signed_transaction(&t)?;
     let bytes = rmp_serde::to_vec_named(&ApiSignedTransaction::from(signed_transaction))?;
 
     let filename = "./signed.tx";


### PR DESCRIPTION
- Use enums for transaction and logic signature types, separate api from domain objects.
- Refactor signing of transactions and logic in `Account`. Removed `merge_multisig_transactions`, which is not needed anymore. Minimized scope of some public functions, to be able to compose more cleanly on the caller side.
- Created a couple of newtypes and convenience functions
- Renamed some public functions, like `sign_transaction_msig` in `init_transaction_msig` to make clearer what they do (in this case generate a new msig). This one is rather tentative, can revert if it causes too much inconvenience with the official SDKs.
 
Closes https://github.com/manuelmauro/algonaut/issues/28