### PR TITLE
refactor(examples): update imports to use "algonaut::" namespace

### DIFF
--- a/examples/app_call.rs
+++ b/examples/app_call.rs
@@ -1,7 +1,7 @@
 use algonaut::algod::v2::Algod;
+use algonaut::transaction::account::Account;
+use algonaut::transaction::builder::CallApplication;
 use algonaut::transaction::TxnBuilder;
-use algonaut_transaction::account::Account;
-use algonaut_transaction::builder::CallApplication;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/app_clear_state.rs
+++ b/examples/app_clear_state.rs
@@ -1,7 +1,7 @@
 use algonaut::algod::v2::Algod;
+use algonaut::transaction::account::Account;
+use algonaut::transaction::builder::ClearApplication;
 use algonaut::transaction::TxnBuilder;
-use algonaut_transaction::account::Account;
-use algonaut_transaction::builder::ClearApplication;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/app_close_out.rs
+++ b/examples/app_close_out.rs
@@ -1,7 +1,7 @@
 use algonaut::algod::v2::Algod;
+use algonaut::transaction::account::Account;
+use algonaut::transaction::builder::CloseApplication;
 use algonaut::transaction::TxnBuilder;
-use algonaut_transaction::account::Account;
-use algonaut_transaction::builder::CloseApplication;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/app_create.rs
+++ b/examples/app_create.rs
@@ -1,10 +1,10 @@
 use algonaut::algod::v2::Algod;
 use algonaut::error::AlgonautError;
+use algonaut::model::algod::v2::PendingTransaction;
+use algonaut::transaction::account::Account;
+use algonaut::transaction::transaction::StateSchema;
+use algonaut::transaction::CreateApplication;
 use algonaut::transaction::TxnBuilder;
-use algonaut_model::algod::v2::PendingTransaction;
-use algonaut_transaction::account::Account;
-use algonaut_transaction::transaction::StateSchema;
-use algonaut_transaction::CreateApplication;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/app_delete.rs
+++ b/examples/app_delete.rs
@@ -1,7 +1,7 @@
 use algonaut::algod::v2::Algod;
+use algonaut::transaction::account::Account;
+use algonaut::transaction::builder::DeleteApplication;
 use algonaut::transaction::TxnBuilder;
-use algonaut_transaction::account::Account;
-use algonaut_transaction::builder::DeleteApplication;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/app_optin.rs
+++ b/examples/app_optin.rs
@@ -1,7 +1,7 @@
 use algonaut::algod::v2::Algod;
+use algonaut::transaction::account::Account;
+use algonaut::transaction::builder::OptInApplication;
 use algonaut::transaction::TxnBuilder;
-use algonaut_transaction::account::Account;
-use algonaut_transaction::builder::OptInApplication;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/app_update.rs
+++ b/examples/app_update.rs
@@ -1,7 +1,7 @@
 use algonaut::algod::v2::Algod;
+use algonaut::transaction::account::Account;
+use algonaut::transaction::builder::UpdateApplication;
 use algonaut::transaction::TxnBuilder;
-use algonaut_transaction::account::Account;
-use algonaut_transaction::builder::UpdateApplication;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/asset_clawback.rs
+++ b/examples/asset_clawback.rs
@@ -1,6 +1,6 @@
 use algonaut::algod::v2::Algod;
-use algonaut_transaction::ClawbackAsset;
-use algonaut_transaction::{account::Account, TxnBuilder};
+use algonaut::transaction::ClawbackAsset;
+use algonaut::transaction::{account::Account, TxnBuilder};
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/asset_create.rs
+++ b/examples/asset_create.rs
@@ -1,8 +1,8 @@
 use algonaut::algod::v2::Algod;
 use algonaut::error::AlgonautError;
+use algonaut::model::algod::v2::PendingTransaction;
+use algonaut::transaction::account::Account;
 use algonaut::transaction::{CreateAsset, TxnBuilder};
-use algonaut_model::algod::v2::PendingTransaction;
-use algonaut_transaction::account::Account;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/asset_optin.rs
+++ b/examples/asset_optin.rs
@@ -1,6 +1,6 @@
 use algonaut::algod::v2::Algod;
-use algonaut_transaction::AcceptAsset;
-use algonaut_transaction::{account::Account, TxnBuilder};
+use algonaut::transaction::AcceptAsset;
+use algonaut::transaction::{account::Account, TxnBuilder};
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/asset_transfer.rs
+++ b/examples/asset_transfer.rs
@@ -1,6 +1,6 @@
 use algonaut::algod::v2::Algod;
-use algonaut_transaction::TransferAsset;
-use algonaut_transaction::{account::Account, TxnBuilder};
+use algonaut::transaction::TransferAsset;
+use algonaut::transaction::{account::Account, TxnBuilder};
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/atomic_swap.rs
+++ b/examples/atomic_swap.rs
@@ -1,9 +1,9 @@
 use algonaut::algod::v2::Algod;
-use algonaut_core::MicroAlgos;
-use algonaut_transaction::account::Account;
-use algonaut_transaction::tx_group::TxGroup;
-use algonaut_transaction::Pay;
-use algonaut_transaction::TxnBuilder;
+use algonaut::core::MicroAlgos;
+use algonaut::transaction::account::Account;
+use algonaut::transaction::tx_group::TxGroup;
+use algonaut::transaction::Pay;
+use algonaut::transaction::TxnBuilder;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/indexer_query.rs
+++ b/examples/indexer_query.rs
@@ -1,5 +1,5 @@
 use algonaut::indexer::v2::Indexer;
-use algonaut_model::indexer::v2::QueryAccount;
+use algonaut::model::indexer::v2::QueryAccount;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/key_reg.rs
+++ b/examples/key_reg.rs
@@ -1,7 +1,7 @@
 use algonaut::algod::v2::Algod;
-use algonaut_core::{VotePk, VrfPk};
-use algonaut_transaction::RegisterKey;
-use algonaut_transaction::{account::Account, TxnBuilder};
+use algonaut::core::{VotePk, VrfPk};
+use algonaut::transaction::RegisterKey;
+use algonaut::transaction::{account::Account, TxnBuilder};
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/logic_sig_contract_account.rs
+++ b/examples/logic_sig_contract_account.rs
@@ -1,8 +1,8 @@
 use algonaut::algod::v2::Algod;
-use algonaut_core::MicroAlgos;
-use algonaut_transaction::contract_account::ContractAccount;
-use algonaut_transaction::Pay;
-use algonaut_transaction::TxnBuilder;
+use algonaut::core::MicroAlgos;
+use algonaut::transaction::contract_account::ContractAccount;
+use algonaut::transaction::Pay;
+use algonaut::transaction::TxnBuilder;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/logic_sig_delegated.rs
+++ b/examples/logic_sig_delegated.rs
@@ -1,8 +1,8 @@
 use algonaut::algod::v2::Algod;
-use algonaut_core::{LogicSignature, MicroAlgos, SignedLogic};
-use algonaut_transaction::transaction::TransactionSignature;
-use algonaut_transaction::{account::Account, TxnBuilder};
-use algonaut_transaction::{Pay, SignedTransaction};
+use algonaut::core::{LogicSignature, MicroAlgos, SignedLogic};
+use algonaut::transaction::transaction::TransactionSignature;
+use algonaut::transaction::{account::Account, TxnBuilder};
+use algonaut::transaction::{Pay, SignedTransaction};
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/logic_sig_delegated_multi.rs
+++ b/examples/logic_sig_delegated_multi.rs
@@ -1,8 +1,8 @@
 use algonaut::algod::v2::Algod;
-use algonaut_core::{LogicSignature, MicroAlgos, MultisigAddress, SignedLogic};
-use algonaut_transaction::transaction::TransactionSignature;
-use algonaut_transaction::{account::Account, TxnBuilder};
-use algonaut_transaction::{Pay, SignedTransaction};
+use algonaut::core::{LogicSignature, MicroAlgos, MultisigAddress, SignedLogic};
+use algonaut::transaction::transaction::TransactionSignature;
+use algonaut::transaction::{account::Account, TxnBuilder};
+use algonaut::transaction::{Pay, SignedTransaction};
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/multi_sig.rs
+++ b/examples/multi_sig.rs
@@ -1,8 +1,8 @@
 use algonaut::algod::v2::Algod;
-use algonaut_core::{MicroAlgos, MultisigAddress};
-use algonaut_transaction::transaction::TransactionSignature;
-use algonaut_transaction::{account::Account, TxnBuilder};
-use algonaut_transaction::{Pay, SignedTransaction};
+use algonaut::core::{MicroAlgos, MultisigAddress};
+use algonaut::transaction::transaction::TransactionSignature;
+use algonaut::transaction::{account::Account, TxnBuilder};
+use algonaut::transaction::{Pay, SignedTransaction};
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/payment.rs
+++ b/examples/payment.rs
@@ -1,7 +1,7 @@
 use algonaut::algod::v2::Algod;
-use algonaut_core::MicroAlgos;
-use algonaut_transaction::Pay;
-use algonaut_transaction::{account::Account, TxnBuilder};
+use algonaut::core::MicroAlgos;
+use algonaut::transaction::Pay;
+use algonaut::transaction::{account::Account, TxnBuilder};
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;


### PR DESCRIPTION
This lets the example code imports work when copied and pasted to external projects that depend only on the "algonaut" crate, rather than the individual crates.