### PR TITLE
Create asset fixes, retrieve asset id

### DIFF
--- a/algonaut_transaction/src/api_model.rs
+++ b/algonaut_transaction/src/api_model.rs
@@ -264,29 +264,23 @@ impl From<Transaction> for ApiTransaction {
 
 #[derive(Debug, PartialEq, Serialize)]
 pub struct ApiAssetParams {
-    #[serde(rename = "an", skip_serializing_if = "Option::is_none")]
-    pub asset_name: Option<String>,
-
-    #[serde(rename = "dc")]
-    pub decimals: u32,
-
-    #[serde(rename = "df", skip_serializing)]
-    pub default_frozen: bool,
-
-    #[serde(rename = "t")]
-    pub total: u64,
-
-    #[serde(rename = "un", skip_serializing_if = "Option::is_none")]
-    pub unit_name: Option<String>,
-
     #[serde(rename = "am", skip_serializing_if = "Option::is_none")]
     pub meta_data_hash: Option<Vec<u8>>,
+
+    #[serde(rename = "an", skip_serializing_if = "Option::is_none")]
+    pub asset_name: Option<String>,
 
     #[serde(rename = "au", skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 
     #[serde(rename = "c", skip_serializing_if = "Option::is_none")]
     pub clawback: Option<Address>,
+
+    #[serde(rename = "dc")]
+    pub decimals: u32,
+
+    #[serde(rename = "df", skip_serializing)]
+    pub default_frozen: bool,
 
     #[serde(rename = "f", skip_serializing_if = "Option::is_none")]
     pub freeze: Option<Address>,
@@ -296,6 +290,12 @@ pub struct ApiAssetParams {
 
     #[serde(rename = "r", skip_serializing_if = "Option::is_none")]
     pub reserve: Option<Address>,
+
+    #[serde(rename = "t")]
+    pub total: u64,
+
+    #[serde(rename = "un", skip_serializing_if = "Option::is_none")]
+    pub unit_name: Option<String>,
 }
 
 fn to_api_transaction_type<'a>(type_: &TransactionType) -> &'a str {

--- a/examples/new_asa_sandnet.rs
+++ b/examples/new_asa_sandnet.rs
@@ -54,7 +54,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .fee(MicroAlgos(100_000))
         .asset_configuration(
             ConfigureAsset::new()
-                .config_asset(0)
                 .total(10)
                 .default_frozen(false)
                 .unit_name("EIRI".to_owned())
@@ -64,7 +63,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 .freeze(creator)
                 .clawback(creator)
                 .url("example.com".to_owned())
-                .meta_data_hash(Vec::new())
                 .decimals(2)
                 .build(),
         )

--- a/examples/new_asa_sandnet.rs
+++ b/examples/new_asa_sandnet.rs
@@ -1,10 +1,10 @@
 use algonaut::algod::v2::Algod;
 use algonaut::algod::AlgodBuilder;
 use algonaut::core::MicroAlgos;
-use algonaut::kmd::KmdBuilder;
 use algonaut::error::AlgonautError;
 use algonaut::transaction::{ConfigureAsset, TxnBuilder};
 use algonaut_client::algod::v2::message::PendingTransaction;
+use algonaut_transaction::account::Account;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;
@@ -15,29 +15,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // load variables in .env
     dotenv().ok();
 
-    // kmd manages wallets and accounts
-    let kmd = KmdBuilder::new()
-        .bind(env::var("KMD_URL")?.as_ref())
-        .auth(env::var("KMD_TOKEN")?.as_ref())
-        .build_v1()?;
-
-    // first we obtain a handle to our wallet
-    let list_response = kmd.list_wallets().await?;
-    let wallet_id = match list_response
-        .wallets
-        .into_iter()
-        .find(|wallet| wallet.name == "unencrypted-default-wallet")
-    {
-        Some(wallet) => wallet.id,
-        None => return Err("Wallet not found".into()),
-    };
-    let init_response = kmd.init_wallet_handle(&wallet_id, "").await?;
-    let wallet_handle_token = init_response.wallet_handle_token;
-    println!("Wallet Handle: {}", wallet_handle_token);
-
     // an account with some funds in our sandbox
-    let creator = env::var("ACCOUNT")?.parse()?;
-    println!("Creator: {:?}", creator);
+    let creator = account1();
+    println!("Creator: {:?}", creator.address());
 
     // algod has a convenient method that retrieves basic information for a transaction
     let algod = AlgodBuilder::new()
@@ -50,7 +30,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // we are ready to build the transaction
     let t = TxnBuilder::new()
-        .sender(creator)
+        .sender(creator.address())
         .first_valid(params.last_round)
         .last_valid(params.last_round + 1000)
         .genesis_id(params.genesis_id)
@@ -62,10 +42,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 .default_frozen(false)
                 .unit_name("EIRI".to_owned())
                 .asset_name("Naki".to_owned())
-                .manager(creator)
-                .reserve(creator)
-                .freeze(creator)
-                .clawback(creator)
+                .manager(creator.address())
+                .reserve(creator.address())
+                .freeze(creator.address())
+                .clawback(creator.address())
                 .url("example.com".to_owned())
                 .decimals(2)
                 .build(),
@@ -73,13 +53,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .build();
 
     // we need to sign the transaction to prove that we own the sender address
-    let sign_response = kmd.sign_transaction(&wallet_handle_token, "", &t).await?;
+    let signed_t = creator.sign_transaction(&t)?;
 
     // broadcast the transaction to the network
-    let send_response = algod
-        .broadcast_raw_transaction(&sign_response.signed_transaction)
-        .await?;
-
+    let send_response = algod.broadcast_signed_transaction(&signed_t).await?;
     println!("Transaction ID: {}", send_response.tx_id);
 
     let pending_t = wait_for_pending_transaction(&algod, &send_response.tx_id).await?;
@@ -87,6 +64,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("Asset index: {:?}", pending_t.unwrap().asset_index);
 
     Ok(())
+}
+
+fn account1() -> Account {
+    let mnemonic = "fire enlist diesel stamp nuclear chunk student stumble call snow flock brush example slab guide choice option recall south kangaroo hundred matrix school above zero";
+    Account::from_mnemonic(mnemonic).unwrap()
 }
 
 /// Utility function to wait on a transaction to be confirmed


### PR DESCRIPTION
- Some issues I found when signing directly (which for some reason is more restrictive than KMD).
- Retrieval of created asset id (used in the [docs](https://developer.algorand.org/docs/features/asa/#creating-an-asset), ported from the [Java SDK](https://github.com/algorand/java-algorand-sdk/blob/e9871a544ad6155df8cb67f5d95ea38254f8a6a7/src/test/java/com/algorand/algosdk/cucumber/shared/Utils.java)). I modified it to return the pending transaction. Probably this function should be moved somewhere else but not sure where: In the Java SDK it's in a testing package. Docs suggest it's for public use. Maybe it should be in the root project. For now it's used only in this example so letting it there.