### PR TITLE
Improve CompiledTeal and contract account signing API

### DIFF
--- a/algonaut_client/src/algod/v2/mod.rs
+++ b/algonaut_client/src/algod/v2/mod.rs
@@ -3,7 +3,7 @@ use crate::extensions::reqwest::{to_header_map, ResponseExt};
 use crate::Headers;
 use algonaut_core::{Address, Round};
 use algonaut_model::algod::v2::{
-    Account, Application, Block, Catchup, CompiledTealWithAddress, DryrunRequest, DryrunResponse,
+    Account, Application, Block, Catchup, CompiledTeal, DryrunRequest, DryrunResponse,
     GenesisBlock, KeyRegistration, NodeStatus, PendingTransaction, PendingTransactions, Supply,
     TransactionParams, TransactionResponse, Version,
 };
@@ -268,10 +268,7 @@ impl Client {
         Ok(response)
     }
 
-    pub async fn compile_teal(
-        &self,
-        teal: Vec<u8>,
-    ) -> Result<CompiledTealWithAddress, ClientError> {
+    pub async fn compile_teal(&self, teal: Vec<u8>) -> Result<CompiledTeal, ClientError> {
         let response = self
             .http_client
             .post(&format!("{}v2/teal/compile", self.url))

--- a/algonaut_core/src/lib.rs
+++ b/algonaut_core/src/lib.rs
@@ -174,7 +174,7 @@ impl VrfPk {
 
 #[derive(Eq, PartialEq, Clone)]
 pub struct SignedLogic {
-    pub logic: CompiledTeal,
+    pub logic: CompiledTealBytes,
     pub args: Vec<Vec<u8>>,
     pub sig: LogicSignature,
 }
@@ -213,9 +213,9 @@ impl Debug for SignedLogic {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct CompiledTeal(pub Vec<u8>);
+pub struct CompiledTealBytes(pub Vec<u8>);
 
-impl CompiledTeal {
+impl CompiledTealBytes {
     pub fn bytes_to_sign(&self) -> Vec<u8> {
         let mut prefix_encoded_tx = b"Program".to_vec();
         prefix_encoded_tx.extend_from_slice(&self.0);

--- a/algonaut_transaction/Cargo.toml
+++ b/algonaut_transaction/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.3.0"
 algonaut_core = {path = "../algonaut_core", version = "0.3.0"}
 algonaut_crypto = {path = "../algonaut_crypto", version = "0.3.0"}
 algonaut_encoding = {path = "../algonaut_encoding", version = "0.3.0"}
+algonaut_model = {path = "../algonaut_model", version = "0.3.0"}
 data-encoding = "2.3.1"
 derive_more = "0.99.13"
 rand = "0.8.3"

--- a/algonaut_transaction/src/api_model.rs
+++ b/algonaut_transaction/src/api_model.rs
@@ -1,7 +1,7 @@
 use std::convert::{TryFrom, TryInto};
 
 use algonaut_core::{
-    Address, CompiledTeal, LogicSignature, MicroAlgos, MultisigSignature, Round, SignedLogic,
+    Address, CompiledTealBytes, LogicSignature, MicroAlgos, MultisigSignature, Round, SignedLogic,
     ToMsgPack, VotePk, VrfPk,
 };
 use algonaut_crypto::{HashDigest, Signature};
@@ -346,11 +346,11 @@ impl TryFrom<ApiTransaction> for Transaction {
                     api_t.on_complete,
                 ))?,
                 accounts: api_t.accounts,
-                approval_program: api_t.approval_program.map(CompiledTeal),
+                approval_program: api_t.approval_program.map(CompiledTealBytes),
                 app_arguments: api_t
                     .app_arguments
                     .map(|args| args.into_iter().map(|a| a.0).collect()),
-                clear_state_program: api_t.clear_state_program.map(CompiledTeal),
+                clear_state_program: api_t.clear_state_program.map(CompiledTealBytes),
                 foreign_apps: api_t.foreign_apps,
                 foreign_assets: api_t.foreign_assets,
 
@@ -706,7 +706,7 @@ impl TryFrom<ApiSignedLogic> for SignedLogic {
             }
         };
         Ok(SignedLogic {
-            logic: CompiledTeal(s.logic),
+            logic: CompiledTealBytes(s.logic),
             args: s.args.into_iter().map(|a| a.0).collect(),
             sig,
         })
@@ -793,7 +793,7 @@ mod tests {
 
     #[test]
     fn test_serialize_signed_logic_contract_account() {
-        let program = CompiledTeal(vec![
+        let program = CompiledTealBytes(vec![
             0x01, 0x20, 0x01, 0x01, 0x22, // int 1
         ]);
         let args = vec![vec![1, 2, 3], vec![4, 5, 6]];
@@ -815,7 +815,7 @@ mod tests {
 
     #[test]
     fn test_serialize_signed_logic_contract_account_no_args() {
-        let program = CompiledTeal(vec![
+        let program = CompiledTealBytes(vec![
             0x01, 0x20, 0x01, 0x01, 0x22, // int 1
         ]);
         let args = vec![];

--- a/algonaut_transaction/src/builder.rs
+++ b/algonaut_transaction/src/builder.rs
@@ -4,7 +4,7 @@ use crate::transaction::{
     AssetTransferTransaction, KeyRegistration, Payment, StateSchema, Transaction, TransactionType,
 };
 use algonaut_core::{
-    Address, CompiledTeal, MicroAlgos, Round, SuggestedTransactionParams, VotePk, VrfPk,
+    Address, CompiledTealBytes, MicroAlgos, Round, SuggestedTransactionParams, VotePk, VrfPk,
 };
 use algonaut_crypto::HashDigest;
 
@@ -558,9 +558,9 @@ impl FreezeAsset {
 pub struct CreateApplication {
     sender: Address,
     accounts: Option<Vec<Address>>,
-    approval_program: Option<CompiledTeal>,
+    approval_program: Option<CompiledTealBytes>,
     app_arguments: Option<Vec<Vec<u8>>>,
-    clear_state_program: Option<CompiledTeal>,
+    clear_state_program: Option<CompiledTealBytes>,
     foreign_apps: Option<Vec<u64>>,
     foreign_assets: Option<Vec<u64>>,
     global_state_schema: Option<StateSchema>,
@@ -571,8 +571,8 @@ pub struct CreateApplication {
 impl CreateApplication {
     pub fn new(
         sender: Address,
-        approval_program: CompiledTeal,
-        clear_state_program: CompiledTeal,
+        approval_program: CompiledTealBytes,
+        clear_state_program: CompiledTealBytes,
         global_state_schema: StateSchema,
         local_state_schema: StateSchema,
     ) -> Self {
@@ -638,9 +638,9 @@ pub struct UpdateApplication {
     sender: Address,
     app_id: u64,
     accounts: Option<Vec<Address>>,
-    approval_program: Option<CompiledTeal>,
+    approval_program: Option<CompiledTealBytes>,
     app_arguments: Option<Vec<Vec<u8>>>,
-    clear_state_program: Option<CompiledTeal>,
+    clear_state_program: Option<CompiledTealBytes>,
     foreign_apps: Option<Vec<u64>>,
     foreign_assets: Option<Vec<u64>>,
 }
@@ -649,8 +649,8 @@ impl UpdateApplication {
     pub fn new(
         sender: Address,
         app_id: u64,
-        approval_program: CompiledTeal,
-        clear_state_program: CompiledTeal,
+        approval_program: CompiledTealBytes,
+        clear_state_program: CompiledTealBytes,
     ) -> Self {
         UpdateApplication {
             sender,

--- a/algonaut_transaction/src/transaction.rs
+++ b/algonaut_transaction/src/transaction.rs
@@ -1,6 +1,6 @@
 use crate::account::Account;
 use crate::error::TransactionError;
-use algonaut_core::CompiledTeal;
+use algonaut_core::CompiledTealBytes;
 use algonaut_core::SignedLogic;
 use algonaut_core::ToMsgPack;
 use algonaut_core::{Address, MultisigSignature};
@@ -328,7 +328,7 @@ pub struct ApplicationCallTransaction {
     /// Logic executed for every application transaction, except when on-completion is set to
     /// "clear". It can read and write global state for the application, as well as account-specific
     /// local state. Approval programs may reject the transaction.
-    pub approval_program: Option<CompiledTeal>,
+    pub approval_program: Option<CompiledTealBytes>,
 
     /// Transaction specific arguments accessed from the application's approval-program and
     /// clear-state-program.
@@ -337,7 +337,7 @@ pub struct ApplicationCallTransaction {
     /// Logic executed for application transactions with on-completion set to "clear". It can read
     /// and write global state for the application, as well as account-specific local state. Clear
     /// state programs cannot reject the transaction.
-    pub clear_state_program: Option<CompiledTeal>,
+    pub clear_state_program: Option<CompiledTealBytes>,
 
     /// Lists the applications in addition to the application-id whose global states may be accessed
     /// by this application's approval-program and clear-state-program. The access is read-only.

--- a/src/algod/v2/mod.rs
+++ b/src/algod/v2/mod.rs
@@ -1,7 +1,7 @@
 use algonaut_client::algod::v2::Client;
 use algonaut_core::{Address, Round, SuggestedTransactionParams, ToMsgPack};
 use algonaut_model::algod::v2::{
-    Account, Application, Block, Catchup, CompiledTealWithAddress, DryrunRequest, DryrunResponse,
+    Account, Application, Block, Catchup, CompiledTeal, DryrunRequest, DryrunResponse,
     GenesisBlock, KeyRegistration, NodeStatus, PendingTransaction, PendingTransactions, Supply,
     TransactionParams, TransactionResponse, Version,
 };
@@ -133,10 +133,7 @@ impl Algod {
     /// Given TEAL source code in plain text, return base64 encoded program bytes and base32
     /// SHA512_256 hash of program bytes (Address style). This endpoint is only enabled when
     /// a node's configuration file sets EnableDeveloperAPI to true.
-    pub async fn compile_teal(
-        &self,
-        teal: &[u8],
-    ) -> Result<CompiledTealWithAddress, AlgonautError> {
+    pub async fn compile_teal(&self, teal: &[u8]) -> Result<CompiledTeal, AlgonautError> {
         Ok(self.client.compile_teal(teal.to_vec()).await?)
     }
 

--- a/tests/test_account.rs
+++ b/tests/test_account.rs
@@ -1,4 +1,4 @@
-use algonaut_core::{Address, CompiledTeal, LogicSignature, MicroAlgos, Round, SignedLogic};
+use algonaut_core::{Address, CompiledTealBytes, LogicSignature, MicroAlgos, Round, SignedLogic};
 use algonaut_core::{MultisigAddress, ToMsgPack};
 use algonaut_crypto::HashDigest;
 use algonaut_transaction::account::Account;
@@ -233,7 +233,7 @@ async fn test_logic_sig_transaction() -> Result<(), Box<dyn Error>> {
     .note(BASE64.decode(b"8xMCTuLQ810=")?)
     .build();
 
-    let program = CompiledTeal(vec![
+    let program = CompiledTealBytes(vec![
         0x01, 0x20, 0x01, 0x01, 0x22, // int 1
     ]);
     let args = vec![vec![49, 50, 51], vec![52, 53, 54]];

--- a/tests/test_logic_signature.rs
+++ b/tests/test_logic_signature.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use algonaut_core::{CompiledTeal, LogicSignature, MultisigAddress, SignedLogic};
+use algonaut_core::{CompiledTealBytes, LogicSignature, MultisigAddress, SignedLogic};
 
 use algonaut_transaction::{account::Account, error::TransactionError};
 use tokio::test;
@@ -10,7 +10,7 @@ use tokio::test;
 
 #[test]
 async fn test_logic_sig_creation() -> Result<(), Box<dyn Error>> {
-    let program = CompiledTeal(vec![
+    let program = CompiledTealBytes(vec![
         0x01, 0x20, 0x01, 0x01, 0x22, // int 1
     ]);
     let args = vec![];
@@ -63,7 +63,7 @@ async fn test_logic_sig_invalid_program_creation() {
 
 #[test]
 async fn test_logic_sig_signature() -> Result<(), Box<dyn Error>> {
-    let program = CompiledTeal(vec![
+    let program = CompiledTealBytes(vec![
         0x01, 0x20, 0x01, 0x01, 0x22, // int 1
     ]);
     let account = Account::generate();
@@ -85,7 +85,7 @@ async fn test_logic_sig_signature() -> Result<(), Box<dyn Error>> {
 
 #[test]
 async fn test_logic_sig_multisig_signature() -> Result<(), Box<dyn Error>> {
-    let program = CompiledTeal(vec![
+    let program = CompiledTealBytes(vec![
         0x01, 0x20, 0x01, 0x01, 0x22, // int 1
     ]);
 


### PR DESCRIPTION
Improved the modeling around these types, e.g. before the trait to sign as a contract account could be implemented by any "compiled teal", which is not ideal semantically. Having a dedicated type for contract accounts is cleaner. Also, now only these contract accounts expose the hash as an address.