### PR TITLE
Fix asset deserialization of metadata_hash field when it is missed

### DIFF
--- a/algonaut_algod/src/models/asset_params.rs
+++ b/algonaut_algod/src/models/asset_params.rs
@@ -37,7 +37,8 @@ pub struct AssetParams {
     #[serde(
         rename = "metadata-hash",
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_opt_hash"
+        deserialize_with = "deserialize_opt_hash",
+        default
     )]
     pub metadata_hash: Option<HashDigest>,
     /// \\[an\\] Name of this asset, as supplied by the creator. Included only when the asset name is composed of printable utf-8 characters.


### PR DESCRIPTION
When it deserializes `models::Asset` from an API call like `let asset = client.asset(1903271236).await?;
 ` and when `metadata_hash` is missed there is an error of `Error: Msg: Serde(Error("missing field `metadata-hash`", line: 1, column: 312))`

the little fix of adding `#[serde(default)]` to the field attribute fixes this issue