### PR TITLE
deps(algonaut_transaction): bump serde_bytes 0.11 → 0.11.4

### DIFF
--- a/algonaut_transaction/Cargo.toml
+++ b/algonaut_transaction/Cargo.toml
@@ -20,7 +20,7 @@ reqwest = {version = "0.11", features = ["json"]}
 ring = "0.16.19"
 rmp-serde = "0.15.5"
 serde = {version = "1.0", features = ["derive"]}
-serde_bytes = "0.11"
+serde_bytes = "0.11.4"
 serde_json = "1.0.40"
 sha2 = "0.9.5"
 thiserror = "1.0.23"


### PR DESCRIPTION
serde_bytes 0.11.4 adds support for bytes inside of Option, which `algonaut_transaction::api_model::ApiTransaction` depends on.

* https://github.com/serde-rs/bytes/releases/tag/0.11.4