### PR TITLE
Pass params as reference

### DIFF
--- a/algonaut_transaction/src/builder.rs
+++ b/algonaut_transaction/src/builder.rs
@@ -47,9 +47,9 @@ pub struct TxnBuilder {
 impl TxnBuilder {
     /// Convenience to initialize builder with suggested transaction params
     /// The txn fee is estimated, based on params. To set the fee manually, use [with_fee](Self::with_fee) or [new](Self::new).
-    pub fn with(params: SuggestedTransactionParams, txn_type: TransactionType) -> Self {
+    pub fn with(params: &SuggestedTransactionParams, txn_type: TransactionType) -> Self {
         Self::with_fee(
-            params.clone(),
+            params,
             TxnFee::Estimated {
                 fee_per_byte: params.fee_per_byte,
                 min_fee: params.min_fee,
@@ -61,7 +61,7 @@ impl TxnBuilder {
     /// Convenience to initialize builder with suggested transaction params, and set the fee manually (ignoring the fee fields in params).
     /// Useful e.g. in txns groups where one txn pays the fee for others.
     pub fn with_fee(
-        params: SuggestedTransactionParams,
+        params: &SuggestedTransactionParams,
         fee: TxnFee,
         txn_type: TransactionType,
     ) -> Self {
@@ -72,7 +72,7 @@ impl TxnBuilder {
             params.genesis_hash,
             txn_type,
         )
-        .genesis_id(params.genesis_id)
+        .genesis_id(params.genesis_id.clone())
     }
 
     pub fn new(

--- a/examples/app_call.rs
+++ b/examples/app_call.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // #pragma version 4
     // int 1
     let t = TxnBuilder::with(
-        params,
+        &params,
         CallApplication::new(sender.address(), 5)
             .app_arguments(vec![vec![1, 0], vec![255]])
             .build(),

--- a/examples/app_clear_state.rs
+++ b/examples/app_clear_state.rs
@@ -17,7 +17,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let params = algod.suggested_transaction_params().await?;
     // to test this, create an application that sets local state and opt-in, for/with the account sending this transaction.
-    let t = TxnBuilder::with(params, ClearApplication::new(sender.address(), 5).build()).build()?;
+    let t =
+        TxnBuilder::with(&params, ClearApplication::new(sender.address(), 5).build()).build()?;
 
     let signed_t = sender.sign_transaction(&t)?;
 

--- a/examples/app_close_out.rs
+++ b/examples/app_close_out.rs
@@ -18,7 +18,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.suggested_transaction_params().await?;
     // to test this, create an application that sets local state and opt-in, for/with the account sending this transaction.
     // the approval program has to return success for the local state to be cleared.
-    let t = TxnBuilder::with(params, CloseApplication::new(sender.address(), 5).build()).build()?;
+    let t =
+        TxnBuilder::with(&params, CloseApplication::new(sender.address(), 5).build()).build()?;
 
     let signed_t = sender.sign_transaction(&t)?;
 

--- a/examples/app_create.rs
+++ b/examples/app_create.rs
@@ -43,7 +43,7 @@ int 1
 
     let params = algod.suggested_transaction_params().await?;
     let t = TxnBuilder::with(
-        params,
+        &params,
         CreateApplication::new(
             sender.address(),
             compiled_approval_program.clone(),

--- a/examples/app_delete.rs
+++ b/examples/app_delete.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // #pragma version 4
     // int 1
     let t = TxnBuilder::with(
-        params,
+        &params,
         DeleteApplication::new(sender.address(), 5)
             .app_arguments(vec![vec![1, 0], vec![255]])
             .build(),

--- a/examples/app_optin.rs
+++ b/examples/app_optin.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // #pragma version 4
     // int 1
     let t = TxnBuilder::with(
-        params,
+        &params,
         OptInApplication::new(sender.address(), 5)
             .app_arguments(vec![vec![1, 0], vec![255]])
             .build(),

--- a/examples/app_update.rs
+++ b/examples/app_update.rs
@@ -44,7 +44,7 @@ int 1
     // #pragma version 4
     // int 1
     let t = TxnBuilder::with(
-        params,
+        &params,
         UpdateApplication::new(
             sender.address(),
             5,

--- a/examples/asset_clawback.rs
+++ b/examples/asset_clawback.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.suggested_transaction_params().await?;
 
     let t = TxnBuilder::with(
-        params,
+        &params,
         ClawbackAsset::new(
             sender_address,
             4,

--- a/examples/asset_create.rs
+++ b/examples/asset_create.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.suggested_transaction_params().await?;
 
     let t = TxnBuilder::with(
-        params,
+        &params,
         CreateAsset::new(creator.address(), 10, 2, false)
             .unit_name("EIRI".to_owned())
             .asset_name("Naki".to_owned())

--- a/examples/asset_optin.rs
+++ b/examples/asset_optin.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let params = algod.suggested_transaction_params().await?;
 
-    let t = TxnBuilder::with(params, AcceptAsset::new(account.address(), 4).build()).build()?;
+    let t = TxnBuilder::with(&params, AcceptAsset::new(account.address(), 4).build()).build()?;
 
     let sign_response = account.sign_transaction(&t)?;
 

--- a/examples/asset_transfer.rs
+++ b/examples/asset_transfer.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.suggested_transaction_params().await?;
 
     let t = TxnBuilder::with(
-        params,
+        &params,
         TransferAsset::new(from.address(), 4, 3, to.address()).build(),
     )
     .build()?;

--- a/examples/atomic_swap.rs
+++ b/examples/atomic_swap.rs
@@ -24,13 +24,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Normally you'll want to submit e.g. a payment and asset transfer or asset transfers for different assets.
 
     let t1 = &mut TxnBuilder::with(
-        params.clone(),
+        &params,
         Pay::new(account1.address(), account2.address(), MicroAlgos(1_000)).build(),
     )
     .build()?;
 
     let t2 = &mut TxnBuilder::with(
-        params,
+        &params,
         Pay::new(account2.address(), account1.address(), MicroAlgos(3_000)).build(),
     )
     .build()?;

--- a/examples/key_reg.rs
+++ b/examples/key_reg.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.suggested_transaction_params().await?;
 
     let t = TxnBuilder::with(
-        params.clone(),
+        &params,
         RegisterKey::online(
             account.address(),
             VotePk::from_base64_str(vote_pk_str)?,

--- a/examples/kmd_sign_submit_transaction.rs
+++ b/examples/kmd_sign_submit_transaction.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.suggested_transaction_params().await?;
 
     let t = TxnBuilder::with(
-        params,
+        &params,
         Pay::new(from_address, to_address, MicroAlgos(123_456)).build(),
     )
     .build()?;

--- a/examples/logic_sig_contract_account.rs
+++ b/examples/logic_sig_contract_account.rs
@@ -36,7 +36,7 @@ byte 0xFF
     let params = algod.suggested_transaction_params().await?;
 
     let t = TxnBuilder::with(
-        params,
+        &params,
         Pay::new(*contract_account.address(), receiver, MicroAlgos(123_456)).build(),
     )
     .build()?;

--- a/examples/logic_sig_delegated.rs
+++ b/examples/logic_sig_delegated.rs
@@ -30,7 +30,7 @@ int 1
     let params = algod.suggested_transaction_params().await?;
 
     let t = TxnBuilder::with(
-        params,
+        &params,
         Pay::new(from.address(), to.address(), MicroAlgos(123_456)).build(),
     )
     .build()?;

--- a/examples/logic_sig_delegated_multi.rs
+++ b/examples/logic_sig_delegated_multi.rs
@@ -33,7 +33,7 @@ int 1
     let params = algod.suggested_transaction_params().await?;
 
     let t = TxnBuilder::with(
-        params,
+        &params,
         Pay::new(multisig_address.address(), receiver, MicroAlgos(123_456)).build(),
     )
     .build()?;

--- a/examples/multi_sig.rs
+++ b/examples/multi_sig.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.suggested_transaction_params().await?;
 
     let t = TxnBuilder::with(
-        params,
+        &params,
         Pay::new(
             multisig_address.address(),
             account2.address(),

--- a/examples/payment.rs
+++ b/examples/payment.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.suggested_transaction_params().await?;
 
     let t = TxnBuilder::with(
-        params,
+        &params,
         Pay::new(from.address(), to.address(), MicroAlgos(123_456)).build(),
     )
     .build()?;

--- a/examples/sign_offline.rs
+++ b/examples/sign_offline.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.suggested_transaction_params().await?;
 
     let t = TxnBuilder::with(
-        params,
+        &params,
         Pay::new(
             account.address(),
             "4MYUHDWHWXAKA5KA7U5PEN646VYUANBFXVJNONBK3TIMHEMWMD4UBOJBI4".parse()?,

--- a/tests/step_defs/integration/applications.rs
+++ b/tests/step_defs/integration/applications.rs
@@ -118,7 +118,7 @@ async fn i_create_a_new_transient_account_and_fund_it_with_microalgos(
 
     let params = algod.suggested_transaction_params().await?;
     let tx = TxnBuilder::with(
-        params,
+        &params,
         Pay::new(
             accounts[1],
             sender_account.address(),
@@ -268,7 +268,7 @@ async fn i_build_an_application_transaction(
         _ => Err(format!("Invalid str: {}", operation))?,
     };
 
-    w.tx = Some(TxnBuilder::with(params, tx_type).build()?);
+    w.tx = Some(TxnBuilder::with(&params, tx_type).build()?);
 
     Ok(())
 }

--- a/tests/test_trasactions.rs
+++ b/tests/test_trasactions.rs
@@ -98,7 +98,7 @@ int 1
 
     let params = algod.suggested_transaction_params().await?;
     let t = TxnBuilder::with(
-        params,
+        &params,
         CreateApplication::new(
             sender.address(),
             compiled_approval_program.clone(),


### PR DESCRIPTION
This is better since params are often reused (e.g. when building transaction groups).