### PR TITLE
Rename axfrz to afrz

### DIFF
--- a/algonaut_model/src/indexer/v2/mod.rs
+++ b/algonaut_model/src/indexer/v2/mod.rs
@@ -1380,7 +1380,7 @@ pub enum TransactionType {
     AssetConfigurationTransaction,
     #[serde(rename = "axfer")]
     AssetTransferTransaction,
-    #[serde(rename = "axfrz")]
+    #[serde(rename = "afrz")]
     AssetFreezeTransaction,
     #[serde(rename = "appl")]
     ApplicationTransaction,


### PR DESCRIPTION
Bug using the indexer to parse transactions if the tx type was ever asset freeze. Simple fix
s/axfrz/afrz