### PR TITLE
Fix asset transfer

### DIFF
--- a/algonaut_transaction/src/api_model.rs
+++ b/algonaut_transaction/src/api_model.rs
@@ -221,12 +221,9 @@ impl From<Transaction> for ApiTransaction {
             }
             TransactionType::AssetTransferTransaction(transfer) => {
                 api_t.xfer = Some(transfer.xfer);
-                api_t.amount = Some(transfer.amount);
-                if let Some(sender) = transfer.sender {
-                    api_t.sender = sender;
-                }
-                api_t.receiver = Some(transfer.receiver);
-                api_t.asset_close_to = Some(transfer.close_to);
+                api_t.asset_amount = Some(transfer.amount);
+                api_t.asset_receiver = Some(transfer.receiver);
+                api_t.asset_close_to = transfer.close_to;
             }
             TransactionType::AssetAcceptTransaction(accept) => {
                 api_t.xfer = Some(accept.xfer);

--- a/algonaut_transaction/src/builder.rs
+++ b/algonaut_transaction/src/builder.rs
@@ -336,7 +336,6 @@ impl ConfigureAsset {
 pub struct TransferAsset {
     xfer: u64,
     amount: u64,
-    sender: Option<Address>,
     receiver: Option<Address>,
     close_to: Option<Address>,
 }
@@ -356,11 +355,6 @@ impl TransferAsset {
         self
     }
 
-    pub fn sender(mut self, sender: Address) -> Self {
-        self.sender = Some(sender);
-        self
-    }
-
     pub fn receiver(mut self, receiver: Address) -> Self {
         self.receiver = Some(receiver);
         self
@@ -375,9 +369,8 @@ impl TransferAsset {
         AssetTransferTransaction {
             xfer: self.xfer,
             amount: self.amount,
-            sender: self.sender,
             receiver: self.receiver.unwrap(),
-            close_to: self.close_to.unwrap(),
+            close_to: self.close_to,
         }
     }
 }

--- a/algonaut_transaction/src/transaction.rs
+++ b/algonaut_transaction/src/transaction.rs
@@ -224,18 +224,12 @@ pub struct AssetTransferTransaction {
     /// asset in the account's Asset map.
     pub amount: u64,
 
-    /// The sender of the transfer. The regular sender field should be used and this one set to the
-    /// zero value for regular transfers between accounts. If this value is nonzero, it indicates a
-    /// clawback transaction where the sender is the asset's clawback address and the asset sender
-    /// is the address from which the funds will be withdrawn.
-    pub sender: Option<Address>,
-
     /// The recipient of the asset transfer.
     pub receiver: Address,
 
     /// Specify this field to remove the asset holding from the sender account and reduce the
     /// account's minimum balance.
-    pub close_to: Address,
+    pub close_to: Option<Address>,
 }
 
 /// This is a special form of an Asset Transfer Transaction.

--- a/examples/transfer_asa.rs
+++ b/examples/transfer_asa.rs
@@ -1,0 +1,63 @@
+use algonaut::algod::AlgodBuilder;
+use algonaut_core::MicroAlgos;
+use algonaut_transaction::TransferAsset;
+use algonaut_transaction::{account::Account, TxnBuilder};
+use dotenv::dotenv;
+use std::env;
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // load variables in .env
+    dotenv().ok();
+
+    let algod = AlgodBuilder::new()
+        .bind(env::var("ALGOD_URL")?.as_ref())
+        .auth(env::var("ALGOD_TOKEN")?.as_ref())
+        .build_v2()?;
+
+    let from = account1();
+    let to = account2();
+
+    let params = algod.transaction_params().await?;
+
+    let t = TxnBuilder::new()
+        .sender(from.address())
+        .first_valid(params.last_round)
+        .last_valid(params.last_round + 10)
+        .genesis_id(params.genesis_id)
+        .genesis_hash(params.genesis_hash)
+        .fee(MicroAlgos(100_000))
+        .asset_transfer(
+            TransferAsset::new()
+                .xfer(4)
+                .amount(3)
+                .receiver(to.address())
+                .build(),
+        )
+        .build();
+
+    let sign_response = from.sign_transaction(&t);
+    println!("{:#?}", sign_response);
+    assert!(sign_response.is_ok());
+    let sign_response = sign_response.unwrap();
+
+    // Broadcast the transaction to the network
+    // Note this transaction will get rejected because the accounts do not have any tokens
+    let send_response = algod.broadcast_signed_transaction(&sign_response).await;
+
+    println!("{:#?}", send_response);
+    assert!(send_response.is_err());
+
+    Ok(())
+}
+
+fn account1() -> Account {
+    let mnemonic = "fire enlist diesel stamp nuclear chunk student stumble call snow flock brush example slab guide choice option recall south kangaroo hundred matrix school above zero";
+    Account::from_mnemonic(mnemonic).unwrap()
+}
+
+fn account2() -> Account {
+    let mnemonic = "since during average anxiety protect cherry club long lawsuit loan expand embark forum theory winter park twenty ball kangaroo cram burst board host ability left";
+    Account::from_mnemonic(mnemonic).unwrap()
+}


### PR DESCRIPTION
Some incorrectly assigned fields, `asset_close_to` [is optional](https://developer.algorand.org/docs/reference/transactions/#asset-transfer-transaction), removed `sender` from the transaction type as it's the same sender of the transaction. `sender` can be different if it's a clawback transaction but there's a different type for that.