### PR TITLE
Support ABI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "algonaut_crypto",
   "algonaut_encoding",
   "algonaut_transaction",
+  "algonaut_abi",
 ]
 
 [dependencies]
@@ -28,6 +29,7 @@ algonaut_core = { path = "algonaut_core", version = "0.3.0" }
 algonaut_crypto = { path = "algonaut_crypto", version = "0.3.0" }
 algonaut_encoding = { path = "algonaut_encoding", version = "0.3.0" }
 algonaut_transaction = { path = "algonaut_transaction", version = "0.3.0" }
+algonaut_abi = { path = "algonaut_abi", version = "0.3.0" }
 thiserror = "1.0.23"
 rmp-serde = "1.0.0"
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 - `algonaut_crypto` contains crypto utilities such as: `ed25519` and `mnemonics`.
 - `algonaut_encoding` implements encoding utility functions such as `serde` visitors.
 - `algonaut_transaction` support developers in building all kinds of Algorand transactions.
+- `algonaut_abi` Application Binary Interface (ABI) to invoke smart contract methods with a standarized interface.
 
 ## External utilities
 

--- a/algonaut_abi/Cargo.toml
+++ b/algonaut_abi/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+authors = ["Manuel Mauro <manuel.mauro@protonmail.com>", "Ivan Schuetz <ivanhp978@gmail.com>",]
+description = "Application Binary Interface (ABI) to invoke smart contract methods with a standarized interface."
+edition = "2018"
+keywords = ["Algorand", "sdk"]
+license = "MIT"
+name = "algonaut_abi"
+repository = "https://github.com/manuelmauro/algonaut"
+version = "0.3.0"
+
+[dependencies]
+algonaut_core = {path = "../algonaut_core", version = "0.3.0"}
+serde = {version = "1.0", features = ["derive"]}
+regex = "1.5.5"
+lazy_static = "1.4.0"
+sha2 = "0.10.1"
+derive_more = "0.99.13"
+thiserror = "1.0.23"
+num-bigint = "0.4.3"
+
+[dev-dependencies]
+serde_json = "1.0.40"
+rand = "0.8.5"
+num-bigint = { version = "0.4.3", features = ["rand"] }

--- a/algonaut_abi/README.md
+++ b/algonaut_abi/README.md
@@ -1,0 +1,3 @@
+# algonaut_abi
+
+For more information refer to [algonaut](https://crates.io/crates/algonaut) crate.

--- a/algonaut_abi/src/abi_encode.rs
+++ b/algonaut_abi/src/abi_encode.rs
@@ -1,0 +1,548 @@
+use crate::{
+    abi_error::AbiError,
+    abi_type::{
+        make_byte_type, make_tuple_type, AbiType, AbiValue, ADDRESS_BYTE_SIZE,
+        LENGTH_ENCODE_BYTE_SIZE, SINGLE_BYTE_SIZE,
+    },
+    biguint_ext::BigUintExt,
+};
+use algonaut_core::Address;
+use num_bigint::BigUint;
+use std::{collections::HashSet, convert::TryInto};
+
+impl AbiType {
+    /// ABI type method to encode abi values into bytes following ABI encoding rules
+    pub fn encode(&self, value: AbiValue) -> Result<Vec<u8>, AbiError> {
+        match self {
+            AbiType::UInt { bit_size } | AbiType::UFixed { bit_size, .. } => {
+                self.encode_int(value, *bit_size)
+            }
+            AbiType::Byte => self.encode_bytes(value),
+            AbiType::Bool => self.encode_bool(value),
+            AbiType::Address => self.encode_static_array(value, &[]),
+            AbiType::StaticArray { .. } => self.encode_static_array(value, &[]),
+            AbiType::DynamicArray { .. } => self.encode_dynamic_array(value),
+            AbiType::String => self.encode_string(value),
+            AbiType::Tuple { .. } => self.encode_tuple(value),
+        }
+    }
+
+    fn encode_int(&self, value: AbiValue, bit_size: u16) -> Result<Vec<u8>, AbiError> {
+        match value {
+            AbiValue::Int(u) => self.encode_u64(u, bit_size / 8),
+            _ => Err(AbiError::Msg(
+                "Incompatible value: {value} for ABI type: {self}".to_owned(),
+            )),
+        }
+    }
+
+    fn encode_bytes(&self, value: AbiValue) -> Result<Vec<u8>, AbiError> {
+        match value {
+            AbiValue::Byte(b) => Ok(vec![b]),
+            _ => Err(incompatible_value_for_type_err(self, &value)),
+        }
+    }
+
+    fn encode_bool(&self, value: AbiValue) -> Result<Vec<u8>, AbiError> {
+        match value {
+            AbiValue::Bool(b) => Ok(vec![if b { 0x80 } else { 0x00 }]),
+            _ => Err(incompatible_value_for_type_err(self, &value)),
+        }
+    }
+
+    fn encode_u64(&self, value: BigUint, byte_len: u16) -> Result<Vec<u8>, AbiError> {
+        let array = value.to_bytes_be_padded(byte_len as usize)?;
+        Ok(array)
+    }
+
+    fn encode_static_array(&self, value: AbiValue, tup_len: &[usize]) -> Result<Vec<u8>, AbiError> {
+        let casted_type = self.type_cast_to_tuple(tup_len)?;
+        casted_type.encode(value)
+    }
+
+    fn encode_string(&self, value: AbiValue) -> Result<Vec<u8>, AbiError> {
+        match value {
+            AbiValue::String(str) => {
+                let str_bytes: Vec<u8> = str.bytes().collect();
+                if str_bytes.len() >= (1 << 16) {
+                    return Err(AbiError::Msg(
+                        "string casted to byte exceeds uint16 maximum, error".to_owned(),
+                    ));
+                }
+
+                let tuple_type = self.type_cast_to_tuple(&[str_bytes.len()])?;
+                let values = str_bytes.into_iter().map(AbiValue::Byte).collect();
+                let encoded_as_tuple = tuple_type.encode(AbiValue::Array(values))?;
+
+                Self::bytes_with_length(encoded_as_tuple.len(), encoded_as_tuple)
+            }
+            _ => Err(incompatible_value_for_type_err(self, &value)),
+        }
+    }
+
+    fn encode_dynamic_array(&self, value: AbiValue) -> Result<Vec<u8>, AbiError> {
+        match &value {
+            AbiValue::Array(values) => {
+                let tuple_type = self.type_cast_to_tuple(&[values.len()])?;
+                let encoded_as_tuple = tuple_type.encode(value.clone())?;
+
+                Self::bytes_with_length(values.len(), encoded_as_tuple)
+            }
+            _ => Err(incompatible_value_for_type_err(self, &value)),
+        }
+    }
+
+    fn bytes_with_length(len: usize, bytes: Vec<u8>) -> Result<Vec<u8>, AbiError> {
+        let mut value = vec![];
+        let mut length_encode = BigUint::from(len).to_bytes_be_padded(LENGTH_ENCODE_BYTE_SIZE)?;
+        value.append(&mut length_encode);
+        for b in bytes {
+            value.push(b);
+        }
+        Ok(value)
+    }
+
+    fn encode_tuple(&self, value: AbiValue) -> Result<Vec<u8>, AbiError> {
+        let values_array = match value {
+            AbiValue::Array(array) => array,
+            AbiValue::Address(address) => address.0.iter().map(|b| AbiValue::Byte(*b)).collect(),
+            _ => {
+                return Err(AbiError::Msg(format!(
+                    "Can't encode tuple: value: {value:?} is not an array."
+                )))
+            }
+        };
+
+        let children = self.children();
+        let children_len = children.len();
+
+        if values_array.len() != children_len {
+            return Err(AbiError::Msg(format!(
+                "abi tuple child type size ({}) != abi tuple element value size ({})",
+                children_len,
+                values_array.len(),
+            )));
+        }
+
+        let mut heads: Vec<Vec<u8>> = vec![vec![]; values_array.len()];
+        let mut tails: Vec<Vec<u8>> = vec![vec![]; values_array.len()];
+
+        let mut dynamic_index: HashSet<usize> = HashSet::new();
+
+        let mut i = 0;
+        while i < values_array.len() {
+            let curr_type = children[i].clone();
+            let curr_value = values_array[i].clone();
+
+            let curr_head;
+            let curr_tail;
+
+            if curr_type.is_dynamic() {
+                curr_head = vec![0x00, 0x00];
+                curr_tail = curr_type.encode(curr_value)?;
+                dynamic_index.insert(i);
+            } else {
+                match curr_type {
+                    AbiType::Bool => {
+                        let before = find_bool_lr(children, i, -1)?;
+                        let mut after = find_bool_lr(children, i, 1)?;
+                        if before % 8 != 0 {
+                            return Err(AbiError::Msg(
+                                "expected before has number of bool mod 8 == 0".to_owned(),
+                            ));
+                        }
+                        after = after.min(7);
+
+                        let mut compressed = 0;
+                        for bool_index in 0..=after {
+                            let value = &values_array[i + bool_index];
+                            match value {
+                                AbiValue::Bool(b) => {
+                                    if *b {
+                                        compressed |= 1u8 << (7 - bool_index);
+                                    }
+                                }
+                                _ => {
+                                    return Err(AbiError::Msg(format!(
+                                        "value: {value:?} is not a bool"
+                                    )));
+                                }
+                            }
+                        }
+
+                        curr_head = vec![compressed];
+                        curr_tail = vec![];
+                        i += after;
+                    }
+                    _ => {
+                        curr_head = curr_type.encode(curr_value)?;
+                        curr_tail = vec![];
+                    }
+                }
+            }
+
+            heads[i] = curr_head;
+            tails[i] = curr_tail;
+
+            i += 1;
+        }
+
+        let mut head_length = 0;
+        for h in &heads {
+            head_length += h.len();
+        }
+
+        let mut tail_curr_length = 0;
+        for i in 0..heads.len() {
+            if dynamic_index.contains(&i) {
+                let head_value = (head_length + tail_curr_length) as u32;
+                if head_value >= (1 << 16) {
+                    return Err(AbiError::Msg(
+                        "encoding error: byte length >= 2^16".to_owned(),
+                    ));
+                }
+                heads[i] = BigUint::from(head_value).to_bytes_be_padded(LENGTH_ENCODE_BYTE_SIZE)?;
+            }
+            tail_curr_length += tails[i].len();
+        }
+
+        Ok([&heads[..], &tails[..]]
+            .concat()
+            .into_iter()
+            .flatten()
+            .collect())
+    }
+
+    pub fn decode(&self, encoded: &[u8]) -> Result<AbiValue, AbiError> {
+        match self {
+            AbiType::UInt { bit_size } | AbiType::UFixed { bit_size, .. } => {
+                decode_uint(encoded, *bit_size)
+            }
+            AbiType::Bool => {
+                if encoded.len() != 1 {
+                    return Err(AbiError::Msg(
+                        "boolean byte should be length 1 byte".to_owned(),
+                    ));
+                }
+                if encoded[0] == 0x00 {
+                    Ok(AbiValue::Bool(false))
+                } else if encoded[0] == 0x80 {
+                    Ok(AbiValue::Bool(true))
+                } else {
+                    Err(AbiError::Msg(
+                        "single boolean encoded byte should be of form 0x80 or 0x00".to_owned(),
+                    ))
+                }
+            }
+            AbiType::Byte => {
+                if encoded.len() != 1 {
+                    return Err(AbiError::Msg(
+                        "boolean byte should be length 1 byte".to_owned(),
+                    ));
+                }
+                Ok(AbiValue::Byte(encoded[0]))
+            }
+            AbiType::StaticArray { .. } => {
+                let casted_type = self.type_cast_to_tuple(&[])?;
+                casted_type.decode(encoded)
+            }
+            AbiType::Address { .. } => {
+                Ok(AbiValue::Address(Address(encoded.try_into().map_err(
+                    |e| AbiError::Msg(format!("Address couldn't be decoded from: {e}")),
+                )?)))
+            }
+            AbiType::DynamicArray { .. } => {
+                if encoded.len() < LENGTH_ENCODE_BYTE_SIZE {
+                    return Err(AbiError::Msg("dynamic array format corrupted".to_owned()));
+                }
+
+                let arr: [u8; 2] = encoded[..LENGTH_ENCODE_BYTE_SIZE]
+                    .try_into()
+                    .map_err(|e| AbiError::Msg(format!("Couldn't convert slice to array: {e}")))?;
+                let dynamic_len = u16::from_be_bytes(arr);
+                let casted_type = self.type_cast_to_tuple(&[dynamic_len as usize])?;
+
+                casted_type.decode(&encoded[LENGTH_ENCODE_BYTE_SIZE..])
+            }
+            AbiType::String => {
+                if encoded.len() < LENGTH_ENCODE_BYTE_SIZE {
+                    return Err(AbiError::Msg("string format corrupted".to_owned()));
+                }
+
+                let arr: [u8; 2] = encoded[..LENGTH_ENCODE_BYTE_SIZE]
+                    .try_into()
+                    .map_err(|e| AbiError::Msg(format!("Couldn't convert slice to string: {e}")))?;
+                let byte_len = u16::from_be_bytes(arr);
+
+                if encoded[LENGTH_ENCODE_BYTE_SIZE..].len() != byte_len as usize {
+                    return Err(AbiError::Msg(
+                        "string representation in byte: length not matching".to_owned(),
+                    ));
+                }
+
+                let s = String::from_utf8(encoded[LENGTH_ENCODE_BYTE_SIZE..].to_vec()).map_err(
+                    |e| AbiError::Msg(format!("Couldn't create string from slice: {e}")),
+                )?;
+                Ok(AbiValue::String(s))
+            }
+
+            AbiType::Tuple { child_types, .. } => {
+                Ok(AbiValue::Array(decode_tuple(encoded, child_types)?))
+            }
+        }
+    }
+
+    /// Cast an array-like ABI type into an ABI tuple type.
+    fn type_cast_to_tuple(&self, tup_len: &[usize]) -> Result<AbiType, AbiError> {
+        let child_types = match self {
+            AbiType::Address => {
+                let mut child_types = Vec::with_capacity(ADDRESS_BYTE_SIZE);
+                for _ in 0..ADDRESS_BYTE_SIZE {
+                    child_types.push(make_byte_type())
+                }
+                child_types
+            }
+            AbiType::StaticArray { len, child_type } => {
+                let mut child_types = Vec::with_capacity(*len as usize);
+                for _ in 0..*len {
+                    child_types.push(child_type.as_ref().clone())
+                }
+                child_types
+            }
+            AbiType::DynamicArray { child_type } => {
+                if tup_len.len() != 1 {
+                    return Err(AbiError::Msg(
+                        "dynamic array type conversion to tuple need 1 length argument".to_owned(),
+                    ));
+                }
+                let mut child_types = Vec::with_capacity(tup_len[0]);
+                for _ in 0..tup_len[0] {
+                    child_types.push(child_type.as_ref().clone())
+                }
+                child_types
+            }
+            AbiType::String => {
+                if tup_len.len() != 1 {
+                    return Err(AbiError::Msg(
+                        "string type conversion to tuple need 1 length argument".to_owned(),
+                    ));
+                }
+                let mut child_types = Vec::with_capacity(tup_len[0]);
+
+                for _ in 0..tup_len[0] {
+                    child_types.push(make_byte_type())
+                }
+                child_types
+            }
+            _ => {
+                return Err(AbiError::Msg(
+                    "type cannot support conversion to tuple".to_owned(),
+                ))
+            }
+        };
+
+        make_tuple_type(child_types)
+    }
+
+    /// ByteLen method calculates the byte length of a static ABI type.
+    pub fn byte_len(&self) -> Result<usize, AbiError> {
+        match self {
+            AbiType::Address => Ok(ADDRESS_BYTE_SIZE),
+            AbiType::Byte => Ok(SINGLE_BYTE_SIZE),
+            AbiType::UInt { bit_size } | AbiType::UFixed { bit_size, .. } => {
+                Ok((bit_size / 8) as usize)
+            }
+            AbiType::Bool => Ok(SINGLE_BYTE_SIZE),
+            AbiType::StaticArray { len, child_type } => match child_type.as_ref() {
+                AbiType::Bool { .. } => {
+                    let byte_len = (*len as usize + 7) / 8;
+                    Ok(byte_len)
+                }
+                _ => {
+                    let elem_byte_len = child_type.byte_len()?;
+                    Ok(*len as usize * elem_byte_len)
+                }
+            },
+            AbiType::Tuple { child_types, .. } => {
+                let mut size = 0;
+                let mut i = 0;
+                while i < child_types.len() {
+                    match child_types[i] {
+                        AbiType::Bool { .. } => {
+                            // search after bool
+                            let after = find_bool_lr(self.children(), i, 1)?;
+                            // shift the index
+                            i += after;
+                            // get number of bool
+                            let bool_num = after + 1;
+                            size += (bool_num + 7) / 8;
+                        }
+                        _ => {
+                            let child_byte_size = self.children()[i].byte_len()?;
+                            size += child_byte_size
+                        }
+                    }
+
+                    i += 1;
+                }
+                Ok(size)
+            }
+            _ => Err(AbiError::Msg(format!(
+                "Can't pre-compute byte length: {} is a dynamic type",
+                self.string()?,
+            ))),
+        }
+    }
+}
+
+fn incompatible_value_for_type_err(type_: &AbiType, value: &AbiValue) -> AbiError {
+    AbiError::Msg(format!(
+        "Incompatible value: {value:?} for ABI type: {type_:?}"
+    ))
+}
+
+fn decode_uint(encoded: &[u8], bit_size: u16) -> Result<AbiValue, AbiError> {
+    let byte_size = bit_size / 8;
+    if encoded.len() != byte_size as usize {
+        return Err(AbiError::Msg(format!(
+            "uint/ufixed decode: expected byte length {}, but got byte length {}",
+            byte_size,
+            encoded.len()
+        )));
+    }
+
+    Ok(AbiValue::Int(BigUint::from_bytes_be(encoded)))
+}
+
+fn decode_tuple(encoded: &[u8], children: &[AbiType]) -> Result<Vec<AbiValue>, AbiError> {
+    let mut dynamic_segments: Vec<usize> = Vec::with_capacity(children.len() + 1);
+    let mut value_partition: Vec<Vec<u8>> = Vec::with_capacity(children.len());
+    let mut iter_index = 0;
+
+    let mut i = 0;
+    while i < children.len() {
+        if children[i].is_dynamic() {
+            if encoded[iter_index..].len() < LENGTH_ENCODE_BYTE_SIZE {
+                return Err(AbiError::Msg(
+                    "ill formed tuple dynamic typed value encoding".to_owned(),
+                ));
+            }
+            let arr: [u8; 2] = encoded[iter_index..iter_index + LENGTH_ENCODE_BYTE_SIZE]
+                .try_into()
+                .map_err(|e| AbiError::Msg(format!("Couldn't convert slice to array: {e}")))?;
+            let dynamic_index = u16::from_be_bytes(arr);
+            dynamic_segments.push(dynamic_index as usize);
+            value_partition.push(vec![]);
+
+            iter_index += LENGTH_ENCODE_BYTE_SIZE;
+        } else {
+            match children[i] {
+                AbiType::Bool => {
+                    // search previous bool
+                    let before = find_bool_lr(children, i, -1)?;
+                    // search after bool
+                    let mut after = find_bool_lr(children, i, 1)?;
+                    if before % 8 == 0 {
+                        if after > 7 {
+                            after = 7
+                        }
+                        // parse bool in a byte to multiple byte strings
+                        for bool_index in 0..=after {
+                            let bool_mask = 0x80 >> bool_index as u8;
+                            if encoded[iter_index] & bool_mask > 0 {
+                                value_partition.push(vec![0x80]);
+                            } else {
+                                value_partition.push(vec![0x00]);
+                            }
+                        }
+                        i += after;
+                        iter_index += 1;
+                    } else {
+                        return Err(AbiError::Msg(
+                            "expected before bool number mod 8 == 0".to_owned(),
+                        ));
+                    }
+                }
+                _ => {
+                    // not bool
+                    let curr_len = children[i].byte_len()?;
+
+                    if iter_index + curr_len > encoded.len() {
+                        return Err(AbiError::Msg(format!("ill formed tuple static typed element encoding: not enough bytes. child: {:?} --- iter_index: {}, current_len: {}, encoded len: {}", children[i], iter_index, curr_len, &encoded.len())));
+                    }
+
+                    value_partition.push(encoded[iter_index..iter_index + curr_len].to_vec());
+                    iter_index += curr_len;
+                }
+            }
+        }
+
+        if i != children.len() - 1 && iter_index >= encoded.len() {
+            return Err(AbiError::Msg("input byte not enough to decode".to_owned()));
+        }
+
+        i += 1;
+    }
+
+    if !dynamic_segments.is_empty() {
+        dynamic_segments.push(encoded.len());
+        iter_index = encoded.len()
+    }
+    if iter_index < encoded.len() {
+        return Err(AbiError::Msg(format!(
+            "input byte not fully consumed. children: {:?}",
+            children
+        )));
+    }
+
+    let mut index_temp: i32 = -1;
+    for var in &dynamic_segments {
+        if *var as i32 >= index_temp {
+            index_temp = *var as i32;
+        } else {
+            return Err(AbiError::Msg(format!(
+                "dynamic segment should display a [l, r] scope with l <= r, dynamic segment: {:?}",
+                dynamic_segments
+            )));
+        }
+    }
+
+    let mut seg_index = 0;
+    for i in 0..children.len() {
+        if children[i].is_dynamic() {
+            value_partition[i] =
+                encoded[dynamic_segments[seg_index]..dynamic_segments[seg_index + 1]].to_vec();
+            seg_index += 1;
+        }
+    }
+
+    let mut values = Vec::with_capacity(children.len());
+    for i in 0..children.len() {
+        values.push(children[i].decode(&value_partition[i])?);
+    }
+
+    Ok(values)
+}
+
+pub fn find_bool_lr(types: &[AbiType], index: usize, delta: i32) -> Result<usize, AbiError> {
+    let mut until: usize = 0;
+    loop {
+        let current_index: usize = (index as i32 + delta * until as i32)
+            .try_into()
+            .map_err(|e| AbiError::Msg(format!("Couldn't convert i32 to usize: {e}")))?;
+        match types[current_index] {
+            AbiType::Bool => {
+                if current_index != types.len() - 1 && delta > 0 || current_index > 0 && delta < 0 {
+                    until += 1;
+                } else {
+                    break;
+                }
+            }
+            _ => {
+                until -= 1;
+                break;
+            }
+        }
+    }
+    Ok(until)
+}

--- a/algonaut_abi/src/abi_encode_test.rs
+++ b/algonaut_abi/src/abi_encode_test.rs
@@ -1,0 +1,1031 @@
+#[cfg(test)]
+mod test_encode {
+    use crate::{
+        abi_type::{
+            make_address_type, make_bool_type, make_byte_type, make_dynamic_array_type,
+            make_static_array_type, make_string_type, make_ufixed_type, make_uint_type, AbiType,
+            AbiValue,
+        },
+        biguint_ext::BigUintExt,
+    };
+    use algonaut_core::Address;
+    use num_bigint::{BigUint, RandBigInt};
+    use rand::Rng;
+    use std::{convert::TryInto, ops::Shl};
+
+    #[test]
+    fn test_encode_int() {
+        let mut rng = rand::thread_rng();
+
+        for size in (8..512).step_by(8) {
+            let upper_limit: BigUint = BigUint::from(1u8).shl(size);
+            let uint_type = make_uint_type(size).unwrap();
+
+            for _ in 0..1000 {
+                let random_int: BigUint = rng.gen_biguint(size.clone().try_into().unwrap());
+
+                // !! problem: large number: len is 1, and big int 32 bytes!
+                let expected = BigUint::from(random_int.clone())
+                    .to_bytes_be_padded(size / 8)
+                    .unwrap();
+
+                let encoded_res = uint_type.encode(AbiValue::Int(random_int));
+                assert!(encoded_res.is_ok(), "encoding from uint type fail");
+                let encoded = encoded_res.unwrap();
+
+                assert_eq!(expected, encoded, "encode uint not match with expected");
+            }
+
+            let largest: BigUint = upper_limit - BigUint::from(1u8);
+            let largest_bytes = largest.to_bytes_be();
+
+            let largest_encoded_res = uint_type.encode(AbiValue::Int(largest));
+            assert!(largest_encoded_res.is_ok(), "largest uint encode error");
+            let largest_encoded = largest_encoded_res.unwrap();
+
+            assert_eq!(
+                largest_bytes, largest_encoded,
+                "encode uint largest do not match with expected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_encode_ufixed() {
+        let mut rng = rand::thread_rng();
+
+        for size in (8..512).step_by(8) {
+            let upper_limit: BigUint = BigUint::from(1u8).shl(size);
+
+            for precision in 1..160 {
+                let ufixed_type_res = make_ufixed_type(size, precision);
+                assert!(ufixed_type_res.is_ok(), "make ufixed type fail");
+                let ufixed_type = ufixed_type_res.unwrap();
+
+                for _ in 0..20 {
+                    let random_int: BigUint = rng.gen_biguint(size.clone().try_into().unwrap());
+
+                    let expected = BigUint::from(random_int.clone())
+                        .to_bytes_be_padded(size / 8)
+                        .unwrap();
+
+                    let encoded_res = ufixed_type.encode(AbiValue::Int(random_int));
+                    assert!(encoded_res.is_ok(), "encoding from ufixed type fail");
+                    let encoded = encoded_res.unwrap();
+
+                    assert_eq!(expected, encoded, "encode ufixed not match with expected");
+                }
+
+                // (2^[bitSize] - 1) / (10^[precision]) test
+                let largest: BigUint = upper_limit.clone() - BigUint::from(1u8);
+                let largest_bytes = largest.to_bytes_be();
+
+                let largest_encoded_res = ufixed_type.encode(AbiValue::Int(largest));
+                assert!(largest_encoded_res.is_ok(), "largest ufixed encode error");
+                let largest_encoded = largest_encoded_res.unwrap();
+
+                assert_eq!(
+                    largest_bytes, largest_encoded,
+                    "encode ufixed largest do not match with expected"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_encode_address() {
+        let mut rng = rand::thread_rng();
+
+        let upper_limit: BigUint = BigUint::from(1u8).shl(256u16) - BigUint::from(1u8);
+        let upper_encoded = BigUint::from(upper_limit).to_bytes_be_padded(32).unwrap();
+
+        for _ in 0..1000 {
+            let mut rand: BigUint = rng.gen_biguint(256);
+
+            while rand >= BigUint::from(1u8).shl(256) {
+                rand = rng.gen_biguint(256);
+                let addr_encode = rand.to_bytes_be_padded(32).unwrap();
+                assert_eq!(
+                    make_address_type()
+                        .encode(AbiValue::Address(Address(
+                            addr_encode.clone().try_into().unwrap()
+                        )))
+                        .unwrap(),
+                    addr_encode
+                );
+            }
+            assert_eq!(
+                make_address_type()
+                    .encode(AbiValue::Address(Address(
+                        upper_encoded.clone().try_into().unwrap()
+                    )))
+                    .unwrap(),
+                upper_encoded
+            );
+        }
+    }
+
+    #[test]
+    fn test_encode_bool() {
+        assert_eq!(
+            make_bool_type().encode(AbiValue::Bool(false)).unwrap(),
+            &[0x00]
+        );
+        assert_eq!(
+            make_bool_type().encode(AbiValue::Bool(true)).unwrap(),
+            &[0x80]
+        );
+    }
+
+    #[test]
+    fn test_encode_byte() {
+        for i in 0..=u8::MAX {
+            assert_eq!(make_byte_type().encode(AbiValue::Byte(i)).unwrap(), &[i]);
+        }
+    }
+
+    #[test]
+    fn test_encode_string() {
+        let rng = rand::thread_rng();
+        for length in 1..=400 {
+            for _ in 0..10 {
+                let gen_string: String = rng
+                    .clone()
+                    .sample_iter::<char, _>(rand::distributions::Standard)
+                    .take(length)
+                    .collect();
+
+                let mut str_bytes = gen_string.as_bytes().to_vec();
+                let mut header = BigUint::from(str_bytes.len())
+                    .to_bytes_be_padded(2)
+                    .unwrap();
+                let mut gen_bytes = vec![];
+                gen_bytes.append(&mut header);
+                gen_bytes.append(&mut str_bytes);
+
+                assert_eq!(
+                    gen_bytes,
+                    make_string_type()
+                        .encode(AbiValue::String(gen_string))
+                        .unwrap(),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_encode_bool_array0() {
+        let inputs = &[true, false, false, true, true];
+        let input_values: Vec<AbiValue> = inputs.into_iter().map(|b| AbiValue::Bool(*b)).collect();
+
+        let expected: &[u8] = &[0b10011000];
+        // assert_eq!(format!("{:b}", x), "101010");
+
+        assert_eq!(
+            make_static_array_type(make_bool_type(), 5)
+                .encode(AbiValue::Array(input_values))
+                .unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_encode_bool_array1() {
+        let inputs = &[
+            false, false, false, true, true, false, true, false, true, false, true,
+        ];
+        let input_values: Vec<AbiValue> = inputs.into_iter().map(|b| AbiValue::Bool(*b)).collect();
+
+        let expected: &[u8] = &[0b00011010, 0b10100000];
+
+        assert_eq!(
+            expected,
+            make_static_array_type(make_bool_type(), 11)
+                .encode(AbiValue::Array(input_values))
+                .unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_encode_bool_array2() {
+        let inputs = &[
+            false, false, false, true, true, false, true, false, true, false, true,
+        ];
+        let input_values: Vec<AbiValue> = inputs.into_iter().map(|b| AbiValue::Bool(*b)).collect();
+
+        let expected: &[u8] = &[0x00, 0x0B, 0b00011010, 0b10100000];
+
+        assert_eq!(
+            expected,
+            make_dynamic_array_type(make_bool_type())
+                .encode(AbiValue::Array(input_values))
+                .unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_uint_array() {
+        let inputs: &[u32] = &[1, 2, 3, 4, 5, 6, 7, 8];
+        let input_values: Vec<AbiValue> = inputs
+            .into_iter()
+            .map(|i| AbiValue::Int(BigUint::from(*i)))
+            .collect();
+
+        let expected: &[u8] = &[
+            0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08,
+        ];
+
+        let type_ = "uint64[]".parse::<AbiType>().unwrap();
+
+        assert_eq!(
+            expected,
+            type_.encode(AbiValue::Array(input_values)).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_dynamic_tuple() {
+        let elements = vec![
+            AbiValue::String("ABC".to_owned()),
+            AbiValue::Bool(true),
+            AbiValue::Bool(false),
+            AbiValue::Bool(true),
+            AbiValue::Bool(false),
+            AbiValue::String("DEF".to_owned()),
+        ];
+
+        let expected = vec![
+            0x00, 0x05, 0b10100000, 0x00, 0x0A, 0x00, 0x03, b'A', b'B', b'C', 0x00, 0x03, b'D',
+            b'E', b'F',
+        ];
+
+        let type_ = "(string,bool,bool,bool,bool,string)"
+            .parse::<AbiType>()
+            .unwrap();
+
+        assert_eq!(expected, type_.encode(AbiValue::Array(elements)).unwrap(),);
+    }
+
+    #[test]
+    fn test_bool_array_tuple() {
+        let elements = vec![
+            AbiValue::Array(vec![AbiValue::Bool(true), AbiValue::Bool(true)]),
+            AbiValue::Array(vec![AbiValue::Bool(true), AbiValue::Bool(true)]),
+        ];
+
+        let expected = vec![0b11000000, 0b11000000];
+
+        let type_ = "(bool[2],bool[2])".parse::<AbiType>().unwrap();
+
+        assert_eq!(expected, type_.encode(AbiValue::Array(elements)).unwrap(),);
+    }
+
+    #[test]
+    fn test_bool_array_tuple1() {
+        let elements = vec![
+            AbiValue::Array(vec![AbiValue::Bool(true), AbiValue::Bool(true)]),
+            AbiValue::Array(vec![AbiValue::Bool(true), AbiValue::Bool(true)]),
+        ];
+
+        let expected = vec![0b11000000, 0x00, 0x03, 0x00, 0x02, 0b11000000];
+
+        let type_ = "(bool[2],bool[])".parse::<AbiType>().unwrap();
+
+        assert_eq!(expected, type_.encode(AbiValue::Array(elements)).unwrap(),);
+    }
+
+    #[test]
+    fn test_bool_array_tuple2() {
+        let elements = vec![
+            AbiValue::Array(vec![AbiValue::Bool(true), AbiValue::Bool(true)]),
+            AbiValue::Array(vec![AbiValue::Bool(true), AbiValue::Bool(true)]),
+        ];
+
+        let expected = vec![
+            0x00, 0x04, 0x00, 0x07, 0x00, 0x02, 0b11000000, 0x00, 0x02, 0b11000000,
+        ];
+
+        let type_ = "(bool[],bool[])".parse::<AbiType>().unwrap();
+
+        assert_eq!(expected, type_.encode(AbiValue::Array(elements)).unwrap(),);
+    }
+
+    #[test]
+    fn test_bool_array_tuple3() {
+        let elements = vec![AbiValue::Array(vec![]), AbiValue::Array(vec![])];
+
+        let expected = vec![0x00, 0x04, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00];
+
+        let type_ = "(bool[],bool[])".parse::<AbiType>().unwrap();
+
+        assert_eq!(expected, type_.encode(AbiValue::Array(elements)).unwrap(),);
+    }
+
+    #[test]
+    fn test_empty_tuple() {
+        let elements = vec![];
+        let expected: Vec<u8> = vec![];
+
+        let type_ = "()".parse::<AbiType>().unwrap();
+
+        assert_eq!(expected, type_.encode(AbiValue::Array(elements)).unwrap(),);
+    }
+}
+
+#[cfg(test)]
+mod test_decode {
+    use std::{convert::TryInto, ops::Shl};
+
+    use algonaut_core::Address;
+    use num_bigint::{BigUint, RandBigInt};
+    use rand::Rng;
+
+    use crate::{
+        abi_type::{
+            make_address_type, make_bool_type, make_byte_type, make_string_type, make_ufixed_type,
+            make_uint_type, AbiType, AbiValue,
+        },
+        biguint_ext::BigUintExt,
+    };
+
+    #[test]
+    fn test_decode_uint() {
+        let mut rng = rand::thread_rng();
+
+        for size in (8..512).step_by(8) {
+            for _ in 0..1000 {
+                let random_int: BigUint = rng.gen_biguint(size.clone().try_into().unwrap());
+                let encoded_int = make_uint_type(size)
+                    .unwrap()
+                    .encode(AbiValue::Int(random_int.clone()))
+                    .unwrap();
+
+                assert_eq!(
+                    AbiValue::Int(random_int),
+                    make_uint_type(size).unwrap().decode(&encoded_int).unwrap(),
+                );
+            }
+
+            // 2^[bitSize] - 1
+            let largest: BigUint = BigUint::from(1u8).shl(size) - BigUint::from(1u8);
+
+            let mut expected = vec![];
+            for _ in 0..(size / 8) {
+                expected.push(0xff);
+            }
+
+            assert_eq!(
+                AbiValue::Int(largest),
+                make_uint_type(size).unwrap().decode(&expected).unwrap(),
+            );
+        }
+    }
+
+    #[test]
+    fn test_decode_ufixed() {
+        let mut rng = rand::thread_rng();
+
+        for size in (8..512).step_by(8) {
+            for precision in 1..160 {
+                for _ in 0..20 {
+                    let random_int: BigUint = rng.gen_biguint(size.clone().try_into().unwrap());
+                    let encoded_int = make_ufixed_type(size, precision)
+                        .unwrap()
+                        .encode(AbiValue::Int(random_int.clone()))
+                        .unwrap();
+                    assert_eq!(
+                        AbiValue::Int(random_int),
+                        make_ufixed_type(size, precision)
+                            .unwrap()
+                            .decode(&encoded_int)
+                            .unwrap(),
+                    );
+                }
+
+                let largest: BigUint = BigUint::from(1u8).shl(size) - BigUint::from(1u8);
+                let mut expected = vec![];
+                for _ in 0..(size / 8) {
+                    expected.push(0xff);
+                }
+
+                assert_eq!(
+                    AbiValue::Int(largest),
+                    make_ufixed_type(size, precision)
+                        .unwrap()
+                        .decode(&expected)
+                        .unwrap(),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_decode_address() {
+        let mut rng = rand::thread_rng();
+
+        let upper_limit: BigUint = BigUint::from(1u8).shl(256u16) - BigUint::from(1u8);
+        let upper_encoded = BigUint::from(upper_limit).to_bytes_be_padded(32).unwrap();
+
+        for _ in 0..1000 {
+            let mut rand: BigUint = rng.gen_biguint(256);
+
+            while rand >= BigUint::from(1u8).shl(256) {
+                rand = rng.gen_biguint(256);
+                let addr_encode = rand.to_bytes_be_padded(32).unwrap();
+
+                assert_eq!(
+                    AbiValue::Address(Address(addr_encode.clone().try_into().unwrap())),
+                    make_address_type().decode(&addr_encode).unwrap(),
+                );
+            }
+
+            assert_eq!(
+                AbiValue::Address(Address(upper_encoded.clone().try_into().unwrap())),
+                make_address_type().decode(&upper_encoded).unwrap(),
+            );
+        }
+    }
+
+    #[test]
+    fn test_decode_bool() {
+        assert_eq!(
+            make_bool_type().decode(&[0x00]).unwrap(),
+            AbiValue::Bool(false)
+        );
+
+        assert_eq!(
+            make_bool_type().decode(&[0x80]).unwrap(),
+            AbiValue::Bool(true)
+        );
+    }
+
+    #[test]
+    fn test_decode_byte() {
+        for i in 0..=u8::MAX {
+            assert_eq!(make_byte_type().decode(&[i]).unwrap(), AbiValue::Byte(i));
+        }
+    }
+
+    #[test]
+    fn test_decode_string() {
+        let rng = rand::thread_rng();
+        for length in 1..=400 {
+            for _ in 0..10 {
+                let gen_string: String = rng
+                    .clone()
+                    .sample_iter::<char, _>(rand::distributions::Standard)
+                    .take(length)
+                    .collect();
+
+                let mut str_bytes = gen_string.as_bytes().to_vec();
+                let mut header = BigUint::from(str_bytes.len())
+                    .to_bytes_be_padded(2)
+                    .unwrap();
+                let mut gen_bytes = vec![];
+                gen_bytes.append(&mut header);
+                gen_bytes.append(&mut str_bytes);
+
+                assert_eq!(
+                    AbiValue::String(gen_string),
+                    make_string_type().decode(&gen_bytes).unwrap(),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_decode_bool_array0() {
+        let inputs = &[true, false, false, true, true];
+        let input_values: Vec<AbiValue> = inputs.into_iter().map(|b| AbiValue::Bool(*b)).collect();
+
+        let type_ = "bool[5]".parse::<AbiType>().unwrap();
+
+        assert_eq!(
+            type_.decode(&[0b10011000]).unwrap(),
+            AbiValue::Array(input_values)
+        );
+    }
+
+    #[test]
+    fn test_decode_bool_array1() {
+        let inputs = &[
+            false, false, false, true, true, false, true, false, true, false, true,
+        ];
+        let input_values: Vec<AbiValue> = inputs.into_iter().map(|b| AbiValue::Bool(*b)).collect();
+
+        let type_ = "bool[11]".parse::<AbiType>().unwrap();
+
+        assert_eq!(
+            type_.decode(&[0b00011010, 0b10100000]).unwrap(),
+            AbiValue::Array(input_values)
+        );
+    }
+
+    #[test]
+    fn test_decode_bool_array2() {
+        let inputs = &[
+            false, false, false, true, true, false, true, false, true, false, true,
+        ];
+        let input_values: Vec<AbiValue> = inputs.into_iter().map(|b| AbiValue::Bool(*b)).collect();
+
+        let type_ = "bool[]".parse::<AbiType>().unwrap();
+
+        assert_eq!(
+            type_.decode(&[0x00, 0x0B, 0b00011010, 0b10100000]).unwrap(),
+            AbiValue::Array(input_values)
+        );
+    }
+
+    #[test]
+    fn test_decode_uint_array() {
+        let inputs: &[u32] = &[1, 2, 3, 4, 5, 6, 7, 8];
+        let input_values: Vec<AbiValue> = inputs
+            .into_iter()
+            .map(|i| AbiValue::Int(BigUint::from(*i)))
+            .collect();
+
+        let type_ = "uint64[8]".parse::<AbiType>().unwrap();
+
+        assert_eq!(
+            type_
+                .decode(&[
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08,
+                ])
+                .unwrap(),
+            AbiValue::Array(input_values)
+        );
+    }
+
+    #[test]
+    fn test_decode_dynamic_tuple() {
+        let tuple = vec![
+            AbiValue::String("ABC".to_owned()),
+            AbiValue::Bool(true),
+            AbiValue::Bool(false),
+            AbiValue::Bool(true),
+            AbiValue::Bool(false),
+            AbiValue::String("DEF".to_owned()),
+        ];
+
+        let type_ = "(string,bool,bool,bool,bool,string)"
+            .parse::<AbiType>()
+            .unwrap();
+
+        assert_eq!(
+            type_
+                .decode(&[
+                    0x00, 0x05, 0b10100000, 0x00, 0x0A, 0x00, 0x03, b'A', b'B', b'C', 0x00, 0x03,
+                    b'D', b'E', b'F',
+                ])
+                .unwrap(),
+            AbiValue::Array(tuple)
+        );
+    }
+
+    #[test]
+    fn test_decode_bool_array_tuple() {
+        let elements = vec![
+            AbiValue::Array(vec![AbiValue::Bool(true), AbiValue::Bool(true)]),
+            AbiValue::Array(vec![AbiValue::Bool(true), AbiValue::Bool(true)]),
+        ];
+
+        let type_ = "(bool[2],bool[2])".parse::<AbiType>().unwrap();
+
+        assert_eq!(
+            type_.decode(&[0b11000000, 0b11000000]).unwrap(),
+            AbiValue::Array(elements)
+        );
+    }
+
+    #[test]
+    fn test_decode_bool_array_tuple1() {
+        let elements = vec![
+            AbiValue::Array(vec![AbiValue::Bool(true), AbiValue::Bool(true)]),
+            AbiValue::Array(vec![AbiValue::Bool(true), AbiValue::Bool(true)]),
+        ];
+
+        let type_ = "(bool[2],bool[])".parse::<AbiType>().unwrap();
+
+        assert_eq!(
+            type_
+                .decode(&[0b11000000, 0x00, 0x03, 0x00, 0x02, 0b11000000])
+                .unwrap(),
+            AbiValue::Array(elements)
+        );
+    }
+
+    #[test]
+    fn test_decode_bool_array_tuple2() {
+        let elements = vec![
+            AbiValue::Array(vec![AbiValue::Bool(true), AbiValue::Bool(true)]),
+            AbiValue::Array(vec![AbiValue::Bool(true), AbiValue::Bool(true)]),
+        ];
+
+        let type_ = "(bool[],bool[])".parse::<AbiType>().unwrap();
+
+        assert_eq!(
+            type_
+                .decode(&[0x00, 0x04, 0x00, 0x07, 0x00, 0x02, 0b11000000, 0x00, 0x02, 0b11000000,])
+                .unwrap(),
+            AbiValue::Array(elements)
+        );
+    }
+
+    #[test]
+    fn test_decode_bool_array_tuple3() {
+        let elements = vec![AbiValue::Array(vec![]), AbiValue::Array(vec![])];
+
+        let type_ = "(bool[],bool[])".parse::<AbiType>().unwrap();
+
+        assert_eq!(
+            type_
+                .decode(&[0x00, 0x04, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00])
+                .unwrap(),
+            AbiValue::Array(elements)
+        );
+    }
+
+    #[test]
+    fn test_empty_tuple() {
+        let elements = vec![];
+        let type_ = "()".parse::<AbiType>().unwrap();
+        assert_eq!(type_.decode(&[]).unwrap(), AbiValue::Array(elements));
+    }
+}
+
+#[cfg(test)]
+mod test_decode_invalid {
+    use crate::abi_type::AbiType;
+
+    #[test]
+    fn test_bool_array() {
+        let input = &[0xff];
+        let type_ = "bool[9]".parse::<AbiType>().unwrap();
+        assert!(type_.decode(input).is_err());
+    }
+
+    #[test]
+    fn test_bool_array1() {
+        let input = &[0xff, 0x00];
+        let type_ = "bool[8]".parse::<AbiType>().unwrap();
+        assert!(type_.decode(input).is_err());
+    }
+
+    #[test]
+    fn test_bool_array2() {
+        let input = &[0x00, 0x0A, 0b10101010];
+        let type_ = "bool[]".parse::<AbiType>().unwrap();
+        assert!(type_.decode(input).is_err());
+    }
+
+    #[test]
+    fn test_bool_array3() {
+        let input = &[0x00, 0x05, 0b10100000, 0x00];
+        let type_ = "bool[]".parse::<AbiType>().unwrap();
+        assert!(type_.decode(input).is_err());
+    }
+
+    #[test]
+    fn test_uint_array_0() {
+        let input = &[
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08,
+        ];
+        let type_ = "uint64[10]".parse::<AbiType>().unwrap();
+        assert!(type_.decode(input).is_err());
+    }
+
+    #[test]
+    fn test_uint_array_1() {
+        let input = &[
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08,
+        ];
+        let type_ = "uint64[6]".parse::<AbiType>().unwrap();
+        assert!(type_.decode(input).is_err());
+    }
+
+    #[test]
+    fn test_tuple_0() {
+        let input = &[
+            0x00, 0x04, 0b10100000, 0x00, 0x0A, 0x00, 0x03, b'A', b'B', b'C', 0x00, 0x03, b'D',
+            b'E', b'F',
+        ];
+        let type_ = "(string,bool,bool,bool,bool,string)"
+            .parse::<AbiType>()
+            .unwrap();
+        assert!(type_.decode(input).is_err());
+    }
+
+    #[test]
+    fn test_bool_array_tuple_0() {
+        let encode0 = &[0b11000000, 0b11000000, 0x00];
+        let encode1 = &[0b11000000];
+
+        let type_ = "(bool[2],bool[2])".parse::<AbiType>().unwrap();
+        assert!(type_.decode(encode0).is_err());
+        assert!(type_.decode(encode1).is_err());
+    }
+
+    #[test]
+    fn test_bool_array_tuple_1() {
+        let encoded = &[0b11000000, 0x03, 0x00, 0x02, 0b11000000];
+
+        let type_ = "(bool[2],bool[])".parse::<AbiType>().unwrap();
+        assert!(type_.decode(encoded).is_err());
+    }
+
+    #[test]
+    fn test_bool_array_tuple_2() {
+        let encoded = &[
+            0x00, 0x04, 0x00, 0x08, 0x00, 0x02, 0b11000000, 0x00, 0x00, 0x02, 0b11000000,
+        ];
+
+        let type_ = "(bool[],bool[])".parse::<AbiType>().unwrap();
+        assert!(type_.decode(encoded).is_err());
+    }
+
+    #[test]
+    fn test_bool_array_tuple_3() {
+        let encoded = &[0x00, 0x04, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00];
+
+        let type_ = "(bool[],bool[])".parse::<AbiType>().unwrap();
+        assert!(type_.decode(encoded).is_err());
+    }
+
+    #[test]
+    fn test_empty_tuple() {
+        let encoded = &[0x0F];
+        let type_ = "()".parse::<AbiType>().unwrap();
+        assert!(type_.decode(encoded).is_err());
+    }
+}
+
+#[cfg(test)]
+mod test_roundrip {
+    use std::convert::TryInto;
+
+    use crate::{
+        abi_type::{
+            make_address_type, make_bool_type, make_byte_type, make_dynamic_array_type,
+            make_static_array_type, make_string_type, make_tuple_type, make_ufixed_type,
+            make_uint_type, AbiType, AbiValue,
+        },
+        biguint_ext::BigUintExt,
+    };
+    use algonaut_core::Address;
+    use num_bigint::{BigUint, RandBigInt};
+    use rand::Rng;
+
+    #[derive(Debug, Clone)]
+    struct RawValueWithAbiType {
+        type_str: String,
+        value: AbiValue,
+    }
+
+    impl RawValueWithAbiType {
+        fn new(type_str: &str, value: AbiValue) -> RawValueWithAbiType {
+            RawValueWithAbiType {
+                type_str: type_str.to_owned(),
+                value,
+            }
+        }
+    }
+
+    fn generate_random_int(bit_size: u64) -> BigUint {
+        let mut rng = rand::thread_rng();
+        let random_int: BigUint = rng.gen_biguint(bit_size);
+        return random_int;
+    }
+
+    fn generate_static_array(test_value_pool: &mut [Vec<RawValueWithAbiType>]) {
+        let mut rng = rand::thread_rng();
+
+        for i in (0..test_value_pool[0].len()).step_by(400) {
+            let mut value_arr = vec![];
+            for cnt in 0..20 {
+                value_arr.push(test_value_pool[0][i + cnt].value.clone());
+            }
+            let type_ = test_value_pool[0][i].type_str.clone().parse().unwrap();
+            test_value_pool[6].push(RawValueWithAbiType::new(
+                &make_static_array_type(type_, 20).string().unwrap(),
+                AbiValue::Array(value_arr),
+            ));
+        }
+
+        let mut value_byte_arr = vec![];
+        for i in 0..20 {
+            value_byte_arr.push(test_value_pool[2][i].value.clone());
+        }
+        test_value_pool[6].push(RawValueWithAbiType::new(
+            "byte[20]",
+            AbiValue::Array(value_byte_arr),
+        ));
+
+        let mut bool_arr = vec![];
+        for _ in 0..20 {
+            let index = if rng.gen_bool(0.5) { 0 } else { 1 };
+            bool_arr.push(test_value_pool[3][index].value.clone());
+        }
+        test_value_pool[6].push(RawValueWithAbiType::new(
+            "bool[20]",
+            AbiValue::Array(bool_arr),
+        ));
+
+        let mut address_arr = vec![];
+        for i in 0..20 {
+            address_arr.push(test_value_pool[4][i].value.clone());
+        }
+        test_value_pool[6].push(RawValueWithAbiType::new(
+            "address[20]",
+            AbiValue::Array(address_arr),
+        ));
+
+        let mut string_arr = vec![];
+        for i in 0..20 {
+            string_arr.push(test_value_pool[5][i].value.clone());
+        }
+        test_value_pool[6].push(RawValueWithAbiType::new(
+            "string[20]",
+            AbiValue::Array(string_arr),
+        ));
+    }
+
+    fn generate_dynamic_array(test_value_pool: &mut [Vec<RawValueWithAbiType>]) {
+        let mut rng = rand::thread_rng();
+
+        for i in (0..test_value_pool[0].len()).step_by(400) {
+            let mut value_arr = vec![];
+            for cnt in 0..20 {
+                value_arr.push(test_value_pool[0][i + cnt].value.clone());
+            }
+            let type_ = test_value_pool[0][i].type_str.clone().parse().unwrap();
+            test_value_pool[6].push(RawValueWithAbiType::new(
+                &make_dynamic_array_type(type_).string().unwrap(),
+                AbiValue::Array(value_arr),
+            ));
+        }
+
+        let mut value_byte_arr = vec![];
+        for i in 0..20 {
+            value_byte_arr.push(test_value_pool[2][i].value.clone());
+        }
+        test_value_pool[7].push(RawValueWithAbiType::new(
+            "byte[]",
+            AbiValue::Array(value_byte_arr),
+        ));
+
+        let mut bool_arr = vec![];
+        for _ in 0..20 {
+            let index = if rng.gen_bool(0.5) { 0 } else { 1 };
+            bool_arr.push(test_value_pool[3][index].value.clone());
+        }
+        test_value_pool[7].push(RawValueWithAbiType::new(
+            "bool[]",
+            AbiValue::Array(bool_arr),
+        ));
+
+        let mut address_arr = vec![];
+        for i in 0..20 {
+            address_arr.push(test_value_pool[4][i].value.clone());
+        }
+        test_value_pool[7].push(RawValueWithAbiType::new(
+            "address[]",
+            AbiValue::Array(address_arr),
+        ));
+
+        let mut string_arr = vec![];
+        for i in 0..20 {
+            string_arr.push(test_value_pool[5][i].value.clone());
+        }
+        test_value_pool[7].push(RawValueWithAbiType::new(
+            "string[]",
+            AbiValue::Array(string_arr),
+        ));
+    }
+
+    fn generate_tuple(index: usize, test_value_pool: &mut [Vec<RawValueWithAbiType>]) {
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..100 {
+            let tuple_len = 1 + rng.gen_range(0..20);
+            let mut tuple_values = vec![];
+            let mut tuple_types: Vec<AbiType> = vec![];
+
+            for _ in 0..tuple_len {
+                let value_type_slot: usize = rng.gen_range(0..index as usize + 1);
+                let value_index = rng.gen_range(0..test_value_pool[value_type_slot].len());
+                tuple_values.push(test_value_pool[value_type_slot][value_index].value.clone());
+                tuple_types.push(
+                    test_value_pool[value_type_slot][value_index]
+                        .type_str
+                        .parse()
+                        .unwrap(),
+                );
+            }
+
+            let abi_str = make_tuple_type(tuple_types).unwrap().string().unwrap();
+            test_value_pool[8].push(RawValueWithAbiType::new(
+                &abi_str,
+                AbiValue::Array(tuple_values),
+            ))
+        }
+    }
+
+    fn setup() -> Vec<Vec<RawValueWithAbiType>> {
+        println!("start test setup");
+        let rng = rand::thread_rng();
+
+        let test_value_pool: &mut Vec<Vec<RawValueWithAbiType>> = &mut vec![];
+        for _ in 0..9 {
+            let v = vec![];
+            test_value_pool.push(v);
+        }
+
+        for i in (8..512).step_by(8) {
+            for _ in 0..200 {
+                test_value_pool[0].push(RawValueWithAbiType::new(
+                    &make_uint_type(i).unwrap().string().unwrap(),
+                    AbiValue::Int(generate_random_int(i as u64)),
+                ));
+            }
+            for j in 1..160 {
+                test_value_pool[1].push(RawValueWithAbiType::new(
+                    &make_ufixed_type(i, j).unwrap().string().unwrap(),
+                    AbiValue::Int(generate_random_int(i as u64)),
+                ));
+            }
+        }
+
+        for i in 0..=u8::MAX {
+            test_value_pool[2].push(RawValueWithAbiType::new(
+                &make_byte_type().string().unwrap(),
+                AbiValue::Byte(i),
+            ));
+        }
+
+        for i in 0..2 {
+            test_value_pool[3].push(RawValueWithAbiType::new(
+                &make_bool_type().string().unwrap(),
+                AbiValue::Bool(i == 0),
+            ));
+        }
+
+        for _ in 0..500 {
+            let temp_address_int = generate_random_int(256);
+            let address_encode = temp_address_int.to_bytes_be_padded(32).unwrap();
+            let address = Address(address_encode.try_into().unwrap());
+
+            test_value_pool[4].push(RawValueWithAbiType::new(
+                &make_address_type().string().unwrap(),
+                AbiValue::Address(address),
+            ));
+        }
+
+        for i in 1..100 {
+            for _ in 0..5 {
+                let gen_string: String = rng
+                    .clone()
+                    .sample_iter::<char, _>(rand::distributions::Standard)
+                    .take(i)
+                    .collect();
+
+                test_value_pool[5].push(RawValueWithAbiType::new(
+                    &make_string_type().string().unwrap(),
+                    AbiValue::String(gen_string),
+                ));
+            }
+        }
+
+        generate_static_array(test_value_pool);
+        generate_dynamic_array(test_value_pool);
+        generate_tuple(7, test_value_pool);
+        generate_tuple(8, test_value_pool);
+
+        test_value_pool.to_owned()
+    }
+
+    #[test]
+    fn test_random_elem_roundtrip() {
+        let test_pool = setup();
+        for v in &test_pool[8] {
+            let abi_type = v.type_str.parse::<AbiType>().unwrap();
+            let encoded = abi_type.encode(v.value.to_owned()).unwrap();
+            assert_eq!(abi_type.decode(&encoded).unwrap(), v.value)
+        }
+    }
+}

--- a/algonaut_abi/src/abi_error.rs
+++ b/algonaut_abi/src/abi_error.rs
@@ -1,0 +1,10 @@
+extern crate derive_more;
+use derive_more::{Display, From};
+use std::fmt::Debug;
+use thiserror::Error;
+
+#[derive(Debug, Display, Error, From, Clone)]
+pub enum AbiError {
+    #[display(fmt = "{}", self.0)]
+    Msg(String),
+}

--- a/algonaut_abi/src/abi_interaction_tests.rs
+++ b/algonaut_abi/src/abi_interaction_tests.rs
@@ -1,0 +1,360 @@
+#[cfg(test)]
+mod tests {
+    use crate::{
+        abi_interactions::{AbiMethod, AbiMethodArg, AbiReturn},
+        abi_type::AbiType,
+    };
+
+    #[test]
+    fn test_method_from_signature() {
+        let uint32_abi_type_res = "uint32".parse::<AbiType>();
+        assert!(uint32_abi_type_res.is_ok());
+        let uint32_abi_type = uint32_abi_type_res.clone().unwrap();
+
+        let expected_args = vec![
+            AbiMethodArg {
+                name: None,
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: Some(uint32_abi_type.clone()),
+            },
+            AbiMethodArg {
+                name: None,
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: Some(uint32_abi_type.clone()),
+            },
+        ];
+        let expected = AbiMethod {
+            name: "add".to_owned(),
+            description: None,
+            args: expected_args,
+            returns: AbiReturn {
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: Some(uint32_abi_type),
+            },
+        };
+
+        let method_sig = "add(uint32,uint32)uint32";
+
+        let result = AbiMethod::from_signature(method_sig);
+        assert!(result.is_ok());
+        let method = result.unwrap();
+
+        assert_eq!(expected, method);
+    }
+
+    #[test]
+    fn test_method_from_signature_with_tuple() {
+        let uint32_abi_type_res = "uint32".parse::<AbiType>();
+        assert!(uint32_abi_type_res.is_ok());
+        let uint32_abi_type = uint32_abi_type_res.clone().unwrap();
+
+        let uint32_tuple_abi_type_res = "(uint32,uint32)".parse::<AbiType>();
+        assert!(uint32_tuple_abi_type_res.is_ok());
+        let uint32_tuple_abi_type = uint32_tuple_abi_type_res.clone().unwrap();
+
+        let uint32_tuple_tuple_abi_type_res = "(uint32,(uint32,uint32))".parse::<AbiType>();
+        assert!(uint32_tuple_tuple_abi_type_res.is_ok());
+        let uint32_tuple_tuple_abi_type = uint32_tuple_tuple_abi_type_res.clone().unwrap();
+
+        let expected_args = vec![
+            AbiMethodArg {
+                name: None,
+                type_: "(uint32,(uint32,uint32))".to_owned(),
+                description: None,
+                parsed: Some(uint32_tuple_tuple_abi_type.clone()),
+            },
+            AbiMethodArg {
+                name: None,
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: Some(uint32_abi_type.clone()),
+            },
+        ];
+        let expected = AbiMethod {
+            name: "add".to_owned(),
+            description: None,
+            args: expected_args,
+            returns: AbiReturn {
+                type_: "(uint32,uint32)".to_owned(),
+                description: None,
+                parsed: Some(uint32_tuple_abi_type),
+            },
+        };
+
+        let method_sig = "add((uint32,(uint32,uint32)),uint32)(uint32,uint32)";
+
+        let result = AbiMethod::from_signature(method_sig);
+        assert!(result.is_ok());
+        let method = result.unwrap();
+
+        assert_eq!(expected, method);
+    }
+
+    #[test]
+    fn test_method_from_signature_with_void_return() {
+        let uint32_abi_type_res = "uint32".parse::<AbiType>();
+        assert!(uint32_abi_type_res.is_ok());
+        let uint32_abi_type = uint32_abi_type_res.clone().unwrap();
+
+        let expected_args = vec![
+            AbiMethodArg {
+                name: None,
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: Some(uint32_abi_type.clone()),
+            },
+            AbiMethodArg {
+                name: None,
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: Some(uint32_abi_type.clone()),
+            },
+        ];
+        let expected = AbiMethod {
+            name: "add".to_owned(),
+            description: None,
+            args: expected_args,
+            returns: AbiReturn {
+                type_: "void".to_owned(),
+                description: None,
+                parsed: None,
+            },
+        };
+
+        let method_sig = "add(uint32,uint32)void";
+
+        let result = AbiMethod::from_signature(method_sig);
+        assert!(result.is_ok());
+        let method = result.unwrap();
+
+        assert_eq!(expected, method);
+    }
+
+    #[test]
+    fn test_method_from_signature_with_no_args() {
+        let expected_args = vec![];
+        let expected = AbiMethod {
+            name: "add".to_owned(),
+            description: None,
+            args: expected_args,
+            returns: AbiReturn {
+                type_: "void".to_owned(),
+                description: None,
+                parsed: None,
+            },
+        };
+
+        let method_sig = "add()void";
+
+        let result = AbiMethod::from_signature(method_sig);
+        assert!(result.is_ok());
+        let method = result.unwrap();
+
+        assert_eq!(expected, method);
+    }
+
+    #[test]
+    fn test_method_from_signature_invalid_format() {
+        let method_sig = "add)uint32,uint32)uint32";
+        let result = AbiMethod::from_signature(method_sig);
+        assert!(result.is_err());
+
+        let method_sig = "add(uint32, uint32)uint32";
+        let result = AbiMethod::from_signature(method_sig);
+        assert!(result.is_err());
+
+        let method_sig = "(uint32,uint32)uint32";
+        let result = AbiMethod::from_signature(method_sig);
+        assert!(result.is_err());
+
+        let method_sig = "add((uint32, uint32)uint32";
+        let result = AbiMethod::from_signature(method_sig);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_method_from_signature_invalid_abi_type() {
+        let method_sig = "add(uint32,uint32)int32";
+        let result = AbiMethod::from_signature(method_sig);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_signature() {
+        let args = vec![
+            AbiMethodArg {
+                name: None,
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: None,
+            },
+            AbiMethodArg {
+                name: None,
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: None,
+            },
+        ];
+        let method = AbiMethod {
+            name: "add".to_owned(),
+            description: None,
+            args,
+            returns: AbiReturn {
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: None,
+            },
+        };
+
+        let expected = "add(uint32,uint32)uint32";
+
+        assert_eq!(expected, method.get_signature());
+    }
+
+    #[test]
+    fn test_get_selector() {
+        let args = vec![
+            AbiMethodArg {
+                name: None,
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: None,
+            },
+            AbiMethodArg {
+                name: None,
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: None,
+            },
+        ];
+        let method = AbiMethod {
+            name: "add".to_owned(),
+            description: None,
+            args,
+            returns: AbiReturn {
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: None,
+            },
+        };
+
+        let expected = [0x3e, 0x1e, 0x52, 0xbd];
+
+        let selector_res = method.get_selector();
+        assert!(selector_res.is_ok());
+        let selector = selector_res.unwrap();
+
+        assert_eq!(expected, selector);
+    }
+}
+
+#[cfg(test)]
+mod tests_cases {
+    use crate::abi_interactions::{AbiMethod, AbiMethodArg};
+    use std::collections::HashMap;
+
+    struct MethodTestCase {
+        signature_str: String,
+        tx_call_count: usize,
+        args: Vec<AbiMethodArg>,
+    }
+
+    impl MethodTestCase {
+        fn new(method_str: &str, tx_call_count: usize, args: Vec<&str>) -> MethodTestCase {
+            MethodTestCase {
+                signature_str: method_str.to_owned(),
+                tx_call_count,
+                args: args
+                    .into_iter()
+                    .map(|type_| AbiMethodArg {
+                        name: None,
+                        type_: type_.to_owned(),
+                        description: None,
+                        parsed: None,
+                    })
+                    .collect(),
+            }
+        }
+    }
+
+    fn test_cases() -> Vec<MethodTestCase> {
+        vec![
+            MethodTestCase::new(
+                "someMethod(uint64,ufixed64x2,(bool,byte),address)void",
+                1,
+                vec!["uint64", "ufixed64x2", "(bool,byte)", "address"],
+            ),
+            MethodTestCase::new("pseudoRandomGenerator()uint256", 1, vec![]),
+            MethodTestCase::new("add(uint64,uint64)uint128", 1, vec!["uint64", "uint64"]),
+            MethodTestCase::new(
+                "someEffectOnTheOtherSide___(uint64,(ufixed256x10,bool))void",
+                1,
+                vec!["uint64", "(ufixed256x10,bool)"],
+            ),
+            MethodTestCase::new(
+                "someMethod(uint64,ufixed64x2,(bool,byte),address)void",
+                1,
+                vec!["uint64", "ufixed64x2", "(bool,byte)", "address"],
+            ),
+            MethodTestCase::new("returnATuple(address)(byte[32],bool)", 1, vec!["address"]),
+            MethodTestCase::new(
+                "txcalls(pay,pay,axfer,byte)bool",
+                4,
+                vec!["pay", "pay", "axfer", "byte"],
+            ),
+            MethodTestCase::new(
+                "foreigns(account,pay,asset,application,bool)void",
+                2,
+                vec!["account", "pay", "asset", "application", "bool"],
+            ),
+        ]
+    }
+
+    #[test]
+    fn test_method_from_signature() {
+        for test_case in test_cases() {
+            let method = AbiMethod::from_signature(&test_case.signature_str).unwrap();
+            assert_eq!(method.get_signature(), test_case.signature_str);
+            assert_eq!(method.get_tx_count(), test_case.tx_call_count);
+            assert_eq!(method.args, test_case.args);
+        }
+    }
+
+    #[test]
+    fn test_method_from_signature_invalid() {
+        let failing_test_cases = vec![
+            "___nopeThis Not Right nAmE () void",
+            "intentional(MessAroundWith(Parentheses(address)(uint8)",
+        ];
+        for test_case in failing_test_cases {
+            let method_res = AbiMethod::from_signature(test_case);
+            assert!(method_res.is_err())
+        }
+    }
+
+    #[test]
+    fn test_method_get_selector() {
+        let method_selector_map: HashMap<&str, Vec<u8>> = [
+            ("add(uint32,uint32)uint32", vec![0x3e, 0x1e, 0x52, 0xbd]),
+            ("add(uint64,uint64)uint128", vec![0x8a, 0xa3, 0xb6, 0x1f]),
+        ]
+        .into();
+        for (key, value) in method_selector_map {
+            let method = AbiMethod::from_signature(key).unwrap();
+            assert_eq!(method.get_selector().unwrap().to_vec(), value);
+        }
+    }
+
+    #[test]
+    fn test_method_json_roundtrip() {
+        for test_case in test_cases() {
+            let method = AbiMethod::from_signature(&test_case.signature_str).unwrap();
+            let bytes = serde_json::to_vec(&method).unwrap();
+            let read_method: AbiMethod = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(read_method, method);
+        }
+    }
+}

--- a/algonaut_abi/src/abi_interactions.rs
+++ b/algonaut_abi/src/abi_interactions.rs
@@ -1,0 +1,398 @@
+use super::abi_type::AbiType;
+use crate::abi_error::AbiError;
+use algonaut_core::{error::CoreError, TransactionTypeEnum};
+use serde::{Deserialize, Serialize};
+use sha2::Digest;
+use std::{collections::HashMap, convert::TryInto};
+
+// AnyTransactionType is the ABI argument type string for a nonspecific transaction argument
+pub const ANY_TRANSACTION_TYPE: &str = "txn";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TransactionArgType {
+    Any, // denotes a placeholder for any of the types below
+    One(TransactionTypeEnum),
+}
+
+impl TransactionArgType {
+    fn from_api_str(s: &str) -> Result<TransactionArgType, AbiError> {
+        match s {
+            "txn" => Ok(TransactionArgType::Any),
+            s => Ok(TransactionTypeEnum::from_api_str(s).map(TransactionArgType::One)?),
+        }
+    }
+
+    #[allow(dead_code)] // from_api_str counterpart
+    fn to_api_str(&self) -> &str {
+        match self {
+            TransactionArgType::Any => "txn",
+            TransactionArgType::One(tx_type_enum) => tx_type_enum.to_api_str(),
+        }
+    }
+
+    fn is_valid_api_str(s: &str) -> bool {
+        Self::from_api_str(s).is_ok()
+    }
+}
+
+impl From<CoreError> for AbiError {
+    fn from(e: CoreError) -> Self {
+        match e {
+            CoreError::General(msg) => Self::Msg(msg),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReferenceArgType {
+    Account,
+    Asset,
+    Application,
+}
+
+impl ReferenceArgType {
+    fn from_api_str(s: &str) -> Result<ReferenceArgType, AbiError> {
+        match s {
+            "account" => Ok(ReferenceArgType::Account),
+            "asset" => Ok(ReferenceArgType::Asset),
+            "application" => Ok(ReferenceArgType::Application),
+            _ => Err(AbiError::Msg(format!(
+                "Not supported reference arg type api string: {s}"
+            ))),
+        }
+    }
+
+    fn is_valid_api_str(s: &str) -> bool {
+        Self::from_api_str(s).is_ok()
+    }
+}
+
+/// Represents an ABI Method argument
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AbiMethodArg {
+    /// User-friendly name for the argument
+    #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// The type of the argument as a string.
+    /// See [get_type_object](get_type_object) to obtain the ABI type object
+    #[serde(rename = "type")]
+    pub type_: String,
+
+    /// User-friendly description for the argument
+    #[serde(rename = "desc", skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Cache that holds the parsed type object
+    #[serde(skip)]
+    pub parsed: Option<AbiType>,
+}
+
+impl PartialEq for AbiMethodArg {
+    fn eq(&self, other: &Self) -> bool {
+        // excludes `parsed`, which is just a cache
+        self.name == other.name
+            && self.type_ == other.type_
+            && self.description == other.description
+    }
+}
+impl Eq for AbiMethodArg {}
+
+impl AbiMethodArg {
+    pub fn is_transaction_arg(&self) -> bool {
+        self.transaction_arg().is_some()
+    }
+
+    pub fn transaction_arg(&self) -> Option<TransactionArgType> {
+        TransactionArgType::from_api_str(&self.type_).ok()
+    }
+
+    pub fn is_reference_arg(&self) -> bool {
+        self.reference_arg().is_some()
+    }
+
+    pub fn reference_arg(&self) -> Option<ReferenceArgType> {
+        ReferenceArgType::from_api_str(&self.type_).ok()
+    }
+
+    /// parses and returns the ABI type object for this argument's
+    /// type. An error will be returned if this argument's type is a transaction or
+    /// reference type
+    pub fn get_type_object(&mut self) -> Result<AbiType, AbiError> {
+        if self.is_transaction_arg() {
+            return Err(AbiError::Msg(format!(
+                "Invalid operation on transaction type: {}",
+                self.type_
+            )));
+        }
+        if self.is_reference_arg() {
+            return Err(AbiError::Msg(format!(
+                "Invalid operation on reference type: {}",
+                self.type_
+            )));
+        }
+        if let Some(parsed) = &self.parsed {
+            return Ok(parsed.clone());
+        }
+
+        let type_obj = self.type_.parse::<AbiType>()?;
+        self.parsed = Some(type_obj.clone());
+
+        Ok(type_obj)
+    }
+}
+
+/// Represents an ABI method return value
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AbiReturn {
+    /// The type of the argument as a string. See the [get_type_object](get_type_object) to
+    /// obtain the ABI type object
+    #[serde(rename = "type")]
+    pub type_: String,
+
+    /// User-friendly description for the argument
+    #[serde(rename = "desc", skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Cache that holds the parsed type object
+    #[serde(skip)]
+    pub parsed: Option<AbiType>,
+}
+
+impl PartialEq for AbiReturn {
+    fn eq(&self, other: &Self) -> bool {
+        // excludes `parsed`, which is just a cache
+        self.type_ == other.type_ && self.description == other.description
+    }
+}
+impl Eq for AbiReturn {}
+
+impl AbiReturn {
+    fn is_void(&self) -> bool {
+        self.type_ == "void"
+    }
+
+    fn get_type_object(&mut self) -> Result<AbiType, AbiError> {
+        if self.is_void() {
+            return Err(AbiError::Msg(
+                "Invalid operation on void return type".to_owned(),
+            ));
+        }
+        if let Some(parsed) = &self.parsed {
+            return Ok(parsed.clone());
+        }
+
+        let type_obj = self.type_.parse::<AbiType>()?;
+        self.parsed = Some(type_obj.clone());
+
+        Ok(type_obj)
+    }
+}
+
+/// Represents an ABI method return value
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AbiMethod {
+    /// The name of the method
+    #[serde(rename = "name")]
+    pub name: String,
+
+    /// User-friendly description for the method
+    #[serde(rename = "desc", skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// The arguments of the method, in order
+    #[serde(default, rename = "args", skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<AbiMethodArg>,
+
+    /// Information about the method's return value
+    #[serde(rename = "returns")]
+    pub returns: AbiReturn,
+}
+
+impl AbiMethod {
+    /// Calculates and returns the signature of the method
+    pub fn get_signature(&self) -> String {
+        let method_signature = format!("{}{}", self.name, "(");
+        let mut str_types: Vec<String> = vec![];
+        for arg in &self.args {
+            str_types.push(arg.type_.to_owned());
+        }
+        format!(
+            "{method_signature}{}){}",
+            str_types.join(","),
+            self.returns.type_
+        )
+    }
+
+    /// Calculates and returns the 4-byte selector of the method
+    pub fn get_selector(&self) -> Result<[u8; 4], AbiError> {
+        let sig = self.get_signature();
+        let sig_hash = sha2::Sha512_256::digest(sig);
+        Ok(sig_hash[..4]
+            .try_into()
+            .expect("Unexpected: couldn't get signature bytes from Sha512_256 digest"))
+    }
+
+    /// Returns the number of transactions required to invoke this method
+    pub fn get_tx_count(&self) -> usize {
+        1 + self.args.iter().filter(|a| a.is_transaction_arg()).count()
+    }
+
+    /// Decodes a method signature string into a Method object.
+    pub fn from_signature(method_str: &str) -> Result<AbiMethod, AbiError> {
+        let open_idx = method_str.chars().position(|c| c == '(').ok_or_else(|| {
+            AbiError::Msg("method signature is missing an open parenthesis".to_owned())
+        })?;
+
+        let name = &method_str[..open_idx];
+        if name.is_empty() {
+            return Err(AbiError::Msg(
+                "method must have a non empty name".to_owned(),
+            ));
+        }
+
+        let (arg_types, close_idx) = parse_method_args(method_str, open_idx)?;
+
+        let mut return_type = AbiReturn {
+            type_: method_str[close_idx + 1..].to_owned(),
+            description: None,
+            parsed: None,
+        };
+
+        if !return_type.is_void() {
+            // fill type object cache
+            return_type.get_type_object()?;
+        }
+
+        let mut args: Vec<AbiMethodArg> = Vec::with_capacity(arg_types.len());
+
+        for (i, arg_type) in arg_types.into_iter().enumerate() {
+            let arg = AbiMethodArg {
+                type_: arg_type.clone(),
+                name: None,
+                description: None,
+                parsed: None,
+            };
+            args.push(arg);
+
+            if TransactionArgType::is_valid_api_str(&arg_type)
+                || ReferenceArgType::is_valid_api_str(&arg_type)
+            {
+                continue;
+            }
+
+            // fill type object cache
+            args[i].get_type_object()?;
+        }
+
+        Ok(AbiMethod {
+            name: name.to_owned(),
+            args,
+            returns: return_type,
+            description: None,
+        })
+    }
+}
+
+/// Parses the arguments from a method signature string.
+/// str_method is the complete method signature and start_idx is the index of the
+/// opening parenthesis of the arguments list. This function returns a list of
+/// the argument types from the method signature and the index of the closing
+/// parenthesis of the arguments list.
+fn parse_method_args(str_method: &str, start_idx: usize) -> Result<(Vec<String>, usize), AbiError> {
+    // handle no args
+    if start_idx < str_method.len() - 1 && str_method.chars().nth(start_idx + 1) == Some(')') {
+        return Ok((vec![], start_idx + 1));
+    }
+
+    let mut arg_types = vec![];
+
+    let mut paren_cnt = 1;
+    let mut prev_pos = start_idx + 1;
+    let mut close_idx = None;
+    let init_prev_pos = prev_pos;
+
+    for cur_pos in init_prev_pos..str_method.len() {
+        let chars = str_method.chars().collect::<Vec<_>>();
+        if chars[cur_pos] == '(' {
+            paren_cnt += 1;
+        } else if chars[cur_pos] == ')' {
+            paren_cnt -= 1;
+        }
+
+        if paren_cnt < 0 {
+            return Err(AbiError::Msg(
+                "method signature parentheses mismatch".to_owned(),
+            ));
+        } else if paren_cnt > 1 {
+            continue;
+        }
+
+        if chars[cur_pos] == ',' || paren_cnt == 0 {
+            let str_arg = &str_method[prev_pos..cur_pos];
+            arg_types.push(str_arg.to_owned());
+            prev_pos = cur_pos + 1;
+        }
+
+        if paren_cnt == 0 {
+            close_idx = Some(cur_pos);
+            break;
+        }
+    }
+
+    if let Some(close_idx) = close_idx {
+        Ok((arg_types, close_idx))
+    } else {
+        Err(AbiError::Msg(
+            "method signature parentheses mismatch".to_owned(),
+        ))
+    }
+}
+
+/// Represents an ABI interface, which is a logically grouped collection of methods
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AbiInterface {
+    /// The name of the interface
+    #[serde(rename = "name")]
+    pub name: String,
+
+    /// User-friendly description for the interface
+    #[serde(rename = "desc", skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// The methods that the interface contains
+    #[serde(rename = "methods", skip_serializing_if = "Vec::is_empty")]
+    pub methods: Vec<AbiMethod>,
+}
+
+/// ContractNetworkInfo contains network-specific information about the contract
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AbiContractNetworkInfo {
+    /// The application ID of the contract for this network
+    #[serde(rename = "appID")]
+    pub app_id: u64,
+}
+
+/// Represents an ABI contract, which is a concrete set of methods implemented by a single app
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AbiContract {
+    /// The name of the contract
+    #[serde(rename = "name")]
+    pub name: String,
+
+    /// User-friendly description for the contract
+    #[serde(rename = "desc", skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Optional information about the contract's instances across different networks
+    #[serde(
+        default,
+        rename = "networks",
+        skip_serializing_if = "HashMap::is_empty"
+    )]
+    pub networks: HashMap<String, AbiContractNetworkInfo>,
+
+    /// The methods that the interface contains
+    #[serde(default, rename = "methods", skip_serializing_if = "Vec::is_empty")]
+    pub methods: Vec<AbiMethod>,
+}

--- a/algonaut_abi/src/abi_json_tests.rs
+++ b/algonaut_abi/src/abi_json_tests.rs
@@ -1,0 +1,386 @@
+#[cfg(test)]
+mod tests {
+    use crate::abi_interactions::{
+        AbiContract, AbiContractNetworkInfo, AbiInterface, AbiMethod, AbiMethodArg, AbiReturn,
+    };
+
+    #[test]
+    fn test_encode_json_method() {
+        let args = vec![
+            AbiMethodArg {
+                name: Some("0".to_owned()),
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: None,
+            },
+            AbiMethodArg {
+                name: Some("1".to_owned()),
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: None,
+            },
+        ];
+        let method = AbiMethod {
+            name: "add".to_owned(),
+            description: None,
+            args,
+            returns: AbiReturn {
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: None,
+            },
+        };
+
+        let expected = r#"{"name":"add","args":[{"name":"0","type":"uint32"},{"name":"1","type":"uint32"}],"returns":{"type":"uint32"}}"#;
+
+        let json_res = serde_json::to_string(&method);
+        assert!(json_res.is_ok());
+        let json = json_res.unwrap();
+
+        assert_eq!(expected, json);
+    }
+
+    #[test]
+    fn test_encode_json_method_with_description() {
+        let args = vec![
+            AbiMethodArg {
+                name: Some("0".to_owned()),
+                type_: "uint32".to_owned(),
+                description: Some("description".to_owned()),
+                parsed: None,
+            },
+            AbiMethodArg {
+                name: Some("1".to_owned()),
+                type_: "uint32".to_owned(),
+                description: Some("description".to_owned()),
+                parsed: None,
+            },
+        ];
+        let method = AbiMethod {
+            name: "add".to_owned(),
+            description: Some("description".to_owned()),
+            args,
+            returns: AbiReturn {
+                type_: "uint32".to_owned(),
+                description: Some("description".to_owned()),
+                parsed: None,
+            },
+        };
+
+        let expected = r#"{"name":"add","desc":"description","args":[{"name":"0","type":"uint32","desc":"description"},{"name":"1","type":"uint32","desc":"description"}],"returns":{"type":"uint32","desc":"description"}}"#;
+
+        let json_res = serde_json::to_string(&method);
+        assert!(json_res.is_ok());
+        let json = json_res.unwrap();
+
+        assert_eq!(expected, json);
+    }
+
+    #[test]
+    fn test_encode_json_interface() {
+        let args = vec![
+            AbiMethodArg {
+                name: Some("0".to_owned()),
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: None,
+            },
+            AbiMethodArg {
+                name: Some("1".to_owned()),
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: None,
+            },
+        ];
+        let method = AbiMethod {
+            name: "add".to_owned(),
+            description: None,
+            args,
+            returns: AbiReturn {
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: None,
+            },
+        };
+
+        let interface_object = AbiInterface {
+            name: "interface".to_owned(),
+            description: None,
+            methods: vec![method],
+        };
+
+        let expected = r#"{"name":"interface","methods":[{"name":"add","args":[{"name":"0","type":"uint32"},{"name":"1","type":"uint32"}],"returns":{"type":"uint32"}}]}"#;
+
+        let json_res = serde_json::to_string(&interface_object);
+        assert!(json_res.is_ok());
+        let json = json_res.unwrap();
+
+        assert_eq!(expected, json);
+    }
+
+    #[test]
+    fn test_encode_json_interface_with_description() {
+        let args = vec![
+            AbiMethodArg {
+                name: Some("0".to_owned()),
+                type_: "uint32".to_owned(),
+                description: Some("description".to_owned()),
+                parsed: None,
+            },
+            AbiMethodArg {
+                name: Some("1".to_owned()),
+                type_: "uint32".to_owned(),
+                description: Some("description".to_owned()),
+                parsed: None,
+            },
+        ];
+        let method = AbiMethod {
+            name: "add".to_owned(),
+            description: Some("description".to_owned()),
+            args,
+            returns: AbiReturn {
+                type_: "uint32".to_owned(),
+                description: Some("description".to_owned()),
+                parsed: None,
+            },
+        };
+
+        let interface_object = AbiInterface {
+            name: "interface".to_owned(),
+            description: None,
+            methods: vec![method],
+        };
+
+        let expected = r#"{"name":"interface","methods":[{"name":"add","desc":"description","args":[{"name":"0","type":"uint32","desc":"description"},{"name":"1","type":"uint32","desc":"description"}],"returns":{"type":"uint32","desc":"description"}}]}"#;
+
+        let json_res = serde_json::to_string(&interface_object);
+        assert!(json_res.is_ok());
+        let json = json_res.unwrap();
+
+        assert_eq!(expected, json);
+    }
+
+    #[test]
+    fn test_encode_json_contract() {
+        let args = vec![
+            AbiMethodArg {
+                name: Some("0".to_owned()),
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: None,
+            },
+            AbiMethodArg {
+                name: Some("1".to_owned()),
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: None,
+            },
+        ];
+        let method = AbiMethod {
+            name: "add".to_owned(),
+            description: None,
+            args,
+            returns: AbiReturn {
+                type_: "uint32".to_owned(),
+                description: None,
+                parsed: None,
+            },
+        };
+
+        let network = AbiContractNetworkInfo { app_id: 123 };
+
+        let contract = AbiContract {
+            name: "contract".to_owned(),
+            networks: [("genesis hash".to_owned(), network)].into(),
+            description: None,
+            methods: vec![method],
+        };
+
+        let expected = r#"{"name":"contract","networks":{"genesis hash":{"appID":123}},"methods":[{"name":"add","args":[{"name":"0","type":"uint32"},{"name":"1","type":"uint32"}],"returns":{"type":"uint32"}}]}"#;
+
+        let json_res = serde_json::to_string(&contract);
+        assert!(json_res.is_ok());
+        let json = json_res.unwrap();
+
+        assert_eq!(expected, json);
+    }
+
+    #[test]
+    fn test_encode_json_contract_with_description() {
+        let args = vec![
+            AbiMethodArg {
+                name: Some("0".to_owned()),
+                type_: "uint32".to_owned(),
+                description: Some("description".to_owned()),
+                parsed: None,
+            },
+            AbiMethodArg {
+                name: Some("1".to_owned()),
+                type_: "uint32".to_owned(),
+                description: Some("description".to_owned()),
+                parsed: None,
+            },
+        ];
+        let method = AbiMethod {
+            name: "add".to_owned(),
+            description: Some("description".to_owned()),
+            args,
+            returns: AbiReturn {
+                type_: "uint32".to_owned(),
+                description: Some("description".to_owned()),
+                parsed: None,
+            },
+        };
+
+        let network = AbiContractNetworkInfo { app_id: 123 };
+
+        let contract = AbiContract {
+            name: "contract".to_owned(),
+            networks: [("genesis hash".to_owned(), network)].into(),
+            description: Some("description for contract".to_owned()),
+            methods: vec![method],
+        };
+
+        let expected = r#"{"name":"contract","desc":"description for contract","networks":{"genesis hash":{"appID":123}},"methods":[{"name":"add","desc":"description","args":[{"name":"0","type":"uint32","desc":"description"},{"name":"1","type":"uint32","desc":"description"}],"returns":{"type":"uint32","desc":"description"}}]}"#;
+
+        let json_res = serde_json::to_string(&contract);
+        assert!(json_res.is_ok());
+        let json = json_res.unwrap();
+
+        assert_eq!(expected, json);
+    }
+
+    #[test]
+    fn test_decode_interface() {
+        let json = r#"{"name": "Calculator","desc":"example description","methods": [{ "name": "add", "args": [ { "name": "a", "type": "uint64", "desc": "..." },{ "name": "b", "type": "uint64", "desc": "..." } ], "returns":{"type":"void"}},{ "name": "multiply", "args": [ { "name": "a", "type": "uint64", "desc": "..." },{ "name": "b", "type": "uint64", "desc": "..." } ], "returns":{"type":"void"}}]}"#;
+        let contract: AbiContract = serde_json::from_str(json).unwrap();
+
+        let methods = vec![
+            AbiMethod {
+                name: "add".to_owned(),
+                description: None,
+                args: vec![
+                    AbiMethodArg {
+                        name: Some("a".to_owned()),
+                        type_: "uint64".to_owned(),
+                        description: Some("...".to_owned()),
+                        parsed: None,
+                    },
+                    AbiMethodArg {
+                        name: Some("b".to_owned()),
+                        type_: "uint64".to_owned(),
+                        description: Some("...".to_owned()),
+                        parsed: None,
+                    },
+                ],
+                returns: AbiReturn {
+                    type_: "void".to_owned(),
+                    description: None,
+                    parsed: None,
+                },
+            },
+            AbiMethod {
+                name: "multiply".to_owned(),
+                description: None,
+                args: vec![
+                    AbiMethodArg {
+                        name: Some("a".to_owned()),
+                        type_: "uint64".to_owned(),
+                        description: Some("...".to_owned()),
+                        parsed: None,
+                    },
+                    AbiMethodArg {
+                        name: Some("b".to_owned()),
+                        type_: "uint64".to_owned(),
+                        description: Some("...".to_owned()),
+                        parsed: None,
+                    },
+                ],
+                returns: AbiReturn {
+                    type_: "void".to_owned(),
+                    description: None,
+                    parsed: None,
+                },
+            },
+        ];
+
+        assert_eq!(
+            contract,
+            AbiContract {
+                name: "Calculator".to_owned(),
+                description: Some("example description".to_owned()),
+                networks: [].into(),
+                methods
+            }
+        )
+    }
+
+    #[test]
+    fn test_decode_contract() {
+        let json = r#"{"name": "Calculator", "desc":"example description", "networks": {"wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=": {"appID": 10}}, "methods": [{ "name": "add", "args": [ { "name": "a", "type": "uint64", "desc": "..." },{ "name": "b", "type": "uint64", "desc": "..." } ], "returns":{"type":"void"}},{ "name": "multiply", "args": [ { "name": "a", "type": "uint64", "desc": "..." },{ "name": "b", "type": "uint64", "desc": "..." } ], "returns":{"type":"void"}}]}"#;
+        let contract: AbiContract = serde_json::from_str(json).unwrap();
+
+        let methods = vec![
+            AbiMethod {
+                name: "add".to_owned(),
+                description: None,
+                args: vec![
+                    AbiMethodArg {
+                        name: Some("a".to_owned()),
+                        type_: "uint64".to_owned(),
+                        description: Some("...".to_owned()),
+                        parsed: None,
+                    },
+                    AbiMethodArg {
+                        name: Some("b".to_owned()),
+                        type_: "uint64".to_owned(),
+                        description: Some("...".to_owned()),
+                        parsed: None,
+                    },
+                ],
+                returns: AbiReturn {
+                    type_: "void".to_owned(),
+                    description: None,
+                    parsed: None,
+                },
+            },
+            AbiMethod {
+                name: "multiply".to_owned(),
+                description: None,
+                args: vec![
+                    AbiMethodArg {
+                        name: Some("a".to_owned()),
+                        type_: "uint64".to_owned(),
+                        description: Some("...".to_owned()),
+                        parsed: None,
+                    },
+                    AbiMethodArg {
+                        name: Some("b".to_owned()),
+                        type_: "uint64".to_owned(),
+                        description: Some("...".to_owned()),
+                        parsed: None,
+                    },
+                ],
+                returns: AbiReturn {
+                    type_: "void".to_owned(),
+                    description: None,
+                    parsed: None,
+                },
+            },
+        ];
+
+        assert_eq!(
+            contract,
+            AbiContract {
+                name: "Calculator".to_owned(),
+                description: Some("example description".to_owned()),
+                networks: [(
+                    "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=".to_owned(),
+                    AbiContractNetworkInfo { app_id: 10 }
+                )]
+                .into(),
+                methods
+            }
+        )
+    }
+}

--- a/algonaut_abi/src/abi_type.rs
+++ b/algonaut_abi/src/abi_type.rs
@@ -1,0 +1,354 @@
+use crate::abi_error::AbiError;
+use algonaut_core::Address;
+use lazy_static::lazy_static;
+use num_bigint::BigUint;
+use regex::Regex;
+use std::{convert::TryInto, str::FromStr};
+
+pub const ADDRESS_BYTE_SIZE: usize = 32;
+pub const LENGTH_ENCODE_BYTE_SIZE: usize = 2;
+pub const SINGLE_BYTE_SIZE: usize = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AbiType {
+    UInt { bit_size: u16 },
+    Byte,
+    UFixed { bit_size: u16, precision: u16 },
+    Bool,
+    Address,
+    StaticArray { len: u16, child_type: Box<AbiType> },
+    DynamicArray { child_type: Box<AbiType> },
+    String,
+    Tuple { len: u16, child_types: Vec<AbiType> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AbiValue {
+    Bool(bool),
+    Byte(u8),
+    Int(BigUint),
+    Address(Address),
+    String(String),
+    Array(Vec<AbiValue>),
+}
+
+impl AbiType {
+    /// Returns true if the type has children and any of the children is dynamic, false otherwise.
+    fn has_dynamic_child(&self) -> bool {
+        match self {
+            AbiType::StaticArray { child_type, .. } | AbiType::DynamicArray { child_type, .. } => {
+                child_type.is_dynamic()
+            }
+            AbiType::Tuple { child_types, .. } => child_types.iter().any(|t| t.is_dynamic()),
+            _ => false,
+        }
+    }
+    /// Returns references to element's children. Variants that don't specify children return an empty vector.
+    pub fn children(&self) -> &[AbiType] {
+        match self {
+            AbiType::StaticArray { child_type, .. } | AbiType::DynamicArray { child_type, .. } => {
+                std::slice::from_ref(&*child_type)
+            }
+            AbiType::Tuple { child_types, .. } => child_types,
+            _ => &[],
+        }
+    }
+}
+
+impl AbiType {
+    /// Determines whether the ABI type is dynamic or static.
+    pub fn is_dynamic(&self) -> bool {
+        match self {
+            AbiType::DynamicArray { .. } | AbiType::String { .. } => true,
+            _ => self.has_dynamic_child(),
+        }
+    }
+
+    /// Serialize an ABI Type to a string in ABI encoding.
+    pub fn string(&self) -> Result<String, AbiError> {
+        match self {
+            AbiType::UInt { bit_size } => Ok(format!("uint{}", bit_size)),
+            AbiType::Byte => Ok("byte".to_owned()),
+            AbiType::UFixed {
+                bit_size,
+                precision,
+            } => Ok(format!("ufixed{}x{}", bit_size, precision)),
+            AbiType::Bool => Ok("bool".to_owned()),
+            AbiType::StaticArray { len, child_type } => {
+                Ok(format!("{}[{}]", child_type.string()?, len))
+            }
+            AbiType::DynamicArray { child_type } => Ok(format!("{}[]", child_type.string()?)),
+            AbiType::String => Ok("string".to_owned()),
+            AbiType::Address => Ok("address".to_owned()),
+            AbiType::Tuple { child_types, .. } => {
+                let mut type_strings = Vec::with_capacity(child_types.len());
+                for child_type in child_types {
+                    type_strings.push(child_type.string()?)
+                }
+                Ok(format!("({})", type_strings.join(",")))
+            }
+        }
+    }
+}
+
+impl FromStr for AbiType {
+    type Err = AbiError;
+
+    /// Parses an ABI type string.
+    /// For example: `from_str("(uint64,byte[])")`
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(stripped) = s.strip_suffix("[]") {
+            let array_arg_type = stripped.parse()?;
+            Ok(make_dynamic_array_type(array_arg_type))
+        } else if s.ends_with(']') {
+            lazy_static! {
+                static ref RE: Regex = Regex::new(r"^([a-z\d\[\](),]+)\[([1-9][\d]*)]$").unwrap();
+            }
+            let caps = RE.captures(s).ok_or_else(|| {
+                AbiError::Msg(format!("Regex for ] ending string: {s} didn't match"))
+            })?;
+
+            if caps.len() != 3 {
+                return Err(AbiError::Msg(format!("ill formed uint type: {s}")));
+            }
+            let array_type = caps[1].parse()?;
+            let array_len_s = caps[2].to_owned();
+
+            let array_len: usize = array_len_s.parse().map_err(|e| {
+                AbiError::Msg(format!("Error parsing array len: {array_len_s}: {e:?}"))
+            })?;
+
+            Ok(make_static_array_type(
+                array_type,
+                array_len.try_into().map_err(|_| {
+                    AbiError::Msg("Couldn't convert array_len: {array_len} in u16".to_owned())
+                })?,
+            ))
+        } else if let Some(stripped) = s.strip_prefix("uint") {
+            let type_size = stripped
+                .parse()
+                .map_err(|e| AbiError::Msg(format!("Ill formed uint type: {s}: {e:?}")))?;
+
+            make_uint_type(type_size)
+        } else if s == "byte" {
+            Ok(make_byte_type())
+        } else if s.starts_with("ufixed") {
+            lazy_static! {
+                static ref RE: Regex = Regex::new(r"^ufixed([1-9][\d]*)x([1-9][\d]*)$").unwrap();
+            }
+            let caps = RE
+                .captures(s)
+                .ok_or_else(|| AbiError::Msg(format!("Regex for ufixed: {s} didn't match")))?;
+
+            if caps.len() != 3 {
+                return Err(AbiError::Msg(format!("ill formed ufixed type: {s}")));
+            }
+            let ufixed_size_s = &caps[1].to_owned();
+            let ufixed_size = ufixed_size_s.parse().map_err(|e| {
+                AbiError::Msg(format!("Error parsing ufixed size: {ufixed_size_s}: {e:?}"))
+            })?;
+
+            let ufixed_precision_s = &caps[2].to_owned();
+            let ufixed_precision = ufixed_precision_s.parse().map_err(|e| {
+                AbiError::Msg(format!(
+                    "Error parsing ufixed precision: {ufixed_precision_s}: {e:?}"
+                ))
+            })?;
+
+            make_ufixed_type(ufixed_size, ufixed_precision)
+        } else if s == "bool" {
+            Ok(make_bool_type())
+        } else if s == "address" {
+            Ok(make_address_type())
+        } else if s == "string" {
+            Ok(make_string_type())
+        } else if s.len() >= 2 && s.starts_with('(') && s.ends_with(')') {
+            let tuple_content = parse_tuple_content(&s[1..s.len() - 1])?;
+            let mut tuple_types = Vec::with_capacity(tuple_content.len());
+
+            for t in tuple_content {
+                let ti = t.parse()?;
+                tuple_types.push(ti);
+            }
+
+            make_tuple_type(tuple_types)
+        } else {
+            Err(AbiError::Msg(format!(
+                "cannot convert string: `{s}` to ABI type"
+            )))
+        }
+    }
+}
+
+// TODO make* -> associated fns from enum probably
+
+pub fn make_dynamic_array_type(arg_type: AbiType) -> AbiType {
+    AbiType::DynamicArray {
+        child_type: Box::new(arg_type),
+    }
+}
+
+pub fn make_static_array_type(arg_type: AbiType, array_len: u16) -> AbiType {
+    AbiType::StaticArray {
+        len: array_len,
+        child_type: Box::new(arg_type),
+    }
+}
+
+/// Makes `Uint` ABI type by taking a type bitSize argument.
+/// The range of type bitSize is [8, 512] and type bitSize % 8 == 0.
+pub fn make_uint_type(type_size: usize) -> Result<AbiType, AbiError> {
+    if type_size % 8 != 0 || type_size < 8 || type_size > 512 {
+        return Err(AbiError::Msg(format!(
+            "unsupported uint type bitSize: {type_size}"
+        )));
+    }
+
+    Ok(AbiType::UInt {
+        bit_size: type_size as u16,
+    })
+}
+
+pub fn make_address_type() -> AbiType {
+    AbiType::Address
+}
+
+pub fn make_byte_type() -> AbiType {
+    AbiType::Byte
+}
+
+pub fn make_bool_type() -> AbiType {
+    AbiType::Bool
+}
+
+pub fn make_string_type() -> AbiType {
+    AbiType::String
+}
+
+/// Makes `UFixed` ABI type by taking type bitSize and type precision as arguments.
+/// The range of type bitSize is [8, 512] and type bitSize % 8 == 0.
+/// The range of type precision is [1, 160].
+pub fn make_ufixed_type(type_size: usize, type_precision: usize) -> Result<AbiType, AbiError> {
+    if type_size % 8 != 0 || !(8..=512).contains(&type_size) {
+        return Err(AbiError::Msg(format!(
+            "unsupported ufixed type bitSize: {type_size}"
+        )));
+    }
+    if !(1..=160).contains(&type_precision) {
+        return Err(AbiError::Msg(format!(
+            "unsupported ufixed type precision: {type_precision}"
+        )));
+    }
+
+    Ok(AbiType::UFixed {
+        bit_size: type_size as u16,       // cast: safe bounds checked in this fn
+        precision: type_precision as u16, // cast: safe bounds checked in this fn
+    })
+}
+
+/// Makes tuple ABI type with argument types
+pub fn make_tuple_type(argument_types: Vec<AbiType>) -> Result<AbiType, AbiError> {
+    if argument_types.len() >= u16::MAX as usize {
+        return Err(AbiError::Msg(
+            "tuple type child type number larger than maximum uint16 error".to_owned(),
+        ));
+    }
+
+    Ok(AbiType::Tuple {
+        len: argument_types.len() as u16, // cast: safe bounds checked in this fn
+        child_types: argument_types,
+    })
+}
+
+/// Keeps track of the start and end of a segment in a string.
+struct Segment {
+    left: usize,
+    right: usize,
+}
+
+/// Splits an ABI encoded string for tuple type into multiple sub-strings.
+/// Each sub-string represents a content type of the tuple type.
+/// The argument str is the content between parentheses of tuple, i.e.
+/// (...... str ......)
+///  ^               ^
+fn parse_tuple_content(str: &str) -> Result<Vec<String>, AbiError> {
+    // if the tuple type content is empty (which is also allowed)
+    // just return the empty string list
+    if str.is_empty() {
+        return Ok(vec![]);
+    }
+
+    // the following 2 checks want to make sure input string can be separated by comma
+    // with form: "...substr_0,...substr_1,...,...substr_k"
+
+    // str should not have leading/tailing comma
+    if str.ends_with(',') || str.starts_with(',') {
+        return Err(AbiError::Msg(
+            "parsing error: tuple content should not start with comma".to_owned(),
+        ));
+    }
+    // str should not have consecutive commas
+    if str.contains(",,") {
+        return Err(AbiError::Msg("no consecutive commas".to_owned()));
+    }
+
+    let mut paren_segment_record = vec![];
+    let mut stack = vec![];
+
+    // get the most exterior parentheses segment (not overlapped by other parentheses)
+    // illustration: "*****,(*****),*****" => ["*****", "(*****)", "*****"]
+    // once iterate to left paren (, stack up by 1 in stack
+    // iterate to right paren ), pop 1 in stack
+    // if iterate to right paren ) with stack height 0, find a parenthesis segment "(******)"
+    for (index, chr) in str.chars().enumerate() {
+        if chr == '(' {
+            stack.push(index);
+        } else if chr == ')' {
+            if stack.is_empty() {
+                return Err(AbiError::Msg(format!("unpaired parentheses: {str}")));
+            }
+
+            let left_paren_index = stack[stack.len() - 1];
+            stack.pop();
+            if stack.is_empty() {
+                paren_segment_record.push(Segment {
+                    left: left_paren_index,
+                    right: index,
+                });
+            }
+        }
+    }
+    if !stack.is_empty() {
+        return Err(AbiError::Msg(format!("unpaired parentheses: {str}")));
+    }
+
+    // take out tuple-formed type str in tuple argument
+    let mut str_copied = str.to_owned();
+
+    for paren_seg in paren_segment_record.iter().rev() {
+        str_copied = format!(
+            "{}{}",
+            str_copied[..paren_seg.left].to_owned(),
+            str_copied[paren_seg.right + 1..].to_owned()
+        );
+    }
+
+    // split the string without parenthesis segments
+    let tuple_str_segs: Vec<&str> = str_copied.split(',').collect();
+    let mut tuple_str_segs_res: Vec<String> = Vec::with_capacity(tuple_str_segs.len());
+
+    // the empty strings are placeholders for parenthesis segments
+    // put the parenthesis segments back into segment list
+    let mut paren_seg_count = 0;
+    for seg_str in tuple_str_segs.iter() {
+        if seg_str.is_empty() {
+            let paren_seg = &paren_segment_record[paren_seg_count];
+            tuple_str_segs_res.push(str[paren_seg.left..paren_seg.right + 1].to_owned());
+            paren_seg_count += 1;
+        } else {
+            tuple_str_segs_res.push((*seg_str).to_owned());
+        }
+    }
+
+    Ok(tuple_str_segs_res)
+}

--- a/algonaut_abi/src/abi_type_test.rs
+++ b/algonaut_abi/src/abi_type_test.rs
@@ -1,0 +1,493 @@
+#[cfg(test)]
+mod test {
+    use rand::Rng;
+
+    struct SetupRes {
+        type_testpool: Vec<AbiType>,
+        tuple_testpool: Vec<AbiType>,
+    }
+    use crate::{
+        abi_encode::find_bool_lr,
+        abi_type::{
+            make_address_type, make_bool_type, make_byte_type, make_dynamic_array_type,
+            make_static_array_type, make_string_type, make_tuple_type, make_ufixed_type,
+            make_uint_type, AbiType,
+        },
+    };
+
+    fn generate_random_tuple_type(
+        type_testpool: &mut [AbiType],
+        tuple_testpool: &mut [AbiType],
+    ) -> AbiType {
+        let mut rng = rand::thread_rng();
+        let tuple_len: usize = rng.gen_range(0..20);
+
+        let mut tuple_elems = vec![];
+
+        for _ in 0..tuple_len {
+            let base_or_tuple: i32 = rng.gen_range(0..5);
+            if base_or_tuple == 1 && tuple_testpool.len() > 0 {
+                tuple_elems.push(tuple_testpool[rng.gen_range(0..tuple_testpool.len())].clone());
+            } else {
+                tuple_elems.push(type_testpool[rng.gen_range(0..type_testpool.len())].clone());
+            }
+        }
+        make_tuple_type(tuple_elems).unwrap()
+    }
+
+    fn setup() -> SetupRes {
+        let mut type_testpool = vec![
+            make_bool_type(),
+            make_address_type(),
+            make_string_type(),
+            make_byte_type(),
+        ];
+
+        for i in (8..512).step_by(8) {
+            type_testpool.push(make_uint_type(i).unwrap());
+        }
+
+        for i in (8..512).step_by(8) {
+            for j in 1..=160 {
+                type_testpool.push(make_ufixed_type(i, j).unwrap());
+            }
+        }
+
+        for i in 0..type_testpool.len() {
+            type_testpool.push(make_dynamic_array_type(type_testpool[i].clone()));
+            type_testpool.push(make_static_array_type(type_testpool[i].clone(), 10));
+            type_testpool.push(make_static_array_type(type_testpool[i].clone(), 20));
+        }
+
+        let mut tuple_testpool = vec![];
+
+        for _ in 0..100 {
+            let temp_tuple = generate_random_tuple_type(&mut type_testpool, &mut tuple_testpool);
+            tuple_testpool.push(temp_tuple);
+        }
+
+        SetupRes {
+            type_testpool,
+            tuple_testpool,
+        }
+    }
+
+    #[test]
+    fn test_uint_valid() {
+        for i in (8..512).step_by(8) {
+            let type_ = make_uint_type(i).unwrap();
+            assert_eq!(type_.string().unwrap(), format!("uint{}", i))
+        }
+    }
+
+    #[test]
+    fn test_uint_invalid() {
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..1000 {
+            let mut size_rand = rng.gen_range(0..65536);
+
+            while size_rand % 8 == 0 && size_rand <= 512 && size_rand >= 8 {
+                size_rand = rng.gen_range(0..1000);
+            }
+
+            let final_size_rand = size_rand;
+            assert!(make_uint_type(final_size_rand).is_err())
+        }
+    }
+
+    #[test]
+    fn test_ufixed_valid() {
+        for i in (8..512).step_by(8) {
+            for j in 1..160 {
+                let type_ = make_ufixed_type(i, j).unwrap();
+                assert_eq!(type_.string().unwrap(), format!("ufixed{}x{}", i, j))
+            }
+        }
+    }
+
+    #[test]
+    fn test_ufixed_invalid() {
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..1000 {
+            let mut size_rand = rng.gen_range(0..65536);
+
+            while size_rand % 8 == 0 && size_rand <= 512 && size_rand >= 8 {
+                size_rand = rng.gen_range(0..65536);
+            }
+
+            let mut precision_rand = rng.gen_range(0..1024);
+            while precision_rand >= 1 && precision_rand <= 160 {
+                precision_rand = rng.gen_range(0..1024);
+            }
+
+            let final_rand_precision = precision_rand;
+            let final_size_rand = size_rand;
+            assert!(make_ufixed_type(final_size_rand, final_rand_precision).is_err())
+        }
+    }
+
+    #[test]
+    fn test_simple_types_valid() {
+        assert_eq!(&make_byte_type().string().unwrap(), "byte");
+        assert_eq!(&make_string_type().string().unwrap(), "string");
+        assert_eq!(&make_address_type().string().unwrap(), "address");
+        assert_eq!(&make_bool_type().string().unwrap(), "bool");
+    }
+
+    #[test]
+    fn test_type_to_string_valid() {
+        assert_eq!(
+            &make_dynamic_array_type(make_uint_type(32).unwrap())
+                .string()
+                .unwrap(),
+            "uint32[]"
+        );
+        assert_eq!(
+            &make_dynamic_array_type(make_dynamic_array_type(make_byte_type()))
+                .string()
+                .unwrap(),
+            "byte[][]"
+        );
+        assert_eq!(
+            &make_static_array_type(make_ufixed_type(128, 10).unwrap(), 100)
+                .string()
+                .unwrap(),
+            "ufixed128x10[100]"
+        );
+        assert_eq!(
+            &make_static_array_type(make_static_array_type(make_bool_type(), 128), 256)
+                .string()
+                .unwrap(),
+            "bool[128][256]"
+        );
+        assert_eq!(
+            &make_tuple_type(vec![
+                make_uint_type(32).unwrap(),
+                make_tuple_type(vec![
+                    make_address_type(),
+                    make_byte_type(),
+                    make_static_array_type(make_bool_type(), 10),
+                    make_dynamic_array_type(make_ufixed_type(256, 10).unwrap()),
+                ])
+                .unwrap()
+            ])
+            .unwrap()
+            .string()
+            .unwrap(),
+            "(uint32,(address,byte,bool[10],ufixed256x10[]))"
+        );
+        assert_eq!(&make_tuple_type(vec![]).unwrap().string().unwrap(), "()");
+    }
+
+    #[test]
+    fn test_uint_from_string_valid() {
+        for i in (8..512).step_by(8) {
+            let encoded = format!("uint{}", i);
+            let uint_type = make_uint_type(i).unwrap();
+            assert_eq!(encoded.parse::<AbiType>().unwrap(), uint_type)
+        }
+    }
+
+    #[test]
+    fn test_uint_from_string_invalid() {
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..100 {
+            let mut size_rand = rng.gen_range(0..65536);
+
+            while size_rand % 8 == 0 && size_rand <= 512 && size_rand >= 8 {
+                size_rand = rng.gen_range(0..65536);
+            }
+
+            let encoded = format!("uint{}", size_rand);
+            assert!(encoded.parse::<AbiType>().is_err());
+        }
+    }
+
+    #[test]
+    fn test_ufixed_from_string_valid() {
+        for i in (8..512).step_by(8) {
+            for j in 1..160 {
+                let encoded = format!("ufixed{}x{}", i, j);
+                let ufixed_t = make_ufixed_type(i, j).unwrap();
+                assert_eq!(encoded.parse::<AbiType>().unwrap(), ufixed_t);
+            }
+        }
+    }
+
+    #[test]
+    fn test_ufixed_from_string_invalid() {
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..1000 {
+            let mut size_rand = rng.gen_range(0..65536);
+
+            while size_rand % 8 == 0 && size_rand <= 512 && size_rand >= 8 {
+                size_rand = rng.gen_range(0..65536);
+            }
+
+            let mut precision_rand = rng.gen_range(0..1024);
+            while precision_rand >= 1 && precision_rand <= 160 {
+                precision_rand = rng.gen_range(0..1024);
+            }
+
+            let encoded = format!("ufixed{}x{}", size_rand, precision_rand);
+            assert!(encoded.parse::<AbiType>().is_err());
+        }
+    }
+
+    #[test]
+    fn test_simple_type_from_string_valid() {
+        assert_eq!("address".parse::<AbiType>().unwrap(), make_address_type());
+        assert_eq!("byte".parse::<AbiType>().unwrap(), make_byte_type());
+        assert_eq!("bool".parse::<AbiType>().unwrap(), make_bool_type());
+        assert_eq!("string".parse::<AbiType>().unwrap(), make_string_type());
+    }
+
+    #[test]
+    fn test_type_from_string_valid() {
+        assert_eq!(
+            "uint256[]".parse::<AbiType>().unwrap(),
+            make_dynamic_array_type(make_uint_type(256).unwrap())
+        );
+        assert_eq!(
+            "ufixed256x64[]".parse::<AbiType>().unwrap(),
+            make_dynamic_array_type(make_ufixed_type(256, 64).unwrap())
+        );
+        assert_eq!(
+            "byte[][][][]".parse::<AbiType>().unwrap(),
+            make_dynamic_array_type(make_dynamic_array_type(make_dynamic_array_type(
+                make_dynamic_array_type(make_byte_type())
+            )))
+        );
+        assert_eq!(
+            "address[100]".parse::<AbiType>().unwrap(),
+            make_static_array_type(make_address_type(), 100)
+        );
+        assert_eq!(
+            "uint64[][100]".parse::<AbiType>().unwrap(),
+            make_static_array_type(make_dynamic_array_type(make_uint_type(64).unwrap()), 100)
+        );
+        assert_eq!(
+            "()".parse::<AbiType>().unwrap(),
+            make_tuple_type(vec![]).unwrap()
+        );
+        assert_eq!(
+            "(uint32,(address,byte,bool[10],ufixed256x10[]),byte[])"
+                .parse::<AbiType>()
+                .unwrap(),
+            make_tuple_type(vec![
+                make_uint_type(32).unwrap(),
+                make_tuple_type(vec![
+                    make_address_type(),
+                    make_byte_type(),
+                    make_static_array_type(make_bool_type(), 10),
+                    make_dynamic_array_type(make_ufixed_type(256, 10).unwrap())
+                ])
+                .unwrap(),
+                make_dynamic_array_type(make_byte_type())
+            ])
+            .unwrap()
+        );
+        assert_eq!(
+            "(uint32,(address,byte,bool[10],(ufixed256x10[])))"
+                .parse::<AbiType>()
+                .unwrap(),
+            make_tuple_type(vec![
+                make_uint_type(32).unwrap(),
+                make_tuple_type(vec![
+                    make_address_type(),
+                    make_byte_type(),
+                    make_static_array_type(make_bool_type(), 10),
+                    make_tuple_type(vec![make_dynamic_array_type(
+                        make_ufixed_type(256, 10).unwrap()
+                    )])
+                    .unwrap()
+                ])
+                .unwrap(),
+            ])
+            .unwrap()
+        );
+        assert_eq!(
+            "((uint32),(address,(byte,bool[10],ufixed256x10[])))"
+                .parse::<AbiType>()
+                .unwrap(),
+            make_tuple_type(vec![
+                make_tuple_type(vec![make_uint_type(32).unwrap()]).unwrap(),
+                make_tuple_type(vec![
+                    make_address_type(),
+                    make_tuple_type(vec![
+                        make_byte_type(),
+                        make_static_array_type(make_bool_type(), 10),
+                        make_dynamic_array_type(make_ufixed_type(256, 10).unwrap())
+                    ])
+                    .unwrap()
+                ])
+                .unwrap(),
+            ])
+            .unwrap()
+        )
+    }
+
+    #[test]
+    fn test_type_from_string_is_invalid() {
+        let test_cases = vec![
+            // uint
+            "uint123x345",
+            "uint 128",
+            "uint8 ",
+            "uint!8",
+            "uint[32]",
+            "uint-893",
+            "uint#120\\",
+            // ufixed
+            "ufixed000000000016x0000010",
+            "ufixed123x345",
+            "ufixed 128 x 100",
+            "ufixed64x10 ",
+            "ufixed!8x2 ",
+            "ufixed[32]x16",
+            "ufixed-64x+100",
+            "ufixed16x+12",
+            // dynamic array
+            "uint256 []",
+            "byte[] ",
+            "[][][]",
+            "stuff[]",
+            // static array
+            "ufixed32x10[0]",
+            "byte[10 ]",
+            "uint64[0x21]",
+            // tuple
+            "(ufixed128x10))",
+            "(,uint128,byte[])",
+            "(address,ufixed64x5,)",
+            "(byte[16],somethingwrong)",
+            "(                )",
+            "((uint32)",
+            "(byte,,byte)",
+            "((byte),,(byte))",
+            // some random stuffs
+            "",
+        ];
+
+        for test_case in test_cases {
+            assert!(test_case.parse::<AbiType>().is_err());
+        }
+    }
+
+    #[test]
+    fn test_tuple_roundtrip() {
+        let tuple_testpool = setup().tuple_testpool;
+        for t in tuple_testpool {
+            let encoded = t.string().unwrap();
+            let decoded = encoded.parse::<AbiType>().unwrap();
+            assert_eq!(decoded, t.clone());
+        }
+    }
+
+    #[test]
+    fn test_self_equiv() {
+        let mut rng = rand::thread_rng();
+
+        let SetupRes {
+            type_testpool,
+            tuple_testpool,
+        } = setup();
+
+        for t in &type_testpool {
+            assert_eq!(t, t);
+        }
+
+        for t in &tuple_testpool {
+            assert_eq!(t, t);
+        }
+
+        for _ in 0..1000 {
+            let index0 = rng.gen_range(0..type_testpool.len());
+            let mut index1 = rng.gen_range(0..type_testpool.len());
+
+            while type_testpool[index0].string().unwrap() == type_testpool[index1].string().unwrap()
+            {
+                index1 = rng.gen_range(0..type_testpool.len());
+            }
+
+            assert_ne!(type_testpool[index0], type_testpool[index1]);
+        }
+
+        for _ in 0..1000 {
+            let index0 = rng.gen_range(0..tuple_testpool.len());
+            let mut index1 = rng.gen_range(0..tuple_testpool.len());
+
+            while tuple_testpool[index0].string().unwrap()
+                == tuple_testpool[index1].string().unwrap()
+            {
+                index1 = rng.gen_range(0..tuple_testpool.len());
+            }
+
+            assert_ne!(tuple_testpool[index0], tuple_testpool[index1]);
+        }
+    }
+
+    #[test]
+    fn test_is_dynamic() {
+        let SetupRes {
+            type_testpool,
+            tuple_testpool,
+        } = setup();
+
+        for t in &type_testpool {
+            let encoded = t.string().unwrap();
+            let infer_from_string = encoded.contains("[]") || encoded.contains("string");
+            assert_eq!(infer_from_string, t.is_dynamic());
+        }
+
+        for t in &tuple_testpool {
+            let encoded = t.string().unwrap();
+            let infer_from_string = encoded.contains("[]") || encoded.contains("string");
+            assert_eq!(infer_from_string, t.is_dynamic());
+        }
+    }
+
+    #[test]
+    fn test_byte_len() {
+        let SetupRes {
+            type_testpool,
+            tuple_testpool,
+        } = setup();
+
+        assert_eq!(make_address_type().byte_len().unwrap(), 32);
+        assert_eq!(make_byte_type().byte_len().unwrap(), 1);
+
+        for t in type_testpool {
+            if t.is_dynamic() {
+                assert!(t.byte_len().is_err())
+            }
+        }
+
+        for t in tuple_testpool {
+            if t.is_dynamic() {
+                assert!(t.byte_len().is_err())
+            } else {
+                let mut size = 0;
+                let ct_list = t.children().clone();
+
+                for i in 0..ct_list.len() {
+                    match ct_list[i] {
+                        AbiType::Bool => {
+                            let bool_num = find_bool_lr(&ct_list, i, 1).unwrap() + 1;
+                            size += bool_num / 8;
+                            size += if bool_num % 8 != 0 { 1 } else { 0 };
+                        }
+                        _ => {
+                            size += ct_list[i].byte_len().unwrap();
+                        }
+                    }
+                }
+                assert_eq!(size, t.byte_len().unwrap());
+            }
+        }
+    }
+}

--- a/algonaut_abi/src/biguint_ext.rs
+++ b/algonaut_abi/src/biguint_ext.rs
@@ -1,0 +1,26 @@
+use crate::abi_error::AbiError;
+use num_bigint::BigUint;
+use std::ops::Shl;
+
+pub trait BigUintExt {
+    /// Encode as a big endian byte vector with `len` length (padded with leading 0s if needed).
+    /// Errors if value cannot be represented with `len` bytes.
+    fn to_bytes_be_padded(&self, len: usize) -> Result<Vec<u8>, AbiError>;
+}
+
+impl BigUintExt for BigUint {
+    fn to_bytes_be_padded(&self, len: usize) -> Result<Vec<u8>, AbiError> {
+        if self >= &BigUint::from(1u8).shl(len * 8) {
+            return Err(AbiError::Msg(format!(
+                "Encode int to byte: integer size for: {self} exceeds the given byte number: {len}"
+            )));
+        }
+
+        let bytes = self.to_bytes_be();
+        let mut new_buffer = vec![0; len];
+        let start = len - bytes.len();
+        // This panics if slices have different lengths, but checks / logic in this function prevent this from happening.
+        new_buffer[start..].clone_from_slice(&bytes);
+        Ok(new_buffer)
+    }
+}

--- a/algonaut_abi/src/lib.rs
+++ b/algonaut_abi/src/lib.rs
@@ -1,0 +1,35 @@
+mod abi_encode;
+mod abi_encode_test;
+pub mod abi_error;
+mod abi_interaction_tests;
+pub mod abi_interactions;
+mod abi_json_tests;
+pub mod abi_type;
+mod abi_type_test;
+mod biguint_ext;
+
+use crate::abi_error::AbiError;
+use abi_type::AbiType;
+
+/// MakeTupleType makes tuple ABI type by taking an array of tuple element types as argument.
+pub fn make_tuple_type(argument_types: &[AbiType]) -> Result<AbiType, AbiError> {
+    if argument_types.is_empty() {
+        return Err(AbiError::Msg(
+            "tuple must contain at least one type".to_string(),
+        ));
+    }
+
+    if argument_types.len() >= u16::MAX as usize {
+        return Err(AbiError::Msg(
+            "tuple type child type number larger than maximum uint16 error".to_string(),
+        ));
+    }
+
+    let mut strs = vec![];
+    for arg in argument_types {
+        strs.push(arg.string()?)
+    }
+
+    let str_tuple = format!("({})", strs.join(","));
+    str_tuple.parse()
+}

--- a/algonaut_core/src/lib.rs
+++ b/algonaut_core/src/lib.rs
@@ -17,7 +17,7 @@ pub use multisig::MultisigSignature;
 pub use multisig::MultisigSubsig;
 
 mod address;
-mod error;
+pub mod error;
 mod multisig;
 
 pub const MICRO_ALGO_CONVERSION_FACTOR: f64 = 1e6;
@@ -252,6 +252,43 @@ pub struct SuggestedTransactionParams {
     pub min_fee: MicroAlgos,
     pub first_valid: Round,
     pub last_valid: Round,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum TransactionTypeEnum {
+    Payment,
+    KeyRegistration,
+    AssetConfiguration,
+    AssetTransfer,
+    AssetFreeze,
+    ApplicationCall,
+}
+
+impl TransactionTypeEnum {
+    pub fn to_api_str(&self) -> &str {
+        match self {
+            TransactionTypeEnum::Payment => "pay",
+            TransactionTypeEnum::KeyRegistration => "keyreg",
+            TransactionTypeEnum::AssetConfiguration => "acfg",
+            TransactionTypeEnum::AssetTransfer => "axfer",
+            TransactionTypeEnum::AssetFreeze => "afrz",
+            TransactionTypeEnum::ApplicationCall => "appl",
+        }
+    }
+
+    pub fn from_api_str(s: &str) -> Result<Self, CoreError> {
+        match s {
+            "pay" => Ok(TransactionTypeEnum::Payment),
+            "keyreg" => Ok(TransactionTypeEnum::KeyRegistration),
+            "acfg" => Ok(TransactionTypeEnum::AssetConfiguration),
+            "axfer" => Ok(TransactionTypeEnum::AssetTransfer),
+            "afrz" => Ok(TransactionTypeEnum::AssetFreeze),
+            "appl" => Ok(TransactionTypeEnum::ApplicationCall),
+            _ => Err(CoreError::General(format!(
+                "Couldn't convert tx type str: `{s}` to tx type"
+            ))),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/algonaut_transaction/src/api_model.rs
+++ b/algonaut_transaction/src/api_model.rs
@@ -2,7 +2,7 @@ use std::convert::{TryFrom, TryInto};
 
 use algonaut_core::{
     Address, CompiledTeal, LogicSignature, MicroAlgos, MultisigSignature, Round, SignedLogic,
-    ToMsgPack, VotePk, VrfPk,
+    ToMsgPack, TransactionTypeEnum, VotePk, VrfPk,
 };
 use algonaut_crypto::{HashDigest, Signature};
 use num_traits::Num;
@@ -191,7 +191,7 @@ impl From<Transaction> for ApiTransaction {
             note: t.note.clone().and_then(vec_as_api_option),
             rekey_to: t.rekey_to,
             sender: t.sender(),
-            type_: to_api_transaction_type(&t.txn_type).to_owned(),
+            type_: to_tx_type_enum(&t.txn_type).to_api_str().to_owned(),
             ///////////////
             asset_amount: None,
             asset_close_to: None,
@@ -553,16 +553,18 @@ impl From<ApiAssetParams> for AssetParams {
     }
 }
 
-fn to_api_transaction_type<'a>(type_: &TransactionType) -> &'a str {
+pub fn to_tx_type_enum(type_: &TransactionType) -> TransactionTypeEnum {
     match type_ {
-        TransactionType::Payment(_) => "pay",
-        TransactionType::KeyRegistration(_) => "keyreg",
-        TransactionType::AssetConfigurationTransaction(_) => "acfg",
-        TransactionType::AssetTransferTransaction(_) => "axfer",
-        TransactionType::AssetAcceptTransaction(_) => "axfer",
-        TransactionType::AssetClawbackTransaction(_) => "axfer",
-        TransactionType::AssetFreezeTransaction(_) => "afrz",
-        TransactionType::ApplicationCallTransaction(_) => "appl",
+        TransactionType::Payment(_) => TransactionTypeEnum::Payment,
+        TransactionType::KeyRegistration(_) => TransactionTypeEnum::KeyRegistration,
+        TransactionType::AssetConfigurationTransaction(_) => {
+            TransactionTypeEnum::AssetConfiguration
+        }
+        TransactionType::AssetTransferTransaction(_)
+        | TransactionType::AssetAcceptTransaction(_)
+        | TransactionType::AssetClawbackTransaction(_) => TransactionTypeEnum::AssetTransfer,
+        TransactionType::AssetFreezeTransaction(_) => TransactionTypeEnum::AssetFreeze,
+        TransactionType::ApplicationCallTransaction(_) => TransactionTypeEnum::ApplicationCall,
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Error, Clone, Debug, PartialEq, Eq)]
 pub enum ServiceError {
     /// URL parse error.
     #[error("Url parsing error.")]
@@ -45,7 +45,7 @@ impl ServiceError {
     }
 }
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Error, Clone, Debug, PartialEq, Eq)]
 #[error("{:?}, {}", url, details)]
 pub struct RequestError {
     pub url: Option<String>,
@@ -63,7 +63,7 @@ impl RequestError {
     }
 }
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Error, Clone, Debug, PartialEq, Eq)]
 pub enum RequestErrorDetails {
     /// Http call error with optional message (returned by remote API)
     #[error("Http error: {}, {}", status, message)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 
 // Re-exports
 
+pub use algonaut_abi as abi;
 pub use algonaut_core as core;
 pub use algonaut_crypto as crypto;
 pub use algonaut_model as model;


### PR DESCRIPTION
Ported from the current last versions of the official SDKs (Go v1.14.1 and the unit tests mostly from Java 1.13.0, since I had issues running the Go tests. Go is supposed to be reference SDK - from what I could see, the tests were ported to the Java SDK, and there were some additional ones which I ported too).

Closes https://github.com/manuelmauro/algonaut/issues/149