### PR TITLE
Fix dryrun endpoint

### DIFF
--- a/algonaut_client/src/algod/v2/mod.rs
+++ b/algonaut_client/src/algod/v2/mod.rs
@@ -3,8 +3,8 @@ use crate::extensions::reqwest::{to_header_map, ResponseExt};
 use crate::Headers;
 use algonaut_core::{Address, Round};
 use algonaut_model::algod::v2::{
-    Account, ApiCompiledTeal, Application, Asset, Block, Catchup, DryrunRequest, DryrunResponse,
-    GenesisBlock, KeyRegistration, NodeStatus, PendingTransaction, PendingTransactions, Supply,
+    Account, ApiCompiledTeal, Application, Asset, Block, Catchup, DryrunResponse, GenesisBlock,
+    KeyRegistration, NodeStatus, PendingTransaction, PendingTransactions, Supply,
     TransactionParams, TransactionResponse, Version,
 };
 use reqwest::header::HeaderMap;
@@ -285,13 +285,13 @@ impl Client {
         Ok(response)
     }
 
-    pub async fn dryrun_teal(&self, req: &DryrunRequest) -> Result<DryrunResponse, ClientError> {
+    pub async fn dryrun_teal(&self, req: Vec<u8>) -> Result<DryrunResponse, ClientError> {
         let response = self
             .http_client
             .post(&format!("{}v2/teal/dryrun", self.url))
             .headers(self.headers.clone())
-            .header("Content-Type", "application/json")
-            .json(req)
+            .header("Content-Type", "application/x-binary")
+            .body(req)
             .send()
             .await?
             .http_error_for_status()

--- a/algonaut_core/src/lib.rs
+++ b/algonaut_core/src/lib.rs
@@ -4,6 +4,7 @@ use algonaut_encoding::U8_32Visitor;
 use data_encoding::BASE64;
 use derive_more::{Add, Display, Sub};
 use error::CoreError;
+pub use multisig::MultisigSignature;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::Digest;
 use static_assertions::_core::ops::{Add, Sub};
@@ -13,7 +14,6 @@ use std::ops::Mul;
 
 pub use address::Address;
 pub use address::MultisigAddress;
-pub use multisig::MultisigSignature;
 pub use multisig::MultisigSubsig;
 
 mod address;
@@ -162,45 +162,6 @@ impl VrfPk {
     }
 }
 
-#[derive(Eq, PartialEq, Clone)]
-pub struct SignedLogic {
-    pub logic: CompiledTeal,
-    pub args: Vec<Vec<u8>>,
-    pub sig: LogicSignature,
-}
-
-impl SignedLogic {
-    pub fn as_address(&self) -> Address {
-        Address(sha2::Sha512_256::digest(&self.logic.bytes_to_sign()).into())
-    }
-
-    /// Performs signature verification against the sender address, and general consistency checks.
-    pub fn verify(&self, address: Address) -> bool {
-        match &self.sig {
-            LogicSignature::ContractAccount => self.as_address() == address,
-            LogicSignature::DelegatedSig(sig) => {
-                let pk = address.as_public_key();
-                pk.verify(&self.logic.bytes_to_sign(), sig)
-            }
-            LogicSignature::DelegatedMultiSig(msig) => msig.verify(&self.logic.bytes_to_sign()),
-        }
-    }
-}
-
-impl Debug for SignedLogic {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "logic: {:?}, args: {:?}, sig: {:?}",
-            BASE64.encode(&self.logic.0),
-            self.args
-                .iter()
-                .map(|a| BASE64.encode(a))
-                .collect::<Vec<String>>(),
-            self.sig
-        )
-    }
-}
 
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct CompiledTeal(pub Vec<u8>);
@@ -291,6 +252,14 @@ impl TransactionTypeEnum {
     }
 }
 
+/// Returns the address corresponding to an application's escrow account.
+pub fn to_app_address(app_id: u64) -> Address {
+    let bytes = app_id.to_be_bytes();
+    let all_bytes = ["appID".as_bytes(), &bytes].concat();
+    let hash = sha2::Sha512_256::digest(all_bytes);
+    Address(hash.into())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -320,12 +289,4 @@ mod tests {
             Address::new(digest.0).to_string()
         );
     }
-}
-
-/// Returns the address corresponding to an application's escrow account.
-pub fn to_app_address(app_id: u64) -> Address {
-    let bytes = app_id.to_be_bytes();
-    let all_bytes = ["appID".as_bytes(), &bytes].concat();
-    let hash = sha2::Sha512_256::digest(all_bytes);
-    Address(hash.into())
 }

--- a/algonaut_core/src/lib.rs
+++ b/algonaut_core/src/lib.rs
@@ -162,7 +162,6 @@ impl VrfPk {
     }
 }
 
-
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct CompiledTeal(pub Vec<u8>);
 

--- a/algonaut_model/src/algod/v2/mod.rs
+++ b/algonaut_model/src/algod/v2/mod.rs
@@ -4,6 +4,8 @@ use algonaut_encoding::deserialize_bytes;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 
+use crate::transaction::ApiSignedTransaction;
+
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Account {
@@ -377,7 +379,7 @@ pub struct DryrunRequest {
 
     pub sources: Vec<DryrunSource>,
 
-    pub txns: Vec<String>,
+    pub txns: Vec<ApiSignedTransaction>,
 }
 
 /// DryrunSource is TEAL source text that gets uploaded, compiled, and inserted into transactions

--- a/algonaut_model/src/algod/v2/mod.rs
+++ b/algonaut_model/src/algod/v2/mod.rs
@@ -1,7 +1,7 @@
-use algonaut_core::{Address, MicroAlgos, Round};
+use algonaut_core::{Address, MicroAlgos, Round, ToMsgPack};
 use algonaut_crypto::{deserialize_hash, HashDigest};
 use algonaut_encoding::deserialize_bytes;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 
 use crate::transaction::ApiSignedTransaction;
@@ -382,6 +382,8 @@ pub struct DryrunRequest {
     pub txns: Vec<ApiSignedTransaction>,
 }
 
+impl ToMsgPack for DryrunRequest {}
+
 /// DryrunSource is TEAL source text that gets uploaded, compiled, and inserted into transactions
 /// or application state.
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -406,7 +408,7 @@ pub struct DryrunSource {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DryrunState {
     /// Evaluation error if any
-    pub error: String,
+    pub error: Option<String>,
 
     /// Line number
     pub line: u64,
@@ -414,6 +416,7 @@ pub struct DryrunState {
     /// Program counter
     pub pc: u64,
 
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub scratch: Vec<TealValue>,
 
     pub stack: Vec<TealValue>,
@@ -423,13 +426,28 @@ pub struct DryrunState {
 /// and state updates from a dryrun.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DryrunTxnResult {
-    #[serde(rename = "app-call-messages")]
+    #[serde(
+        default,
+        rename = "app-call-messages",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub app_call_messages: Vec<String>,
 
-    #[serde(rename = "app-call-trace")]
+    #[serde(
+        default,
+        rename = "app-call-trace",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub app_call_trace: Vec<DryrunState>,
 
     /// Disassembled program line by line.
+    /// Documented as required, but for some reason the API can send null (which is unusual, normally keys with null values are omitted)
+    /// so it has to be marked as optional.
+    // pub disassembly: Option<Vec<String>>,
+    #[serde(
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "deserialize_vec_opt_to_vec"
+    )]
     pub disassembly: Vec<String>,
 
     #[serde(
@@ -439,26 +457,50 @@ pub struct DryrunTxnResult {
     )]
     pub global_delta: Vec<EvalDeltaKeyValue>,
 
-    #[serde(rename = "local-deltas")]
+    #[serde(
+        default,
+        rename = "local-deltas",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub local_deltas: Vec<AccountStateDelta>,
 
-    #[serde(rename = "logic-sig-messages")]
+    #[serde(
+        default,
+        rename = "logic-sig-messages",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub logic_sig_messages: Vec<String>,
 
-    #[serde(rename = "logic-sig-trace")]
+    #[serde(
+        default,
+        rename = "logic-sig-trace",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub logic_sig_trace: Vec<DryrunState>,
+
+    /// Logs for the application being executed by this transaction.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub logs: Vec<String>,
+}
+
+fn deserialize_vec_opt_to_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: Option<Vec<String>> = Deserialize::deserialize(deserializer)?;
+    Ok(s.unwrap_or_default())
 }
 
 /// DryrunResponse
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DryrunResponse {
-    pub error: String,
+    pub error: Option<String>,
 
     /// Protocol version is the protocol version Dryrun was operated under.
     #[serde(rename = "protocol-version")]
     pub protocol_version: String,
 
-    #[serde(rename = "logic-sig-trace")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub txns: Vec<DryrunTxnResult>,
 }
 
@@ -618,10 +660,8 @@ pub struct PendingTransaction {
 
     /// Logs for the application being executed by this transaction.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    // #[serde(default)]
-    // pub logs: Vec<Vec<u8>>,
     pub logs: Vec<String>,
-    // pub logs: Option<String>,
+
     /// The raw signed transaction.
     pub txn: Transaction,
 }

--- a/algonaut_model/src/lib.rs
+++ b/algonaut_model/src/lib.rs
@@ -1,6 +1,4 @@
-/// Algorand protocol daemon
 pub mod algod;
-/// Algorand's indexer
 pub mod indexer;
-/// Key management daemon
 pub mod kmd;
+pub mod transaction;

--- a/algonaut_model/src/transaction.rs
+++ b/algonaut_model/src/transaction.rs
@@ -1,0 +1,241 @@
+use algonaut_core::{Address, MicroAlgos, MultisigSignature, Round, ToMsgPack, VotePk, VrfPk};
+use algonaut_crypto::{HashDigest, Signature};
+use serde::{Deserialize, Serialize};
+
+/// IMPORTANT:
+/// When serializing:
+/// - Fields have to be sorted alphabetically.
+/// - Keys must be excluded if they've a "zero value" (e.g. the number 0 or an empty vector).
+/// otherwise the node's signature validation will fail.
+/// When deserializing:
+/// - Non existent keys can mean None or a semantic zero value, depending on context.
+///
+/// Note that to date the REST API documentation specifies explicitly zero values for some fields, which is incorrect.
+/// https://github.com/algorand/docs/pull/454, https://github.com/algorand/docs/issues/415 (not comprehensive)
+///
+/// We intentionally don't use `skip_serializing_if` for values other than `Option` for a consistent representation of optionals.
+///
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ApiTransaction {
+    #[serde(rename = "aamt", skip_serializing_if = "Option::is_none")]
+    pub asset_amount: Option<u64>,
+
+    #[serde(rename = "aclose", skip_serializing_if = "Option::is_none")]
+    pub asset_close_to: Option<Address>,
+
+    #[serde(rename = "afrz", skip_serializing_if = "Option::is_none")]
+    pub frozen: Option<bool>,
+
+    #[serde(rename = "amt", skip_serializing_if = "Option::is_none")]
+    pub amount: Option<u64>,
+
+    #[serde(rename = "apaa", skip_serializing_if = "Option::is_none")]
+    pub app_arguments: Option<Vec<AppArgument>>,
+
+    #[serde(rename = "apan", skip_serializing_if = "Option::is_none")]
+    pub on_complete: Option<u32>,
+
+    #[serde(
+        default,
+        rename = "apap",
+        with = "serde_bytes",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub approval_program: Option<Vec<u8>>,
+
+    #[serde(rename = "apar", skip_serializing_if = "Option::is_none")]
+    pub asset_params: Option<ApiAssetParams>,
+
+    #[serde(rename = "apas", skip_serializing_if = "Option::is_none")]
+    pub foreign_assets: Option<Vec<u64>>,
+
+    #[serde(rename = "apat", skip_serializing_if = "Option::is_none")]
+    pub accounts: Option<Vec<Address>>,
+
+    #[serde(rename = "apep", skip_serializing_if = "Option::is_none")]
+    pub extra_pages: Option<u32>,
+
+    #[serde(rename = "apfa", skip_serializing_if = "Option::is_none")]
+    pub foreign_apps: Option<Vec<u64>>,
+
+    #[serde(rename = "apgs", skip_serializing_if = "Option::is_none")]
+    pub global_state_schema: Option<ApiStateSchema>,
+
+    #[serde(rename = "apid", skip_serializing_if = "Option::is_none")]
+    pub app_id: Option<u64>,
+
+    #[serde(rename = "apls", skip_serializing_if = "Option::is_none")]
+    pub local_state_schema: Option<ApiStateSchema>,
+
+    #[serde(
+        default,
+        rename = "apsu",
+        with = "serde_bytes",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub clear_state_program: Option<Vec<u8>>,
+
+    #[serde(rename = "arcv", skip_serializing_if = "Option::is_none")]
+    pub asset_receiver: Option<Address>,
+
+    #[serde(rename = "asnd", skip_serializing_if = "Option::is_none")]
+    pub asset_sender: Option<Address>,
+
+    #[serde(rename = "caid", skip_serializing_if = "Option::is_none")]
+    pub config_asset: Option<u64>,
+
+    #[serde(rename = "close", skip_serializing_if = "Option::is_none")]
+    pub close_reminder_to: Option<Address>,
+
+    #[serde(rename = "fadd", skip_serializing_if = "Option::is_none")]
+    pub freeze_account: Option<Address>,
+
+    #[serde(rename = "faid", skip_serializing_if = "Option::is_none")]
+    pub asset_id: Option<u64>,
+
+    #[serde(rename = "fee", skip_serializing_if = "Option::is_none")]
+    pub fee: Option<MicroAlgos>, // optional for serialization zero value omission
+
+    #[serde(rename = "fv", skip_serializing_if = "Option::is_none")]
+    pub first_valid: Option<Round>, // optional for serialization zero value (technically possible) omission
+
+    #[serde(rename = "gen", skip_serializing_if = "Option::is_none")]
+    pub genesis_id: Option<String>,
+
+    #[serde(rename = "gh")]
+    pub genesis_hash: HashDigest,
+
+    #[serde(rename = "grp", skip_serializing_if = "Option::is_none")]
+    pub group: Option<HashDigest>,
+
+    #[serde(rename = "lv", skip_serializing_if = "Option::is_none")]
+    pub last_valid: Option<Round>, // optional for serialization zero value (technically possible) omission
+
+    #[serde(rename = "lx", skip_serializing_if = "Option::is_none")]
+    pub lease: Option<HashDigest>,
+
+    #[serde(rename = "nonpart", skip_serializing_if = "Option::is_none")]
+    pub nonparticipating: Option<bool>,
+
+    #[serde(
+        default,
+        rename = "note",
+        with = "serde_bytes",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub note: Option<Vec<u8>>,
+
+    #[serde(rename = "rcv", skip_serializing_if = "Option::is_none")]
+    pub receiver: Option<Address>,
+
+    #[serde(rename = "rekey", skip_serializing_if = "Option::is_none")]
+    pub rekey_to: Option<Address>,
+
+    #[serde(rename = "selkey", skip_serializing_if = "Option::is_none")]
+    pub selection_pk: Option<VrfPk>,
+
+    #[serde(rename = "snd")]
+    pub sender: Address,
+
+    #[serde(rename = "type")]
+    pub type_: String,
+
+    #[serde(rename = "votefst", skip_serializing_if = "Option::is_none")]
+    pub vote_first: Option<Round>,
+
+    #[serde(rename = "votekd", skip_serializing_if = "Option::is_none")]
+    pub vote_key_dilution: Option<u64>,
+
+    #[serde(rename = "votekey", skip_serializing_if = "Option::is_none")]
+    pub vote_pk: Option<VotePk>,
+
+    #[serde(rename = "votelst", skip_serializing_if = "Option::is_none")]
+    pub vote_last: Option<Round>,
+
+    #[serde(rename = "xaid", skip_serializing_if = "Option::is_none")]
+    pub xfer: Option<u64>,
+}
+
+#[derive(Default, Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+pub struct ApiSignedLogicArg(#[serde(with = "serde_bytes")] pub Vec<u8>);
+
+#[derive(Default, Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+pub struct ApiSignedLogic {
+    #[serde(rename = "arg")]
+    pub args: Vec<ApiSignedLogicArg>,
+    #[serde(rename = "l", with = "serde_bytes")]
+    pub logic: Vec<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub msig: Option<MultisigSignature>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sig: Option<Signature>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ApiSignedTransaction {
+    #[serde(rename = "lsig", skip_serializing_if = "Option::is_none")]
+    pub lsig: Option<ApiSignedLogic>,
+
+    #[serde(rename = "msig", skip_serializing_if = "Option::is_none")]
+    pub msig: Option<MultisigSignature>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sig: Option<Signature>,
+
+    #[serde(rename = "txn")]
+    pub transaction: ApiTransaction,
+
+    #[serde(skip)]
+    pub transaction_id: String,
+}
+
+#[derive(Default, Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+pub struct AppArgument(#[serde(with = "serde_bytes")] pub Vec<u8>);
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct ApiAssetParams {
+    #[serde(rename = "am", skip_serializing_if = "Option::is_none")]
+    pub meta_data_hash: Option<Vec<u8>>,
+
+    #[serde(rename = "an", skip_serializing_if = "Option::is_none")]
+    pub asset_name: Option<String>,
+
+    #[serde(rename = "au", skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+
+    #[serde(rename = "c", skip_serializing_if = "Option::is_none")]
+    pub clawback: Option<Address>,
+
+    #[serde(rename = "dc", skip_serializing_if = "Option::is_none")]
+    pub decimals: Option<u32>,
+
+    #[serde(rename = "df", skip_serializing)]
+    pub default_frozen: Option<bool>,
+
+    #[serde(rename = "f", skip_serializing_if = "Option::is_none")]
+    pub freeze: Option<Address>,
+
+    #[serde(rename = "m", skip_serializing_if = "Option::is_none")]
+    pub manager: Option<Address>,
+
+    #[serde(rename = "r", skip_serializing_if = "Option::is_none")]
+    pub reserve: Option<Address>,
+
+    #[serde(rename = "t", skip_serializing_if = "Option::is_none")]
+    pub total: Option<u64>,
+
+    #[serde(rename = "un", skip_serializing_if = "Option::is_none")]
+    pub unit_name: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ApiStateSchema {
+    #[serde(rename = "nbs", skip_serializing_if = "Option::is_none")]
+    pub number_byteslices: Option<u64>,
+
+    #[serde(rename = "nui", skip_serializing_if = "Option::is_none")]
+    pub number_ints: Option<u64>,
+}
+
+impl ToMsgPack for ApiTransaction {}
+impl ToMsgPack for ApiSignedTransaction {}

--- a/algonaut_transaction/src/api_model.rs
+++ b/algonaut_transaction/src/api_model.rs
@@ -1,181 +1,23 @@
 use std::convert::{TryFrom, TryInto};
 
-use algonaut_core::{
-    Address, CompiledTeal, LogicSignature, MicroAlgos, MultisigSignature, Round, SignedLogic,
-    ToMsgPack, TransactionTypeEnum, VotePk, VrfPk,
-};
-use algonaut_crypto::{HashDigest, Signature};
-use num_traits::Num;
-use serde::{Deserialize, Serialize};
-
 use crate::{
     error::TransactionError,
     transaction::{
-        ApplicationCallOnComplete, ApplicationCallTransaction, AssetAcceptTransaction,
-        AssetClawbackTransaction, AssetConfigurationTransaction, AssetFreezeTransaction,
-        AssetParams, AssetTransferTransaction, KeyRegistration, Payment, StateSchema,
-        TransactionSignature,
+        to_tx_type_enum, ApplicationCallOnComplete, ApplicationCallTransaction,
+        AssetAcceptTransaction, AssetClawbackTransaction, AssetConfigurationTransaction,
+        AssetFreezeTransaction, AssetParams, AssetTransferTransaction, KeyRegistration, Payment,
+        SignedLogic, StateSchema, TransactionSignature,
     },
     tx_group::TxGroup,
     SignedTransaction, Transaction, TransactionType,
 };
-
-/// IMPORTANT:
-/// When serializing:
-/// - Fields have to be sorted alphabetically.
-/// - Keys must be excluded if they've a "zero value" (e.g. the number 0 or an empty vector) 😬.
-/// otherwise the node's signature validation will fail.
-/// When deserializing:
-/// - Non existent keys can mean None or a semantic zero value, depending on context 😬.
-///
-/// Note that to date the REST API documentation specifies explicitly zero values for some fields, which is incorrect.
-/// https://github.com/algorand/docs/pull/454, https://github.com/algorand/docs/issues/415 (not comprehensive)
-///
-/// We intentionally don't use `skip_serializing_if` for values other than `Option` for a consistent representation of optionals.
-///
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct ApiTransaction {
-    #[serde(rename = "aamt", skip_serializing_if = "Option::is_none")]
-    pub asset_amount: Option<u64>,
-
-    #[serde(rename = "aclose", skip_serializing_if = "Option::is_none")]
-    pub asset_close_to: Option<Address>,
-
-    #[serde(rename = "afrz", skip_serializing_if = "Option::is_none")]
-    pub frozen: Option<bool>,
-
-    #[serde(rename = "amt", skip_serializing_if = "Option::is_none")]
-    pub amount: Option<u64>,
-
-    #[serde(rename = "apaa", skip_serializing_if = "Option::is_none")]
-    pub app_arguments: Option<Vec<AppArgument>>,
-
-    #[serde(rename = "apan", skip_serializing_if = "Option::is_none")]
-    pub on_complete: Option<u32>,
-
-    #[serde(
-        default,
-        rename = "apap",
-        with = "serde_bytes",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub approval_program: Option<Vec<u8>>,
-
-    #[serde(rename = "apar", skip_serializing_if = "Option::is_none")]
-    pub asset_params: Option<ApiAssetParams>,
-
-    #[serde(rename = "apas", skip_serializing_if = "Option::is_none")]
-    pub foreign_assets: Option<Vec<u64>>,
-
-    #[serde(rename = "apat", skip_serializing_if = "Option::is_none")]
-    pub accounts: Option<Vec<Address>>,
-
-    #[serde(rename = "apep", skip_serializing_if = "Option::is_none")]
-    pub extra_pages: Option<u32>,
-
-    #[serde(rename = "apfa", skip_serializing_if = "Option::is_none")]
-    pub foreign_apps: Option<Vec<u64>>,
-
-    #[serde(rename = "apgs", skip_serializing_if = "Option::is_none")]
-    pub global_state_schema: Option<ApiStateSchema>,
-
-    #[serde(rename = "apid", skip_serializing_if = "Option::is_none")]
-    pub app_id: Option<u64>,
-
-    #[serde(rename = "apls", skip_serializing_if = "Option::is_none")]
-    pub local_state_schema: Option<ApiStateSchema>,
-
-    #[serde(
-        default,
-        rename = "apsu",
-        with = "serde_bytes",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub clear_state_program: Option<Vec<u8>>,
-
-    #[serde(rename = "arcv", skip_serializing_if = "Option::is_none")]
-    pub asset_receiver: Option<Address>,
-
-    #[serde(rename = "asnd", skip_serializing_if = "Option::is_none")]
-    pub asset_sender: Option<Address>,
-
-    #[serde(rename = "caid", skip_serializing_if = "Option::is_none")]
-    pub config_asset: Option<u64>,
-
-    #[serde(rename = "close", skip_serializing_if = "Option::is_none")]
-    pub close_reminder_to: Option<Address>,
-
-    #[serde(rename = "fadd", skip_serializing_if = "Option::is_none")]
-    pub freeze_account: Option<Address>,
-
-    #[serde(rename = "faid", skip_serializing_if = "Option::is_none")]
-    pub asset_id: Option<u64>,
-
-    #[serde(rename = "fee", skip_serializing_if = "Option::is_none")]
-    pub fee: Option<MicroAlgos>, // optional for serialization zero value omission
-
-    #[serde(rename = "fv", skip_serializing_if = "Option::is_none")]
-    pub first_valid: Option<Round>, // optional for serialization zero value (technically possible) omission
-
-    #[serde(rename = "gen", skip_serializing_if = "Option::is_none")]
-    pub genesis_id: Option<String>,
-
-    #[serde(rename = "gh")]
-    pub genesis_hash: HashDigest,
-
-    #[serde(rename = "grp", skip_serializing_if = "Option::is_none")]
-    pub group: Option<HashDigest>,
-
-    #[serde(rename = "lv", skip_serializing_if = "Option::is_none")]
-    pub last_valid: Option<Round>, // optional for serialization zero value (technically possible) omission
-
-    #[serde(rename = "lx", skip_serializing_if = "Option::is_none")]
-    pub lease: Option<HashDigest>,
-
-    #[serde(rename = "nonpart", skip_serializing_if = "Option::is_none")]
-    pub nonparticipating: Option<bool>,
-
-    #[serde(
-        default,
-        rename = "note",
-        with = "serde_bytes",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub note: Option<Vec<u8>>,
-
-    #[serde(rename = "rcv", skip_serializing_if = "Option::is_none")]
-    pub receiver: Option<Address>,
-
-    #[serde(rename = "rekey", skip_serializing_if = "Option::is_none")]
-    pub rekey_to: Option<Address>,
-
-    #[serde(rename = "selkey", skip_serializing_if = "Option::is_none")]
-    pub selection_pk: Option<VrfPk>,
-
-    #[serde(rename = "snd")]
-    pub sender: Address,
-
-    #[serde(rename = "type")]
-    pub type_: String,
-
-    #[serde(rename = "votefst", skip_serializing_if = "Option::is_none")]
-    pub vote_first: Option<Round>,
-
-    #[serde(rename = "votekd", skip_serializing_if = "Option::is_none")]
-    pub vote_key_dilution: Option<u64>,
-
-    #[serde(rename = "votekey", skip_serializing_if = "Option::is_none")]
-    pub vote_pk: Option<VotePk>,
-
-    #[serde(rename = "votelst", skip_serializing_if = "Option::is_none")]
-    pub vote_last: Option<Round>,
-
-    #[serde(rename = "xaid", skip_serializing_if = "Option::is_none")]
-    pub xfer: Option<u64>,
-}
-
-#[derive(Default, Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
-pub struct AppArgument(#[serde(with = "serde_bytes")] Vec<u8>);
+use algonaut_core::{CompiledTeal, LogicSignature, MicroAlgos, Round, ToMsgPack};
+use algonaut_model::transaction::{
+    ApiAssetParams, ApiSignedLogic, ApiSignedLogicArg, ApiSignedTransaction, ApiStateSchema,
+    ApiTransaction, AppArgument,
+};
+use num_traits::Num;
+use serde::{Deserialize, Serialize};
 
 impl From<Transaction> for ApiTransaction {
     fn from(t: Transaction) -> Self {
@@ -480,43 +322,6 @@ fn transaction_signature(
         ))),
     }
 }
-
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
-pub struct ApiAssetParams {
-    #[serde(rename = "am", skip_serializing_if = "Option::is_none")]
-    pub meta_data_hash: Option<Vec<u8>>,
-
-    #[serde(rename = "an", skip_serializing_if = "Option::is_none")]
-    pub asset_name: Option<String>,
-
-    #[serde(rename = "au", skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
-
-    #[serde(rename = "c", skip_serializing_if = "Option::is_none")]
-    pub clawback: Option<Address>,
-
-    #[serde(rename = "dc", skip_serializing_if = "Option::is_none")]
-    pub decimals: Option<u32>,
-
-    #[serde(rename = "df", skip_serializing)]
-    pub default_frozen: Option<bool>,
-
-    #[serde(rename = "f", skip_serializing_if = "Option::is_none")]
-    pub freeze: Option<Address>,
-
-    #[serde(rename = "m", skip_serializing_if = "Option::is_none")]
-    pub manager: Option<Address>,
-
-    #[serde(rename = "r", skip_serializing_if = "Option::is_none")]
-    pub reserve: Option<Address>,
-
-    #[serde(rename = "t", skip_serializing_if = "Option::is_none")]
-    pub total: Option<u64>,
-
-    #[serde(rename = "un", skip_serializing_if = "Option::is_none")]
-    pub unit_name: Option<String>,
-}
-
 impl From<AssetParams> for ApiAssetParams {
     fn from(params: AssetParams) -> Self {
         ApiAssetParams {
@@ -553,40 +358,6 @@ impl From<ApiAssetParams> for AssetParams {
     }
 }
 
-// TODO move this somewhere else and make api_model non pub again
-pub fn to_tx_type_enum(type_: &TransactionType) -> TransactionTypeEnum {
-    match type_ {
-        TransactionType::Payment(_) => TransactionTypeEnum::Payment,
-        TransactionType::KeyRegistration(_) => TransactionTypeEnum::KeyRegistration,
-        TransactionType::AssetConfigurationTransaction(_) => {
-            TransactionTypeEnum::AssetConfiguration
-        }
-        TransactionType::AssetTransferTransaction(_)
-        | TransactionType::AssetAcceptTransaction(_)
-        | TransactionType::AssetClawbackTransaction(_) => TransactionTypeEnum::AssetTransfer,
-        TransactionType::AssetFreezeTransaction(_) => TransactionTypeEnum::AssetFreeze,
-        TransactionType::ApplicationCallTransaction(_) => TransactionTypeEnum::ApplicationCall,
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct ApiSignedTransaction {
-    #[serde(rename = "lsig", skip_serializing_if = "Option::is_none")]
-    pub lsig: Option<ApiSignedLogic>,
-
-    #[serde(rename = "msig", skip_serializing_if = "Option::is_none")]
-    pub msig: Option<MultisigSignature>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub sig: Option<Signature>,
-
-    #[serde(rename = "txn")]
-    pub transaction: ApiTransaction,
-
-    #[serde(skip)]
-    pub transaction_id: String,
-}
-
 impl From<SignedTransaction> for ApiSignedTransaction {
     fn from(t: SignedTransaction) -> Self {
         let (sig, msig, lsig) = match t.sig {
@@ -602,15 +373,6 @@ impl From<SignedTransaction> for ApiSignedTransaction {
             transaction_id: t.transaction_id,
         }
     }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct ApiStateSchema {
-    #[serde(rename = "nbs", skip_serializing_if = "Option::is_none")]
-    pub number_byteslices: Option<u64>,
-
-    #[serde(rename = "nui", skip_serializing_if = "Option::is_none")]
-    pub number_ints: Option<u64>,
 }
 
 impl From<StateSchema> for Option<ApiStateSchema> {
@@ -637,8 +399,6 @@ impl From<ApiStateSchema> for StateSchema {
     }
 }
 
-impl ToMsgPack for ApiTransaction {}
-impl ToMsgPack for ApiSignedTransaction {}
 impl ToMsgPack for Transaction {}
 impl ToMsgPack for SignedTransaction {}
 impl ToMsgPack for TxGroup {}
@@ -688,21 +448,6 @@ impl<'de> Deserialize<'de> for SignedTransaction {
     }
 }
 
-#[derive(Default, Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
-struct ApiSignedLogicArg(#[serde(with = "serde_bytes")] Vec<u8>);
-
-#[derive(Default, Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
-pub struct ApiSignedLogic {
-    #[serde(rename = "arg")]
-    args: Vec<ApiSignedLogicArg>,
-    #[serde(rename = "l", with = "serde_bytes")]
-    pub logic: Vec<u8>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub msig: Option<MultisigSignature>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub sig: Option<Signature>,
-}
-
 impl From<SignedLogic> for ApiSignedLogic {
     fn from(s: SignedLogic) -> Self {
         let (sig, msig) = match s.sig {
@@ -716,28 +461,6 @@ impl From<SignedLogic> for ApiSignedLogic {
             msig,
             args: s.args.into_iter().map(ApiSignedLogicArg).collect(),
         }
-    }
-}
-
-impl TryFrom<ApiSignedLogic> for SignedLogic {
-    type Error = TransactionError;
-
-    fn try_from(s: ApiSignedLogic) -> Result<Self, Self::Error> {
-        let sig = match (s.sig, s.msig) {
-            (Some(sig), None) => LogicSignature::DelegatedSig(sig),
-            (None, Some(msig)) => LogicSignature::DelegatedMultiSig(msig),
-            (None, None) => LogicSignature::ContractAccount,
-            _ => {
-                return Err(TransactionError::Deserialization(
-                    "Invalid sig/msig combination".to_owned(),
-                ))
-            }
-        };
-        Ok(SignedLogic {
-            logic: CompiledTeal(s.logic),
-            args: s.args.into_iter().map(|a| a.0).collect(),
-            sig,
-        })
     }
 }
 

--- a/algonaut_transaction/src/contract_account.rs
+++ b/algonaut_transaction/src/contract_account.rs
@@ -1,6 +1,6 @@
 use crate::error::TransactionError;
-use crate::transaction::{SignedTransaction, Transaction, TransactionSignature};
-use algonaut_core::{Address, CompiledTeal, LogicSignature, SignedLogic};
+use crate::transaction::{SignedLogic, SignedTransaction, Transaction, TransactionSignature};
+use algonaut_core::{Address, CompiledTeal, LogicSignature};
 use serde::{Deserialize, Serialize};
 
 /// Convenience CompiledTeal "view", used to sign as contract account.

--- a/algonaut_transaction/src/lib.rs
+++ b/algonaut_transaction/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod account;
-pub mod api_model; // TODO revert pub
+mod api_model;
 pub mod auction;
 pub mod builder;
 pub mod contract_account;

--- a/examples/logic_sig_delegated.rs
+++ b/examples/logic_sig_delegated.rs
@@ -1,8 +1,9 @@
 use algonaut::algod::v2::Algod;
-use algonaut::core::{LogicSignature, MicroAlgos, SignedLogic};
+use algonaut::core::{LogicSignature, MicroAlgos};
 use algonaut::transaction::transaction::TransactionSignature;
 use algonaut::transaction::{account::Account, TxnBuilder};
 use algonaut::transaction::{Pay, SignedTransaction};
+use algonaut_transaction::transaction::SignedLogic;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/logic_sig_delegated_multi.rs
+++ b/examples/logic_sig_delegated_multi.rs
@@ -1,8 +1,9 @@
 use algonaut::algod::v2::Algod;
-use algonaut::core::{LogicSignature, MicroAlgos, MultisigAddress, SignedLogic};
+use algonaut::core::{LogicSignature, MicroAlgos, MultisigAddress};
 use algonaut::transaction::transaction::TransactionSignature;
 use algonaut::transaction::{account::Account, TxnBuilder};
 use algonaut::transaction::{Pay, SignedTransaction};
+use algonaut_transaction::transaction::SignedLogic;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/src/algod/v2/mod.rs
+++ b/src/algod/v2/mod.rs
@@ -167,7 +167,8 @@ impl Algod {
     /// This endpoint is only enabled when a node's configureation file sets EnableDeveloperAPI
     /// to true.
     pub async fn dryrun_teal(&self, req: &DryrunRequest) -> Result<DryrunResponse, ServiceError> {
-        Ok(self.client.dryrun_teal(req).await?)
+        let bytes = req.to_msg_pack()?;
+        Ok(self.client.dryrun_teal(bytes).await?)
     }
 
     /// Broadcasts a transaction to the network.

--- a/src/atomic_transaction_composer/mod.rs
+++ b/src/atomic_transaction_composer/mod.rs
@@ -12,10 +12,11 @@ use algonaut_core::{Address, CompiledTeal, SuggestedTransactionParams};
 use algonaut_crypto::HashDigest;
 use algonaut_model::algod::v2::PendingTransaction;
 use algonaut_transaction::{
-    api_model::to_tx_type_enum,
     builder::TxnFee,
     error::TransactionError,
-    transaction::{ApplicationCallOnComplete, ApplicationCallTransaction, StateSchema},
+    transaction::{
+        to_tx_type_enum, ApplicationCallOnComplete, ApplicationCallTransaction, StateSchema,
+    },
     tx_group::TxGroup,
     SignedTransaction, Transaction, TransactionType, TxnBuilder,
 };

--- a/tests/test_account.rs
+++ b/tests/test_account.rs
@@ -1,9 +1,9 @@
-use algonaut_core::{Address, CompiledTeal, LogicSignature, MicroAlgos, Round, SignedLogic};
+use algonaut_core::{Address, CompiledTeal, LogicSignature, MicroAlgos, Round};
 use algonaut_core::{MultisigAddress, ToMsgPack};
 use algonaut_crypto::HashDigest;
 use algonaut_transaction::account::Account;
 use algonaut_transaction::builder::TxnFee;
-use algonaut_transaction::transaction::TransactionSignature;
+use algonaut_transaction::transaction::{TransactionSignature, SignedLogic};
 use algonaut_transaction::{Pay, SignedTransaction, TxnBuilder};
 use data_encoding::{BASE64, HEXLOWER};
 use std::convert::TryInto;

--- a/tests/test_account.rs
+++ b/tests/test_account.rs
@@ -3,7 +3,7 @@ use algonaut_core::{MultisigAddress, ToMsgPack};
 use algonaut_crypto::HashDigest;
 use algonaut_transaction::account::Account;
 use algonaut_transaction::builder::TxnFee;
-use algonaut_transaction::transaction::{TransactionSignature, SignedLogic};
+use algonaut_transaction::transaction::{SignedLogic, TransactionSignature};
 use algonaut_transaction::{Pay, SignedTransaction, TxnBuilder};
 use data_encoding::{BASE64, HEXLOWER};
 use std::convert::TryInto;

--- a/tests/test_logic_signature.rs
+++ b/tests/test_logic_signature.rs
@@ -1,8 +1,6 @@
+use algonaut_core::{CompiledTeal, LogicSignature, MultisigAddress};
+use algonaut_transaction::{account::Account, error::TransactionError, transaction::SignedLogic};
 use std::error::Error;
-
-use algonaut_core::{CompiledTeal, LogicSignature, MultisigAddress, SignedLogic};
-
-use algonaut_transaction::{account::Account, error::TransactionError};
 use tokio::test;
 
 // Reference:


### PR DESCRIPTION
Had to move some models around to be able to reference `ApiSignedTransaction` (previously in the transactions package) from `DryrunRequest` (which makes sense to keeps in the models package).

Further, nothing was working, changed the request format to msg pack, fixed deserialization etc.