### PR TITLE
Fix asset opt-in

### DIFF
--- a/algonaut_transaction/src/api_model.rs
+++ b/algonaut_transaction/src/api_model.rs
@@ -230,7 +230,6 @@ impl From<Transaction> for ApiTransaction {
             }
             TransactionType::AssetAcceptTransaction(accept) => {
                 api_t.xfer = Some(accept.xfer);
-                api_t.asset_sender = Some(accept.sender);
                 api_t.asset_receiver = Some(accept.receiver);
             }
             TransactionType::AssetClawbackTransaction(clawback) => {

--- a/algonaut_transaction/src/builder.rs
+++ b/algonaut_transaction/src/builder.rs
@@ -386,7 +386,6 @@ impl TransferAsset {
 #[derive(Default)]
 pub struct AcceptAsset {
     xfer: u64,
-    sender: Option<Address>,
     receiver: Option<Address>,
 }
 
@@ -400,11 +399,6 @@ impl AcceptAsset {
         self
     }
 
-    pub fn sender(mut self, sender: Address) -> Self {
-        self.sender = Some(sender);
-        self
-    }
-
     pub fn receiver(mut self, receiver: Address) -> Self {
         self.receiver = Some(receiver);
         self
@@ -413,7 +407,6 @@ impl AcceptAsset {
     pub fn build(self) -> AssetAcceptTransaction {
         AssetAcceptTransaction {
             xfer: self.xfer,
-            sender: self.sender.unwrap(),
             receiver: self.receiver.unwrap(),
         }
     }

--- a/algonaut_transaction/src/transaction.rs
+++ b/algonaut_transaction/src/transaction.rs
@@ -244,10 +244,7 @@ pub struct AssetAcceptTransaction {
     /// The unique ID of the asset to be transferred.
     pub xfer: u64,
 
-    /// The account which is allocating the asset to their account's Asset map.
-    pub sender: Address,
-
-    /// The account which is allocating the asset to their account's Asset map.
+    /// The account opting in (must be the same as the transaction's sender).
     pub receiver: Address,
 }
 

--- a/examples/optin_asa.rs
+++ b/examples/optin_asa.rs
@@ -1,0 +1,56 @@
+use algonaut::algod::AlgodBuilder;
+use algonaut_core::MicroAlgos;
+use algonaut_transaction::AcceptAsset;
+use algonaut_transaction::{account::Account, TxnBuilder};
+use dotenv::dotenv;
+use std::env;
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // load variables in .env
+    dotenv().ok();
+
+    let algod = AlgodBuilder::new()
+        .bind(env::var("ALGOD_URL")?.as_ref())
+        .auth(env::var("ALGOD_TOKEN")?.as_ref())
+        .build_v2()?;
+
+    let account = account();
+
+    let params = algod.transaction_params().await?;
+
+    let t = TxnBuilder::new()
+        .sender(account.address())
+        .first_valid(params.last_round)
+        .last_valid(params.last_round + 10)
+        .genesis_id(params.genesis_id)
+        .genesis_hash(params.genesis_hash)
+        .fee(MicroAlgos(100_000))
+        .asset_accept(
+            AcceptAsset::new()
+                .xfer(4)
+                .receiver(account.address())
+                .build(),
+        )
+        .build();
+
+    let sign_response = account.sign_transaction(&t);
+    println!("{:#?}", sign_response);
+    assert!(sign_response.is_ok());
+    let sign_response = sign_response.unwrap();
+
+    // Broadcast the transaction to the network
+    // Note this transaction will get rejected because the accounts do not have any tokens
+    let send_response = algod.broadcast_signed_transaction(&sign_response).await;
+
+    println!("{:#?}", send_response);
+    assert!(send_response.is_err());
+
+    Ok(())
+}
+
+fn account() -> Account {
+    let mnemonic = "since during average anxiety protect cherry club long lawsuit loan expand embark forum theory winter park twenty ball kangaroo cram burst board host ability left";
+    Account::from_mnemonic(mnemonic).unwrap()
+}


### PR DESCRIPTION
Removed `asnd` (it has to be removed from the [documentation](https://developer.algorand.org/docs/reference/transactions/#asset-accept-transaction) too, it's only used for clawback). Renamed the remaining field to improve semantics.