### PR TITLE
Set transaction fee correctly

### DIFF
--- a/algonaut_core/src/lib.rs
+++ b/algonaut_core/src/lib.rs
@@ -258,7 +258,7 @@ pub struct SuggestedTransactionParams {
     pub genesis_id: String,
     pub genesis_hash: HashDigest,
     pub consensus_version: String,
-    pub fee: MicroAlgos,
+    pub fee_per_byte: MicroAlgos,
     pub min_fee: MicroAlgos,
     pub first_valid: Round,
     pub last_valid: Round,

--- a/algonaut_model/src/algod/v2/mod.rs
+++ b/algonaut_model/src/algod/v2/mod.rs
@@ -778,7 +778,8 @@ pub struct TransactionParams {
     /// Fee is in units of micro-Algos per byte.
     /// Fee may fall to zero but transactions must still have a fee of
     /// at least MinTxnFee for the current network protocol.
-    pub fee: MicroAlgos,
+    #[serde(rename = "fee")]
+    pub fee_per_byte: MicroAlgos,
 
     /// GenesisHash is the hash of the genesis block.
     // Pattern : "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$"

--- a/examples/app_call.rs
+++ b/examples/app_call.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .app_arguments(vec![vec![1, 0], vec![255]])
             .build(),
     )
-    .build();
+    .build()?;
 
     let signed_t = sender.sign_transaction(&t)?;
 

--- a/examples/app_clear_state.rs
+++ b/examples/app_clear_state.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let params = algod.suggested_transaction_params().await?;
     // to test this, create an application that sets local state and opt-in, for/with the account sending this transaction.
-    let t = TxnBuilder::with(params, ClearApplication::new(sender.address(), 5).build()).build();
+    let t = TxnBuilder::with(params, ClearApplication::new(sender.address(), 5).build()).build()?;
 
     let signed_t = sender.sign_transaction(&t)?;
 

--- a/examples/app_close_out.rs
+++ b/examples/app_close_out.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.suggested_transaction_params().await?;
     // to test this, create an application that sets local state and opt-in, for/with the account sending this transaction.
     // the approval program has to return success for the local state to be cleared.
-    let t = TxnBuilder::with(params, CloseApplication::new(sender.address(), 5).build()).build();
+    let t = TxnBuilder::with(params, CloseApplication::new(sender.address(), 5).build()).build()?;
 
     let signed_t = sender.sign_transaction(&t)?;
 

--- a/examples/app_create.rs
+++ b/examples/app_create.rs
@@ -60,7 +60,7 @@ int 1
         .app_arguments(vec![vec![1, 0], vec![255]])
         .build(),
     )
-    .build();
+    .build()?;
 
     let signed_t = sender.sign_transaction(&t)?;
 

--- a/examples/app_delete.rs
+++ b/examples/app_delete.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .app_arguments(vec![vec![1, 0], vec![255]])
             .build(),
     )
-    .build();
+    .build()?;
 
     let signed_t = sender.sign_transaction(&t)?;
 

--- a/examples/app_optin.rs
+++ b/examples/app_optin.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .app_arguments(vec![vec![1, 0], vec![255]])
             .build(),
     )
-    .build();
+    .build()?;
 
     let signed_t = sender.sign_transaction(&t)?;
 

--- a/examples/app_update.rs
+++ b/examples/app_update.rs
@@ -54,7 +54,7 @@ int 1
         .app_arguments(vec![vec![1, 0], vec![255]]) // for the program being upgraded
         .build(),
     )
-    .build();
+    .build()?;
 
     let signed_t = sender.sign_transaction(&t)?;
 

--- a/examples/asset_clawback.rs
+++ b/examples/asset_clawback.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         )
         .build(),
     )
-    .build();
+    .build()?;
 
     let sign_response = sender.sign_transaction(&t)?;
 

--- a/examples/asset_create.rs
+++ b/examples/asset_create.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .url("example.com".to_owned())
             .build(),
     )
-    .build();
+    .build()?;
 
     // we need to sign the transaction to prove that we own the sender address
     let signed_t = creator.sign_transaction(&t)?;

--- a/examples/asset_optin.rs
+++ b/examples/asset_optin.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let params = algod.suggested_transaction_params().await?;
 
-    let t = TxnBuilder::with(params, AcceptAsset::new(account.address(), 4).build()).build();
+    let t = TxnBuilder::with(params, AcceptAsset::new(account.address(), 4).build()).build()?;
 
     let sign_response = account.sign_transaction(&t)?;
 

--- a/examples/asset_transfer.rs
+++ b/examples/asset_transfer.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         params,
         TransferAsset::new(from.address(), 4, 3, to.address()).build(),
     )
-    .build();
+    .build()?;
 
     let sign_response = from.sign_transaction(&t)?;
 

--- a/examples/atomic_swap.rs
+++ b/examples/atomic_swap.rs
@@ -27,13 +27,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
         params.clone(),
         Pay::new(account1.address(), account2.address(), MicroAlgos(1_000)).build(),
     )
-    .build();
+    .build()?;
 
     let t2 = &mut TxnBuilder::with(
         params,
         Pay::new(account2.address(), account1.address(), MicroAlgos(3_000)).build(),
     )
-    .build();
+    .build()?;
 
     TxGroup::assign_group_id(vec![t1, t2])?;
 

--- a/examples/key_reg.rs
+++ b/examples/key_reg.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         )
         .build(),
     )
-    .build();
+    .build()?;
 
     let sign_response = account.sign_transaction(&t)?;
 

--- a/examples/kmd_sign_submit_transaction.rs
+++ b/examples/kmd_sign_submit_transaction.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         params,
         Pay::new(from_address, to_address, MicroAlgos(123_456)).build(),
     )
-    .build();
+    .build()?;
 
     // we need to sign the transaction to prove that we own the sender address
     let sign_response = kmd.sign_transaction(&wallet_handle_token, "", &t).await?;

--- a/examples/logic_sig_contract_account.rs
+++ b/examples/logic_sig_contract_account.rs
@@ -39,7 +39,7 @@ byte 0xFF
         params,
         Pay::new(*contract_account.address(), receiver, MicroAlgos(123_456)).build(),
     )
-    .build();
+    .build()?;
 
     let signed_t = contract_account.sign(&t, vec![vec![1, 0], vec![255]])?;
 

--- a/examples/logic_sig_delegated.rs
+++ b/examples/logic_sig_delegated.rs
@@ -33,7 +33,7 @@ int 1
         params,
         Pay::new(from.address(), to.address(), MicroAlgos(123_456)).build(),
     )
-    .build();
+    .build()?;
 
     let signature = from.generate_program_sig(&program);
 

--- a/examples/logic_sig_delegated_multi.rs
+++ b/examples/logic_sig_delegated_multi.rs
@@ -36,7 +36,7 @@ int 1
         params,
         Pay::new(multisig_address.address(), receiver, MicroAlgos(123_456)).build(),
     )
-    .build();
+    .build()?;
 
     let msig = account1.init_logic_msig(&program, &multisig_address)?;
     let msig = account2.append_to_logic_msig(&program, msig)?;

--- a/examples/multi_sig.rs
+++ b/examples/multi_sig.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         )
         .build(),
     )
-    .build();
+    .build()?;
 
     let msig = account1.init_transaction_msig(&t, &multisig_address)?;
     let msig = account2.append_to_transaction_msig(&t, msig)?;

--- a/examples/payment.rs
+++ b/examples/payment.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         params,
         Pay::new(from.address(), to.address(), MicroAlgos(123_456)).build(),
     )
-    .build();
+    .build()?;
 
     let sign_response = from.sign_transaction(&t)?;
 

--- a/examples/sign_offline.rs
+++ b/examples/sign_offline.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         )
         .build(),
     )
-    .build();
+    .build()?;
 
     // sign the transaction
     let signed_transaction = account.sign_transaction(&t)?;

--- a/src/algod/v2/mod.rs
+++ b/src/algod/v2/mod.rs
@@ -221,7 +221,7 @@ impl Algod {
             genesis_id: params.genesis_id,
             genesis_hash: params.genesis_hash,
             consensus_version: params.consensus_version,
-            fee: params.fee,
+            fee_per_byte: params.fee_per_byte,
             min_fee: params.min_fee,
             first_valid: params.last_round,
             last_valid: params.last_round + 1000,

--- a/tests/step_defs/integration/applications.rs
+++ b/tests/step_defs/integration/applications.rs
@@ -126,7 +126,7 @@ async fn i_create_a_new_transient_account_and_fund_it_with_microalgos(
         )
         .build(),
     )
-    .build();
+    .build()?;
 
     let s_tx = sender_account.sign_transaction(&tx)?;
 
@@ -268,7 +268,7 @@ async fn i_build_an_application_transaction(
         _ => Err(format!("Invalid str: {}", operation))?,
     };
 
-    w.tx = Some(TxnBuilder::with(params, tx_type).build());
+    w.tx = Some(TxnBuilder::with(params, tx_type).build()?);
 
     Ok(())
 }

--- a/tests/test_account.rs
+++ b/tests/test_account.rs
@@ -2,6 +2,7 @@ use algonaut_core::{Address, CompiledTeal, LogicSignature, MicroAlgos, Round, Si
 use algonaut_core::{MultisigAddress, ToMsgPack};
 use algonaut_crypto::HashDigest;
 use algonaut_transaction::account::Account;
+use algonaut_transaction::builder::TxnFee;
 use algonaut_transaction::transaction::TransactionSignature;
 use algonaut_transaction::{Pay, SignedTransaction, TxnBuilder};
 use data_encoding::{BASE64, HEXLOWER};
@@ -29,14 +30,14 @@ async fn test_signs_transaction_e2e() -> Result<(), Box<dyn Error>> {
 
     // build unsigned transaction
     let tx = TxnBuilder::new(
-        MicroAlgos(1000),
+        TxnFee::Fixed(MicroAlgos(1000)),
         Round(106575),
         Round(107575),
         // non 0 array for easier comparison with (modified) Java SDK test. Java SDK doesn't serialize 0 value array.
         HashDigest([1; 32]),
         Pay::new(from_addr, to_addr, MicroAlgos(1234)).build(),
     )
-    .build();
+    .build()?;
 
     let account = Account::from_mnemonic(from_sk)?;
 
@@ -74,14 +75,14 @@ async fn test_signs_transaction_zero_val_e2e() -> Result<(), Box<dyn Error>> {
 
     // build unsigned transaction
     let tx = TxnBuilder::new(
-        MicroAlgos(1000),
+        TxnFee::Fixed(MicroAlgos(1000)),
         // Java SDK 0 replaced with non zero value (see comment on test)
         Round(106575),
         Round(107575),
         HashDigest([1; 32]),
         Pay::new(from_addr, to_addr, MicroAlgos(1234)).build(),
     )
-    .build();
+    .build()?;
 
     let account = Account::from_mnemonic(from_sk)?;
 
@@ -111,7 +112,7 @@ async fn test_sign_multisig_transaction() -> Result<(), Box<dyn Error>> {
 
     // build unsigned transaction
     let tx = TxnBuilder::new(
-        MicroAlgos(217000),
+        TxnFee::Fixed(MicroAlgos(217000)),
         Round(972508),
         Round(973508),
         // non 0 array for easier comparison with (modified) Java SDK test. Java SDK doesn't serialize 0 value array.
@@ -125,7 +126,7 @@ async fn test_sign_multisig_transaction() -> Result<(), Box<dyn Error>> {
     )
     .genesis_id("testnet-v31.0".to_owned())
     .note(BASE64.decode(b"tFF5Ofz60nE=")?)
-    .build();
+    .build()?;
 
     let account = Account::from_mnemonic("auction inquiry lava second expand liberty glass involve ginger illness length room item discover ahead table doctor term tackle cement bonus profit right above catch")?;
 
@@ -221,7 +222,7 @@ async fn test_logic_sig_transaction() -> Result<(), Box<dyn Error>> {
 
     // build unsigned transaction
     let tx = TxnBuilder::new(
-        MicroAlgos(1000),
+        TxnFee::Fixed(MicroAlgos(1000)),
         Round(2063137),
         Round(2063137 + 1000),
         HashDigest(
@@ -235,7 +236,7 @@ async fn test_logic_sig_transaction() -> Result<(), Box<dyn Error>> {
     )
     .genesis_id("devnet-v1.0".to_owned())
     .note(BASE64.decode(b"8xMCTuLQ810=")?)
-    .build();
+    .build()?;
 
     let program = CompiledTeal(vec![
         0x01, 0x20, 0x01, 0x01, 0x22, // int 1

--- a/tests/test_trasactions.rs
+++ b/tests/test_trasactions.rs
@@ -129,7 +129,7 @@ int 1
         .foreign_assets(vec![1234])
         .build(),
     )
-    .build();
+    .build()?;
 
     let signed_t = sender.sign_transaction(&t)?;
 


### PR DESCRIPTION
Basically ported this: https://github.com/algorand/go-algorand-sdk/blob/c37407700af350ef13aea10b844529144f498b6c/future/transaction.go#L14-L29

Notes:

- The semantics around the fee "estimation" are a bit weird, it's more an accurate prediction of the signed txn size, if it has a regular signature (not lsig or msig). But I didn't want to diverge much from the official SDK for now. 
- Renamed the `fee` field in the [txn params](https://developer.algorand.org/docs/rest-apis/algod/v2/#get-v2transactionsparams) into `fee_per_byte`, to make clearer what it is.
- Added an enum `TxnFee` to the txn builder, to be able to set the fee to either "estimated" (based on `fee_per_byte` / `min_fee` and the "estimated" txn size) or fixed, which is just setting directly the txn's fee.
- The `TxnBuilder` `with` initializer implementation was adjusted to use `TxnFee::Estimated`, which seems a sensible default.
- Added a new convenience initializer to `TxnBuilder` called `with_fee`, which allows to pass the params and set the fee. Having to pass `first_valid`, `genesis_hash` etc. in order to set the fee is inconvenient. The current naming `with` / `with_fee` / `new` feels a bit arbitrary but prioritizing shortness - can be discussed.
- Added a `zero()` convenience initializer to the `TxnFee` enum, to be able to create easily a `0` fee. This is useful for txn groups, where `lsig` txn fees are paid by another txn in the group. Here the `lsig` txn's fee is set to `0`. Note that this used to be solved by sending a dedicated "pay fee" txn.
- Added `estimate_fee` and `estimate_fee_with_params`(convenience) to `Transaction`, to be able to easily calculate the fee - this is useful again for txn groups, when calculating the fee for the "paying" txn.
- Not using a hardcoded [MinTxnFee](https://github.com/algorand/go-algorand-sdk/blob/c37407700af350ef13aea10b844529144f498b6c/transaction/transaction.go#L13). This is provided by the API (transaction params) and it's a required field in our case (we have a higher min consensus version).