### PR TITLE
Add ability to include additional custom headers.

### DIFF
--- a/algonaut_client/src/algod/v1/mod.rs
+++ b/algonaut_client/src/algod/v1/mod.rs
@@ -1,6 +1,7 @@
 use crate::error::ClientError;
-use crate::extensions::reqwest::ResponseExt;
+use crate::extensions::reqwest::{to_header_map, ResponseExt};
 use crate::token::ApiToken;
+use crate::Headers;
 use algonaut_core::Round;
 use algonaut_model::algod::v1::{
     Account, Block, NodeStatus, PendingTransactions, QueryAccountTransactions, Supply, Transaction,
@@ -23,10 +24,14 @@ pub struct Client {
 
 impl Client {
     pub fn new(url: &str, token: &str) -> Result<Client, ClientError> {
+        Self::new_with_header(url, token, vec![])
+    }
+
+    pub fn new_with_header(url: &str, token: &str, headers: Headers) -> Result<Client, ClientError> {
         Ok(Client {
             url: Url::parse(url)?.as_ref().into(),
             token: ApiToken::parse(token)?.to_string(),
-            headers: HeaderMap::new(),
+            headers: to_header_map(headers)?,
             http_client: reqwest::Client::new(),
         })
     }

--- a/algonaut_client/src/algod/v1/mod.rs
+++ b/algonaut_client/src/algod/v1/mod.rs
@@ -1,13 +1,11 @@
 use crate::error::ClientError;
-use crate::extensions::reqwest::{to_header_map, ResponseExt};
+use crate::extensions::reqwest::ResponseExt;
 use crate::token::ApiToken;
-use crate::Headers;
 use algonaut_core::Round;
 use algonaut_model::algod::v1::{
     Account, Block, NodeStatus, PendingTransactions, QueryAccountTransactions, Supply, Transaction,
     TransactionFee, TransactionId, TransactionList, TransactionParams, Version,
 };
-use reqwest::header::HeaderMap;
 use reqwest::Url;
 
 /// API message structs for Algorand's daemon v1
@@ -18,20 +16,14 @@ const AUTH_HEADER: &str = "X-Algo-API-Token";
 pub struct Client {
     url: String,
     token: String,
-    headers: HeaderMap,
     http_client: reqwest::Client,
 }
 
 impl Client {
     pub fn new(url: &str, token: &str) -> Result<Client, ClientError> {
-        Self::new_with_header(url, token, vec![])
-    }
-
-    pub fn new_with_header(url: &str, token: &str, headers: Headers) -> Result<Client, ClientError> {
         Ok(Client {
             url: Url::parse(url)?.as_ref().into(),
             token: ApiToken::parse(token)?.to_string(),
-            headers: to_header_map(headers)?,
             http_client: reqwest::Client::new(),
         })
     }
@@ -40,7 +32,6 @@ impl Client {
         let _ = self
             .http_client
             .get(&format!("{}health", self.url))
-            .headers(self.headers.clone())
             .send()
             .await?
             .http_error_for_status()
@@ -52,7 +43,6 @@ impl Client {
         let response = self
             .http_client
             .get(&format!("{}versions", self.url))
-            .headers(self.headers.clone())
             .header(AUTH_HEADER, &self.token)
             .send()
             .await?
@@ -68,7 +58,6 @@ impl Client {
             .http_client
             .get(&format!("{}v1/status", self.url))
             .header(AUTH_HEADER, &self.token)
-            .headers(self.headers.clone())
             .send()
             .await?
             .http_error_for_status()
@@ -86,7 +75,6 @@ impl Client {
                 self.url, round.0
             ))
             .header(AUTH_HEADER, &self.token)
-            .headers(self.headers.clone())
             .send()
             .await?
             .http_error_for_status()
@@ -101,7 +89,6 @@ impl Client {
             .http_client
             .get(&format!("{}v1/block/{}", self.url, round.0))
             .header(AUTH_HEADER, &self.token)
-            .headers(self.headers.clone())
             .send()
             .await?
             .http_error_for_status()
@@ -116,7 +103,6 @@ impl Client {
             .http_client
             .get(&format!("{}v1/ledger/supply", self.url))
             .header(AUTH_HEADER, &self.token)
-            .headers(self.headers.clone())
             .send()
             .await?
             .http_error_for_status()
@@ -131,7 +117,6 @@ impl Client {
             .http_client
             .get(&format!("{}v1/account/{}", self.url, address))
             .header(AUTH_HEADER, &self.token)
-            .headers(self.headers.clone())
             .send()
             .await?
             .http_error_for_status()
@@ -149,7 +134,6 @@ impl Client {
             .http_client
             .get(&format!("{}v1/transactions/pending", self.url))
             .header(AUTH_HEADER, &self.token)
-            .headers(self.headers.clone())
             .query(&[("max", limit.to_string())])
             .send()
             .await?
@@ -171,7 +155,6 @@ impl Client {
                 self.url, transaction_id
             ))
             .header(AUTH_HEADER, &self.token)
-            .headers(self.headers.clone())
             .send()
             .await?
             .http_error_for_status()
@@ -190,7 +173,6 @@ impl Client {
             .http_client
             .get(&format!("{}v1/account/{}/transactions", self.url, address))
             .header(AUTH_HEADER, &self.token)
-            .headers(self.headers.clone())
             .query(query)
             .send()
             .await?
@@ -207,7 +189,6 @@ impl Client {
             .post(&format!("{}v1/transactions", self.url))
             .header(AUTH_HEADER, &self.token)
             .header("Content-Type", "application/x-binary")
-            .headers(self.headers.clone())
             .body(raw.to_vec())
             .send()
             .await?
@@ -223,7 +204,6 @@ impl Client {
             .http_client
             .get(&format!("{}v1/transaction/{}", self.url, transaction_id))
             .header(AUTH_HEADER, &self.token)
-            .headers(self.headers.clone())
             .send()
             .await?
             .http_error_for_status()
@@ -245,7 +225,6 @@ impl Client {
                 self.url, address, transaction_id
             ))
             .header(AUTH_HEADER, &self.token)
-            .headers(self.headers.clone())
             .send()
             .await?
             .http_error_for_status()
@@ -260,7 +239,6 @@ impl Client {
             .http_client
             .get(&format!("{}v1/transactions/fee", self.url))
             .header(AUTH_HEADER, &self.token)
-            .headers(self.headers.clone())
             .send()
             .await?
             .http_error_for_status()
@@ -275,7 +253,6 @@ impl Client {
             .http_client
             .get(&format!("{}v1/transactions/params", self.url))
             .header(AUTH_HEADER, &self.token)
-            .headers(self.headers.clone())
             .send()
             .await?
             .http_error_for_status()

--- a/src/algod/mod.rs
+++ b/src/algod/mod.rs
@@ -71,7 +71,7 @@ impl<'a> AlgodBuilder<'a> {
                     url,
                     vec![("X-Algo-API-Token", &ApiToken::parse(token)?.to_string())],
                 )?))
-            },
+            }
             (None, Some(_)) => Err(AlgonautError::UnitializedUrl),
             (Some(_), None) => Err(AlgonautError::UnitializedToken),
             (None, None) => Err(AlgonautError::UnitializedUrl),

--- a/src/algod/mod.rs
+++ b/src/algod/mod.rs
@@ -14,6 +14,7 @@ pub mod v2;
 ///     let algod = AlgodBuilder::new()
 ///         .bind("http://localhost:4001")
 ///         .auth("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+///         .header("HeaderName", "HeaderData")
 ///         .build_v2()?;
 ///
 ///     println!("Algod versions: {:?}", algod.versions().await?.versions);
@@ -25,6 +26,7 @@ pub mod v2;
 pub struct AlgodBuilder<'a> {
     url: Option<&'a str>,
     token: Option<&'a str>,
+    additional_headers: Headers<'a>,
 }
 
 impl<'a> AlgodBuilder<'a> {
@@ -45,13 +47,23 @@ impl<'a> AlgodBuilder<'a> {
         self
     }
 
+    /// Add an extra header to the client.
+    pub fn header(mut self, header_name: &'a str, header_data: &'a str) -> Self {
+        self.additional_headers.push((header_name, header_data));
+        self
+    }
+
     /// Build a v1 client for Algorand protocol daemon.
     ///
     /// Returns an error if url or token is not set or has an invalid format.
     pub fn build_v1(self) -> Result<v1::Algod, AlgonautError> {
         match (self.url, self.token) {
             (Some(url), Some(token)) => Ok(v1::Algod::new(
-                algonaut_client::algod::v1::Client::new(url, &ApiToken::parse(token)?.to_string())?,
+                algonaut_client::algod::v1::Client::new_with_header(
+                    url,
+                    &ApiToken::parse(token)?.to_string(),
+                    self.additional_headers,
+                )?,
             )),
             (None, Some(_)) => Err(AlgonautError::UnitializedUrl),
             (Some(_), None) => Err(AlgonautError::UnitializedToken),
@@ -63,16 +75,18 @@ impl<'a> AlgodBuilder<'a> {
     ///
     /// Returns an error if url or token is not set or has an invalid format.
     pub fn build_v2(self) -> Result<v2::Algod, AlgonautError> {
-        match (self.url, self.token) {
-            (Some(url), Some(token)) => {
+        match (self.url, self.token, self.additional_headers) {
+            (Some(url), Some(token), mut headers) => {
+                let token = ApiToken::parse(token)?.to_string();
+                headers.push(("X-Algo-API-Token", token.as_str()));
                 Ok(v2::Algod::new(algonaut_client::algod::v2::Client::new(
                     url,
-                    vec![("X-Algo-API-Token", &ApiToken::parse(token)?.to_string())],
+                    headers,
                 )?))
             }
-            (None, Some(_)) => Err(AlgonautError::UnitializedUrl),
-            (Some(_), None) => Err(AlgonautError::UnitializedToken),
-            (None, None) => Err(AlgonautError::UnitializedUrl),
+            (None, Some(_), _) => Err(AlgonautError::UnitializedUrl),
+            (Some(_), None, _) => Err(AlgonautError::UnitializedToken),
+            (None, None, _) => Err(AlgonautError::UnitializedUrl),
         }
     }
 }

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -7,6 +7,7 @@ pub mod v2;
 #[derive(Default)]
 pub struct IndexerBuilder<'a> {
     url: Option<&'a str>,
+    additional_headers: Headers<'a>,
 }
 
 impl<'a> IndexerBuilder<'a> {
@@ -21,12 +22,18 @@ impl<'a> IndexerBuilder<'a> {
         self
     }
 
+    /// Add an extra header to the client.
+    pub fn header(mut self, header_name: &'a str, header_data: &'a str) -> Self {
+        self.additional_headers.push((header_name, header_data));
+        self
+    }
+
     /// Build a v2 client for Algorand's indexer.
     ///
     /// Returns an error if url is not set or has an invalid format.
     pub fn build_v2(self) -> Result<v2::Indexer, AlgonautError> {
         match self.url {
-            Some(url) => Ok(v2::Indexer::new(Client::new(url, vec![])?)),
+            Some(url) => Ok(v2::Indexer::new(Client::new(url, self.additional_headers)?)),
             None => Err(AlgonautError::UnitializedUrl),
         }
     }

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -4,10 +4,11 @@ use algonaut_client::{indexer::v2::Client, Headers};
 pub mod v2;
 
 /// Indexer is the entry point to the creation of a client for the Algorand's indexer
+///
+/// For third party providers, use [`IndexerCustomEndpointBuilder`] instead.
 #[derive(Default)]
 pub struct IndexerBuilder<'a> {
     url: Option<&'a str>,
-    additional_headers: Headers<'a>,
 }
 
 impl<'a> IndexerBuilder<'a> {
@@ -22,18 +23,12 @@ impl<'a> IndexerBuilder<'a> {
         self
     }
 
-    /// Add an extra header to the client.
-    pub fn header(mut self, header_name: &'a str, header_data: &'a str) -> Self {
-        self.additional_headers.push((header_name, header_data));
-        self
-    }
-
     /// Build a v2 client for Algorand's indexer.
     ///
     /// Returns an error if url is not set or has an invalid format.
     pub fn build_v2(self) -> Result<v2::Indexer, AlgonautError> {
         match self.url {
-            Some(url) => Ok(v2::Indexer::new(Client::new(url, self.additional_headers)?)),
+            Some(url) => Ok(v2::Indexer::new(Client::new(url, vec![])?)),
             None => Err(AlgonautError::UnitializedUrl),
         }
     }

--- a/src/kmd/mod.rs
+++ b/src/kmd/mod.rs
@@ -54,14 +54,18 @@ impl<'a> KmdBuilder<'a> {
     ///
     /// Returns an error if url or token is not set or has an invalid format.
     pub fn build_v1(self) -> Result<v1::Kmd, AlgonautError> {
-        match (self.url, self.token) {
-            (Some(url), Some(token)) => Ok(v1::Kmd::new(Client::new(
-                url,
-                vec![("X-KMD-API-Token", &ApiToken::parse(token)?.to_string())],
-            )?)),
-            (None, Some(_)) => Err(AlgonautError::UnitializedUrl),
-            (Some(_), None) => Err(AlgonautError::UnitializedToken),
-            (None, None) => Err(AlgonautError::UnitializedUrl),
+        match (self.url, self.token, self.headers) {
+            (Some(url), Some(token), mut headers) => {
+                let token = ApiToken::parse(token)?.to_string();
+                headers.push(("X-KMD-API-Token", &token));
+                Ok(v1::Kmd::new(Client::new(
+                    url,
+                    headers,
+                )?))
+            },
+            (None, Some(_), _) => Err(AlgonautError::UnitializedUrl),
+            (Some(_), None, _) => Err(AlgonautError::UnitializedToken),
+            (None, None, _) => Err(AlgonautError::UnitializedUrl),
         }
     }
 }


### PR DESCRIPTION
It's useful for interfacing with third party services (e.g. [PureStake](purestake.io)) if they don't require a completely different API and instead just an API key.

There were a few methods earlier related to custom headers, whose values were largely ignored. Not entirely sure why this was the case, but went ahead and wired the pieces together.

The API is a little inconsistent (`headers` vs `header`) but wasn't sure if there was a reason for going with one or the other or if I should have implemented both.