### PR TITLE
Make key registration transaction fields optional

### DIFF
--- a/algonaut_transaction/src/api_model.rs
+++ b/algonaut_transaction/src/api_model.rs
@@ -196,11 +196,11 @@ impl From<Transaction> for ApiTransaction {
                 api_t.close_reminder_to = payment.close_remainder_to;
             }
             TransactionType::KeyRegistration(reg) => {
-                api_t.vote_pk = Some(reg.vote_pk);
-                api_t.selection_pk = Some(reg.selection_pk);
-                api_t.vote_first = Some(reg.vote_first);
-                api_t.vote_last = Some(reg.vote_last);
-                api_t.vote_key_dilution = Some(reg.vote_key_dilution);
+                api_t.vote_pk = reg.vote_pk;
+                api_t.selection_pk = reg.selection_pk;
+                api_t.vote_first = reg.vote_first;
+                api_t.vote_last = reg.vote_last;
+                api_t.vote_key_dilution = reg.vote_key_dilution;
                 api_t.nonparticipating = reg.nonparticipating;
             }
             TransactionType::AssetConfigurationTransaction(config) => {

--- a/algonaut_transaction/src/builder.rs
+++ b/algonaut_transaction/src/builder.rs
@@ -176,9 +176,9 @@ impl Pay {
 pub struct RegisterKey {
     vote_pk: Option<VotePk>,
     selection_pk: Option<VrfPk>,
-    vote_first: Round,
-    vote_last: Round,
-    vote_key_dilution: u64,
+    vote_first: Option<Round>,
+    vote_last: Option<Round>,
+    vote_key_dilution: Option<u64>,
     nonparticipating: Option<bool>,
 }
 
@@ -198,17 +198,17 @@ impl RegisterKey {
     }
 
     pub fn vote_first(mut self, vote_first: Round) -> Self {
-        self.vote_first = vote_first;
+        self.vote_first = Some(vote_first);
         self
     }
 
     pub fn vote_last(mut self, vote_last: Round) -> Self {
-        self.vote_last = vote_last;
+        self.vote_last = Some(vote_last);
         self
     }
 
     pub fn vote_key_dilution(mut self, vote_key_dilution: u64) -> Self {
-        self.vote_key_dilution = vote_key_dilution;
+        self.vote_key_dilution = Some(vote_key_dilution);
         self
     }
 
@@ -219,8 +219,8 @@ impl RegisterKey {
 
     pub fn build(self) -> KeyRegistration {
         KeyRegistration {
-            vote_pk: self.vote_pk.unwrap(),
-            selection_pk: self.selection_pk.unwrap(),
+            vote_pk: self.vote_pk,
+            selection_pk: self.selection_pk,
             vote_first: self.vote_first,
             vote_last: self.vote_last,
             vote_key_dilution: self.vote_key_dilution,

--- a/algonaut_transaction/src/transaction.rs
+++ b/algonaut_transaction/src/transaction.rs
@@ -135,21 +135,21 @@ pub struct Payment {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct KeyRegistration {
     /// The root participation public key. See Generate a Participation Key to learn more.
-    pub vote_pk: VotePk,
+    pub vote_pk: Option<VotePk>,
 
     /// The VRF public key.
-    pub selection_pk: VrfPk,
+    pub selection_pk: Option<VrfPk>,
 
     /// The first round that the participation key is valid. Not to be confused with the FirstValid
     /// round of the keyreg transaction.
-    pub vote_first: Round,
+    pub vote_first: Option<Round>,
 
     /// The last round that the participation key is valid. Not to be confused with the LastValid
     /// round of the keyreg transaction.
-    pub vote_last: Round,
+    pub vote_last: Option<Round>,
 
     /// This is the dilution for the 2-level participation key.
-    pub vote_key_dilution: u64,
+    pub vote_key_dilution: Option<u64>,
 
     /// All new Algorand accounts are participating by default. This means that they earn rewards.
     /// Mark an account nonparticipating by setting this value to true and this account will no


### PR DESCRIPTION
As per [docs](https://developer.algorand.org/docs/reference/transactions/#key-registration-transaction) the fields are required only online key registrations. Probably we should create different domain models for online/offline/toggle rewards. For now just fixing the api.