### PR TITLE
Add feature flags for selecting rustls or openssl as the tls implementation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [dependencies]
-algonaut_client = {path = "algonaut_client", version = "0.3.0"}
+algonaut_client = {path = "algonaut_client", version = "0.3.0", default-features = false}
 algonaut_model = {path = "algonaut_model", version = "0.3.0"}
 algonaut_core = {path = "algonaut_core", version = "0.3.0"}
 algonaut_crypto = {path = "algonaut_crypto", version = "0.3.0"}
@@ -34,3 +34,8 @@ tokio = { version = "1.6.0", features = ["rt-multi-thread", "macros"] }
 rand = "0.8.3"
 getrandom = { version = "0.2.2", features = ["js"] }
 data-encoding = "2.3.1"
+
+[features]
+default = ["native"]
+native = ["algonaut_client/native"]
+rustls = ["algonaut_client/rustls"]

--- a/algonaut_client/Cargo.toml
+++ b/algonaut_client/Cargo.toml
@@ -15,7 +15,7 @@ algonaut_crypto = {path = "../algonaut_crypto", version = "0.3.0"}
 algonaut_encoding = {path = "../algonaut_encoding", version = "0.3.0"}
 data-encoding = "2.3.1"
 derive_more = "0.99.13"
-reqwest = {version = "0.11", features = ["json"]}
+reqwest = {version = "0.11", features = ["json"], default-features = false}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0.40"
 thiserror = "1.0.23"
@@ -27,3 +27,8 @@ dotenv = "0.15.0"
 rand = "0.8.3"
 getrandom = { version = "0.2.2", features = ["js"] }
 tokio = { version = "1.6.0", features = ["macros"] }
+
+[features]
+default = ["native"]
+rustls = ["reqwest/rustls-tls"]
+native = ["reqwest/native-tls"]

--- a/src/algod/mod.rs
+++ b/src/algod/mod.rs
@@ -21,6 +21,7 @@ pub mod v2;
 ///     Ok(())
 /// }
 /// ```
+#[derive(Default)]
 pub struct AlgodBuilder<'a> {
     url: Option<&'a str>,
     token: Option<&'a str>,
@@ -76,15 +77,7 @@ impl<'a> AlgodBuilder<'a> {
     }
 }
 
-impl<'a> Default for AlgodBuilder<'a> {
-    fn default() -> Self {
-        AlgodBuilder {
-            url: None,
-            token: None,
-        }
-    }
-}
-
+#[derive(Default)]
 pub struct AlgodCustomEndpointBuilder<'a> {
     url: Option<&'a str>,
     headers: Headers<'a>,
@@ -118,15 +111,6 @@ impl<'a> AlgodCustomEndpointBuilder<'a> {
                 self.headers,
             )?)),
             None => Err(AlgonautError::UnitializedUrl),
-        }
-    }
-}
-
-impl<'a> Default for AlgodCustomEndpointBuilder<'a> {
-    fn default() -> Self {
-        AlgodCustomEndpointBuilder {
-            url: None,
-            headers: vec![],
         }
     }
 }

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -4,6 +4,7 @@ use algonaut_client::{indexer::v2::Client, Headers};
 pub mod v2;
 
 /// Indexer is the entry point to the creation of a client for the Algorand's indexer
+#[derive(Default)]
 pub struct IndexerBuilder<'a> {
     url: Option<&'a str>,
 }
@@ -31,12 +32,7 @@ impl<'a> IndexerBuilder<'a> {
     }
 }
 
-impl<'a> Default for IndexerBuilder<'a> {
-    fn default() -> Self {
-        IndexerBuilder { url: None }
-    }
-}
-
+#[derive(Default)]
 pub struct IndexerCustomEndpointBuilder<'a> {
     url: Option<&'a str>,
     headers: Headers<'a>,
@@ -67,15 +63,6 @@ impl<'a> IndexerCustomEndpointBuilder<'a> {
         match self.url {
             Some(url) => Ok(v2::Indexer::new(Client::new(url, self.headers)?)),
             None => Err(AlgonautError::UnitializedUrl),
-        }
-    }
-}
-
-impl<'a> Default for IndexerCustomEndpointBuilder<'a> {
-    fn default() -> Self {
-        IndexerCustomEndpointBuilder {
-            url: None,
-            headers: vec![],
         }
     }
 }

--- a/src/kmd/mod.rs
+++ b/src/kmd/mod.rs
@@ -19,6 +19,7 @@ pub mod v1;
 ///     Ok(())
 /// }
 /// ```
+#[derive(Default)]
 pub struct KmdBuilder<'a> {
     url: Option<&'a str>,
     token: Option<&'a str>,
@@ -65,16 +66,7 @@ impl<'a> KmdBuilder<'a> {
     }
 }
 
-impl<'a> Default for KmdBuilder<'a> {
-    fn default() -> Self {
-        KmdBuilder {
-            url: None,
-            token: None,
-            headers: vec![],
-        }
-    }
-}
-
+#[derive(Default)]
 pub struct KmdCustomEndpointBuilder<'a> {
     url: Option<&'a str>,
     headers: Headers<'a>,
@@ -105,15 +97,6 @@ impl<'a> KmdCustomEndpointBuilder<'a> {
         match self.url {
             Some(url) => Ok(v1::Kmd::new(Client::new(url, self.headers)?)),
             None => Err(AlgonautError::UnitializedUrl),
-        }
-    }
-}
-
-impl<'a> Default for KmdCustomEndpointBuilder<'a> {
-    fn default() -> Self {
-        KmdCustomEndpointBuilder {
-            url: None,
-            headers: vec![],
         }
     }
 }


### PR DESCRIPTION
A simple switch for allowing `reqwest` to compile with `rustls` instead of `native` which relies on `openssl`.

`openssl` is known to be a non-trivial dependency in the compilation process.