### PR TITLE
Rename AlgonautError in ServiceError

### DIFF
--- a/examples/app_create.rs
+++ b/examples/app_create.rs
@@ -1,5 +1,5 @@
 use algonaut::algod::v2::Algod;
-use algonaut::error::AlgonautError;
+use algonaut::error::ServiceError;
 use algonaut::model::algod::v2::PendingTransaction;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::transaction::StateSchema;
@@ -79,7 +79,7 @@ int 1
 async fn wait_for_pending_transaction(
     algod: &Algod,
     txid: &str,
-) -> Result<Option<PendingTransaction>, AlgonautError> {
+) -> Result<Option<PendingTransaction>, ServiceError> {
     let timeout = Duration::from_secs(10);
     let start = Instant::now();
     loop {

--- a/examples/asset_create.rs
+++ b/examples/asset_create.rs
@@ -1,5 +1,5 @@
 use algonaut::algod::v2::Algod;
-use algonaut::error::AlgonautError;
+use algonaut::error::ServiceError;
 use algonaut::model::algod::v2::PendingTransaction;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::{CreateAsset, TxnBuilder};
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn wait_for_pending_transaction(
     algod: &Algod,
     txid: &str,
-) -> Result<Option<PendingTransaction>, AlgonautError> {
+) -> Result<Option<PendingTransaction>, ServiceError> {
     let timeout = Duration::from_secs(10);
     let start = Instant::now();
     loop {

--- a/src/indexer/v2/mod.rs
+++ b/src/indexer/v2/mod.rs
@@ -8,7 +8,7 @@ use algonaut_model::indexer::v2::{
     QueryBalances, QueryTransaction, TransactionInfoResponse, TransactionResponse,
 };
 
-use crate::error::AlgonautError;
+use crate::error::ServiceError;
 
 #[derive(Debug)]
 pub struct Indexer {
@@ -19,7 +19,7 @@ impl Indexer {
     /// Build a v2 client for Algorand's indexer.
     ///
     /// Returns an error if the url has an invalid format.
-    pub fn new(url: &str) -> Result<Indexer, AlgonautError> {
+    pub fn new(url: &str) -> Result<Indexer, ServiceError> {
         Self::with_headers(url, vec![])
     }
 
@@ -27,19 +27,19 @@ impl Indexer {
     /// Use this initializer when interfacing with third party services, that require custom headers.
     ///
     /// Returns an error if the url or the headers have an invalid format.
-    pub fn with_headers(url: &str, headers: Headers) -> Result<Indexer, AlgonautError> {
+    pub fn with_headers(url: &str, headers: Headers) -> Result<Indexer, ServiceError> {
         Ok(Indexer {
             client: Client::new(url, headers)?,
         })
     }
 
     /// Returns Ok if healthy
-    pub async fn health(&self) -> Result<(), AlgonautError> {
+    pub async fn health(&self) -> Result<(), ServiceError> {
         Ok(self.client.health().await?)
     }
 
     /// Search for accounts.
-    pub async fn accounts(&self, query: &QueryAccount) -> Result<AccountResponse, AlgonautError> {
+    pub async fn accounts(&self, query: &QueryAccount) -> Result<AccountResponse, ServiceError> {
         Ok(self.client.accounts(query).await?)
     }
 
@@ -48,7 +48,7 @@ impl Indexer {
         &self,
         address: &Address,
         query: &QueryAccountInfo,
-    ) -> Result<AccountInfoResponse, AlgonautError> {
+    ) -> Result<AccountInfoResponse, ServiceError> {
         Ok(self.client.account_info(address, query).await?)
     }
 
@@ -57,7 +57,7 @@ impl Indexer {
         &self,
         address: &Address,
         query: &QueryAccountTransaction,
-    ) -> Result<AccountTransactionResponse, AlgonautError> {
+    ) -> Result<AccountTransactionResponse, ServiceError> {
         Ok(self.client.account_transactions(address, query).await?)
     }
 
@@ -65,7 +65,7 @@ impl Indexer {
     pub async fn applications(
         &self,
         query: &QueryApplications,
-    ) -> Result<ApplicationResponse, AlgonautError> {
+    ) -> Result<ApplicationResponse, ServiceError> {
         Ok(self.client.applications(query).await?)
     }
 
@@ -74,12 +74,12 @@ impl Indexer {
         &self,
         id: u64,
         query: &QueryApplicationInfo,
-    ) -> Result<ApplicationInfoResponse, AlgonautError> {
+    ) -> Result<ApplicationInfoResponse, ServiceError> {
         Ok(self.client.application_info(id, query).await?)
     }
 
     /// Search for assets.
-    pub async fn assets(&self, query: &QueryAssets) -> Result<AssetResponse, AlgonautError> {
+    pub async fn assets(&self, query: &QueryAssets) -> Result<AssetResponse, ServiceError> {
         Ok(self.client.assets(query).await?)
     }
 
@@ -88,7 +88,7 @@ impl Indexer {
         &self,
         id: u64,
         query: &QueryAssetsInfo,
-    ) -> Result<AssetsInfoResponse, AlgonautError> {
+    ) -> Result<AssetsInfoResponse, ServiceError> {
         Ok(self.client.assets_info(id, query).await?)
     }
 
@@ -97,7 +97,7 @@ impl Indexer {
         &self,
         id: u64,
         query: &QueryBalances,
-    ) -> Result<BalancesResponse, AlgonautError> {
+    ) -> Result<BalancesResponse, ServiceError> {
         Ok(self.client.asset_balances(id, query).await?)
     }
 
@@ -106,12 +106,12 @@ impl Indexer {
         &self,
         id: u64,
         query: &QueryAssetTransaction,
-    ) -> Result<AssetTransactionResponse, AlgonautError> {
+    ) -> Result<AssetTransactionResponse, ServiceError> {
         Ok(self.client.asset_transactions(id, query).await?)
     }
 
     /// Lookup block.
-    pub async fn block(&self, round: Round) -> Result<Block, AlgonautError> {
+    pub async fn block(&self, round: Round) -> Result<Block, ServiceError> {
         Ok(self.client.block(round).await?)
     }
 
@@ -119,7 +119,7 @@ impl Indexer {
     pub async fn transactions(
         &self,
         query: &QueryTransaction,
-    ) -> Result<TransactionResponse, AlgonautError> {
+    ) -> Result<TransactionResponse, ServiceError> {
         Ok(self.client.transactions(query).await?)
     }
 
@@ -127,7 +127,7 @@ impl Indexer {
     pub async fn transaction_info(
         &self,
         id: &str,
-    ) -> Result<TransactionInfoResponse, AlgonautError> {
+    ) -> Result<TransactionInfoResponse, ServiceError> {
         Ok(self.client.transaction_info(id).await?)
     }
 }

--- a/src/kmd/v1/mod.rs
+++ b/src/kmd/v1/mod.rs
@@ -11,7 +11,7 @@ use algonaut_model::kmd::v1::{
 };
 use algonaut_transaction::Transaction;
 
-use crate::error::AlgonautError;
+use crate::error::ServiceError;
 
 #[derive(Debug)]
 pub struct Kmd {
@@ -22,7 +22,7 @@ impl Kmd {
     /// Build a v1 client for the Algorand key management daemon.
     ///
     /// Returns an error if the url or token have an invalid format.
-    pub fn new(url: &str, token: &str) -> Result<Kmd, AlgonautError> {
+    pub fn new(url: &str, token: &str) -> Result<Kmd, ServiceError> {
         Self::with_headers(
             url,
             vec![("X-KMD-API-Token", &ApiToken::parse(token)?.to_string())],
@@ -33,19 +33,19 @@ impl Kmd {
     /// Use this initializer when interfacing with third party services, that require custom headers.
     ///
     /// Returns an error if the url or headers have an invalid format.
-    pub fn with_headers(url: &str, headers: Headers) -> Result<Kmd, AlgonautError> {
+    pub fn with_headers(url: &str, headers: Headers) -> Result<Kmd, ServiceError> {
         Ok(Kmd {
             client: Client::new(url, headers)?,
         })
     }
 
     /// Retrieves the current version
-    pub async fn versions(&self) -> Result<VersionsResponse, AlgonautError> {
+    pub async fn versions(&self) -> Result<VersionsResponse, ServiceError> {
         Ok(self.client.versions().await?)
     }
 
     /// List all of the wallets that kmd is aware of
-    pub async fn list_wallets(&self) -> Result<ListWalletsResponse, AlgonautError> {
+    pub async fn list_wallets(&self) -> Result<ListWalletsResponse, ServiceError> {
         Ok(self.client.list_wallets().await?)
     }
 
@@ -56,7 +56,7 @@ impl Kmd {
         wallet_password: &str,
         wallet_driver_name: &str,
         master_derivation_key: MasterDerivationKey,
-    ) -> Result<CreateWalletResponse, AlgonautError> {
+    ) -> Result<CreateWalletResponse, ServiceError> {
         Ok(self
             .client
             .create_wallet(
@@ -78,7 +78,7 @@ impl Kmd {
         &self,
         wallet_id: &str,
         wallet_password: &str,
-    ) -> Result<InitWalletHandleResponse, AlgonautError> {
+    ) -> Result<InitWalletHandleResponse, ServiceError> {
         Ok(self
             .client
             .init_wallet_handle(wallet_id, wallet_password)
@@ -89,7 +89,7 @@ impl Kmd {
     pub async fn release_wallet_handle(
         &self,
         wallet_handle: &str,
-    ) -> Result<ReleaseWalletHandleResponse, AlgonautError> {
+    ) -> Result<ReleaseWalletHandleResponse, ServiceError> {
         Ok(self.client.release_wallet_handle(wallet_handle).await?)
     }
 
@@ -97,7 +97,7 @@ impl Kmd {
     pub async fn renew_wallet_handle(
         &self,
         wallet_handle: &str,
-    ) -> Result<RenewWalletHandleResponse, AlgonautError> {
+    ) -> Result<RenewWalletHandleResponse, ServiceError> {
         Ok(self.client.renew_wallet_handle(wallet_handle).await?)
     }
 
@@ -107,7 +107,7 @@ impl Kmd {
         wallet_id: &str,
         wallet_password: &str,
         new_name: &str,
-    ) -> Result<RenameWalletResponse, AlgonautError> {
+    ) -> Result<RenameWalletResponse, ServiceError> {
         Ok(self
             .client
             .rename_wallet(wallet_id, wallet_password, new_name)
@@ -118,7 +118,7 @@ impl Kmd {
     pub async fn get_wallet_info(
         &self,
         wallet_handle: &str,
-    ) -> Result<GetWalletInfoResponse, AlgonautError> {
+    ) -> Result<GetWalletInfoResponse, ServiceError> {
         Ok(self.client.get_wallet_info(wallet_handle).await?)
     }
 
@@ -127,7 +127,7 @@ impl Kmd {
         &self,
         wallet_handle: &str,
         wallet_password: &str,
-    ) -> Result<ExportMasterDerivationKeyResponse, AlgonautError> {
+    ) -> Result<ExportMasterDerivationKeyResponse, ServiceError> {
         Ok(self
             .client
             .export_master_derivation_key(wallet_handle, wallet_password)
@@ -139,7 +139,7 @@ impl Kmd {
         &self,
         wallet_handle: &str,
         private_key: [u8; 32],
-    ) -> Result<ImportKeyResponse, AlgonautError> {
+    ) -> Result<ImportKeyResponse, ServiceError> {
         Ok(self.client.import_key(wallet_handle, private_key).await?)
     }
 
@@ -151,7 +151,7 @@ impl Kmd {
         wallet_handle: &str,
         wallet_password: &str,
         address: &Address,
-    ) -> Result<ExportKeyResponse, AlgonautError> {
+    ) -> Result<ExportKeyResponse, ServiceError> {
         Ok(self
             .client
             .export_key(wallet_handle, wallet_password, address)
@@ -162,7 +162,7 @@ impl Kmd {
     pub async fn generate_key(
         &self,
         wallet_handle: &str,
-    ) -> Result<GenerateKeyResponse, AlgonautError> {
+    ) -> Result<GenerateKeyResponse, ServiceError> {
         Ok(self.client.generate_key(wallet_handle).await?)
     }
 
@@ -172,7 +172,7 @@ impl Kmd {
         wallet_handle: &str,
         wallet_password: &str,
         address: &str,
-    ) -> Result<DeleteKeyResponse, AlgonautError> {
+    ) -> Result<DeleteKeyResponse, ServiceError> {
         Ok(self
             .client
             .delete_key(wallet_handle, wallet_password, address)
@@ -180,7 +180,7 @@ impl Kmd {
     }
 
     /// List all of the public keys in the wallet
-    pub async fn list_keys(&self, wallet_handle: &str) -> Result<ListKeysResponse, AlgonautError> {
+    pub async fn list_keys(&self, wallet_handle: &str) -> Result<ListKeysResponse, ServiceError> {
         Ok(self.client.list_keys(wallet_handle).await?)
     }
 
@@ -190,7 +190,7 @@ impl Kmd {
         wallet_handle: &str,
         wallet_password: &str,
         transaction: &Transaction,
-    ) -> Result<SignTransactionResponse, AlgonautError> {
+    ) -> Result<SignTransactionResponse, ServiceError> {
         Ok(self
             .client
             .sign_transaction(wallet_handle, wallet_password, transaction.to_msg_pack()?)
@@ -201,7 +201,7 @@ impl Kmd {
     pub async fn list_multisig(
         &self,
         wallet_handle: &str,
-    ) -> Result<ListMultisigResponse, AlgonautError> {
+    ) -> Result<ListMultisigResponse, ServiceError> {
         Ok(self.client.list_multisig(wallet_handle).await?)
     }
 
@@ -212,7 +212,7 @@ impl Kmd {
         version: u8,
         threshold: u8,
         pks: &[Ed25519PublicKey],
-    ) -> Result<ImportMultisigResponse, AlgonautError> {
+    ) -> Result<ImportMultisigResponse, ServiceError> {
         Ok(self
             .client
             .import_multisig(wallet_handle, version, threshold, pks)
@@ -224,7 +224,7 @@ impl Kmd {
         &self,
         wallet_handle: &str,
         address: &str,
-    ) -> Result<ExportMultisigResponse, AlgonautError> {
+    ) -> Result<ExportMultisigResponse, ServiceError> {
         Ok(self.client.export_multisig(wallet_handle, address).await?)
     }
 
@@ -234,7 +234,7 @@ impl Kmd {
         wallet_handle: &str,
         wallet_password: &str,
         address: &str,
-    ) -> Result<DeleteMultisigResponse, AlgonautError> {
+    ) -> Result<DeleteMultisigResponse, ServiceError> {
         Ok(self
             .client
             .delete_multisig(wallet_handle, wallet_password, address)
@@ -251,7 +251,7 @@ impl Kmd {
         transaction: &Transaction,
         public_key: Ed25519PublicKey,
         partial_multisig: Option<MultisigSignature>,
-    ) -> Result<SignMultisigTransactionResponse, AlgonautError> {
+    ) -> Result<SignMultisigTransactionResponse, ServiceError> {
         Ok(self
             .client
             .sign_multisig_transaction(

--- a/tests/step_defs/util.rs
+++ b/tests/step_defs/util.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use algonaut::{algod::v2::Algod, error::AlgonautError};
+use algonaut::{algod::v2::Algod, error::ServiceError};
 use algonaut_core::Address;
 use algonaut_model::{algod::v2::PendingTransaction, kmd::v1::ExportKeyResponse};
 use algonaut_transaction::account::Account;
@@ -14,7 +14,7 @@ use algonaut_transaction::account::Account;
 pub async fn wait_for_pending_transaction(
     algod: &Algod,
     txid: &str,
-) -> Result<Option<PendingTransaction>, AlgonautError> {
+) -> Result<Option<PendingTransaction>, ServiceError> {
     let timeout = Duration::from_secs(10);
     let start = Instant::now();
     loop {


### PR DESCRIPTION
These errors are specific to the algod/kmd/indexer REST client wrappers and not general to Algonaut.

`ServiceError` sounds extraneous, as we don't have anything called "service", but it's a kind of implied name for the algod/kmd/indexer wrappers, which are currently in the root package. Moving these wrappers to a new package seems overkill. Another name could be "client wrapper" or something like that, but "service" sounds better.

Closes https://github.com/manuelmauro/algonaut/issues/99