### PR TITLE
chore: hoist dependency versions to workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,40 +24,85 @@ members = [
   "algonaut_abi",
 ]
 
-[dependencies]
+[workspace.dependencies]
+algonaut_abi = { path = "algonaut_abi", version = "0.4.2" }
 algonaut_algod = { path = "algonaut_algod", version = "0.4.2" }
-algonaut_model = { path = "algonaut_model", version = "0.4.2" }
 algonaut_core = { path = "algonaut_core", version = "0.4.2" }
 algonaut_crypto = { path = "algonaut_crypto", version = "0.4.2" }
 algonaut_encoding = { path = "algonaut_encoding", version = "0.4.2" }
-algonaut_indexer = { path = "algonaut_indexer", version = "0.4.2", default-features = false }
+algonaut_indexer = { path = "algonaut_indexer", version = "0.4.2" }
 algonaut_kmd = { path = "algonaut_kmd", version = "0.4.2", default-features = false }
+algonaut_model = { path = "algonaut_model", version = "0.4.2" }
 algonaut_transaction = { path = "algonaut_transaction", version = "0.4.2" }
-algonaut_abi = { path = "algonaut_abi", version = "0.4.2" }
+
+async-trait = "0.1.89"
+cucumber = "0.23.0"
 data-encoding = "2.11.0"
+derive_more = "2.1.1"
+dotenv = "0.15.0"
 env_logger = "0.11.10"
 futures-timer = "3.0.3"
-instant = { version = "0.1", features = ["now"] }
+getrandom = "0.2"
+gloo-timers = "0.4.0"
+indexmap = "2.14.0"
+instant = "0.1"
+lazy_static = "1.5.0"
 log = "0.4.29"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
+rand = "0.8.5"
+regex = "1.12.3"
 reqwest = "0.13.3"
+ring = "0.17.14"
 rmp-serde = "1.3.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_bytes = "0.11.19"
+serde_derive = "1.0"
 serde_json = "1.0.149"
+serde_with = "3.20.0"
 sha2 = "0.11.0"
+static_assertions = "1.1.0"
 thiserror = "2.0.18"
+tokio = "1.52.3"
+url = "2.5.8"
+urlencoding = "2.1.3"
+uuid = { version = "1.23", features = ["serde"] }
+
+[dependencies]
+algonaut_abi = { workspace = true }
+algonaut_algod = { workspace = true }
+algonaut_core = { workspace = true }
+algonaut_crypto = { workspace = true }
+algonaut_encoding = { workspace = true }
+algonaut_indexer = { workspace = true }
+algonaut_kmd = { workspace = true }
+algonaut_model = { workspace = true }
+algonaut_transaction = { workspace = true }
+
+data-encoding = { workspace = true }
+env_logger = { workspace = true }
+futures-timer = { workspace = true }
+instant = { workspace = true, features = ["now"] }
+log = { workspace = true }
+num-bigint = { workspace = true }
+num-traits = { workspace = true }
+reqwest = { workspace = true }
+rmp-serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-gloo-timers = { version = "0.4.0", features = ["futures"] }
-instant = { version = "0.1", features = ["now", "wasm-bindgen"] }
+gloo-timers = { workspace = true, features = ["futures"] }
+instant = { workspace = true, features = ["now", "wasm-bindgen"] }
 
 [dev-dependencies]
-dotenv = "0.15.0"
-tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros"] }
-rand = "0.8.5"
-getrandom = { version = "0.2", features = ["js"] }
-cucumber = "0.23.0"
-async-trait = "0.1.89"
+async-trait = { workspace = true }
+cucumber = { workspace = true }
+dotenv = { workspace = true }
+getrandom = { workspace = true, features = ["js"] }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [features]
 default = ["native"]

--- a/algonaut_abi/Cargo.toml
+++ b/algonaut_abi/Cargo.toml
@@ -9,16 +9,16 @@ repository = "https://github.com/manuelmauro/algonaut"
 version = "0.4.2"
 
 [dependencies]
-algonaut_core = {path = "../algonaut_core", version = "0.4.2"}
-serde = {version = "1.0", features = ["derive"]}
-regex = "1.12.3"
-lazy_static = "1.5.0"
-sha2 = "0.11.0"
-derive_more = { version = "2.1.1", features = ["display", "from"] }
-thiserror = "2.0.18"
-num-bigint = "0.4.6"
+algonaut_core = { workspace = true }
+derive_more = { workspace = true, features = ["display", "from"] }
+lazy_static = { workspace = true }
+num-bigint = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-serde_json = "1.0.149"
-rand = "0.8.5"
-num-bigint = { version = "0.4.6", features = ["rand"] }
+num-bigint = { workspace = true, features = ["rand"] }
+rand = { workspace = true }
+serde_json = { workspace = true }

--- a/algonaut_algod/Cargo.toml
+++ b/algonaut_algod/Cargo.toml
@@ -8,15 +8,13 @@ license = "MIT"
 edition = "2024"
 
 [dependencies]
-algonaut_crypto = { path = "../algonaut_crypto", version = "0.4.2" }
-algonaut_encoding = { path = "../algonaut_encoding", version = "0.4.2" }
-algonaut_model = { path = "../algonaut_model", version = "0.4.2" }
-algonaut_transaction = { path = "../algonaut_transaction", version = "0.4.2" }
-serde = "^1.0"
-serde_derive = "^1.0"
-serde_json = "^1.0"
-url = "^2.5"
-uuid = { version = "^1.23", features = ["serde"] }
-[dependencies.reqwest]
-version = "^0.13"
-features = ["json", "multipart", "query"]
+algonaut_crypto = { workspace = true }
+algonaut_encoding = { workspace = true }
+algonaut_model = { workspace = true }
+algonaut_transaction = { workspace = true }
+reqwest = { workspace = true, features = ["json", "multipart", "query"] }
+serde = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true }

--- a/algonaut_core/Cargo.toml
+++ b/algonaut_core/Cargo.toml
@@ -9,16 +9,16 @@ repository = "https://github.com/manuelmauro/algonaut"
 version = "0.4.2"
 
 [dependencies]
-algonaut_crypto = {path = "../algonaut_crypto", version = "0.4.2"}
-algonaut_encoding = {path = "../algonaut_encoding", version = "0.4.2"}
-data-encoding = "2.11.0"
-derive_more = { version = "2.1.1", features = ["add", "display", "from"] }
-serde = {version = "1.0", features = ["derive"]}
-sha2 = "0.11.0"
-static_assertions = "1.1.0"
-rmp-serde = "1.3.1"
-thiserror = "2.0.18"
-ring = "0.17.14"
+algonaut_crypto = { workspace = true }
+algonaut_encoding = { workspace = true }
+data-encoding = { workspace = true }
+derive_more = { workspace = true, features = ["add", "display", "from"] }
+ring = { workspace = true }
+rmp-serde = { workspace = true }
+serde = { workspace = true }
+sha2 = { workspace = true }
+static_assertions = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-rand = "0.8.5"
+rand = { workspace = true }

--- a/algonaut_crypto/Cargo.toml
+++ b/algonaut_crypto/Cargo.toml
@@ -12,13 +12,13 @@ repository = "https://github.com/manuelmauro/algonaut"
 version = "0.4.2"
 
 [dependencies]
-algonaut_encoding = { path = "../algonaut_encoding", version = "0.4.2" }
-data-encoding = "2.11.0"
-derive_more = { version = "2.1.1", features = ["display", "from"] }
-indexmap = "2.14.0"
-lazy_static = "1.5.0"
-serde = { version = "1.0", features = ["derive"] }
-sha2 = "0.11.0"
-static_assertions = "1.1.0"
-thiserror = "2.0.18"
-ring = "0.17.14"
+algonaut_encoding = { workspace = true }
+data-encoding = { workspace = true }
+derive_more = { workspace = true, features = ["display", "from"] }
+indexmap = { workspace = true }
+lazy_static = { workspace = true }
+ring = { workspace = true }
+serde = { workspace = true }
+sha2 = { workspace = true }
+static_assertions = { workspace = true }
+thiserror = { workspace = true }

--- a/algonaut_encoding/Cargo.toml
+++ b/algonaut_encoding/Cargo.toml
@@ -9,5 +9,5 @@ repository = "https://github.com/manuelmauro/algonaut"
 version = "0.4.2"
 
 [dependencies]
-data-encoding = "2.11.0"
-serde = {version = "1.0", features = ["derive"]}
+data-encoding = { workspace = true }
+serde = { workspace = true }

--- a/algonaut_indexer/Cargo.toml
+++ b/algonaut_indexer/Cargo.toml
@@ -8,13 +8,11 @@ license = "MIT"
 edition = "2024"
 
 [dependencies]
-algonaut_crypto = { path = "../algonaut_crypto", version = "0.4.2" }
-algonaut_encoding = { path = "../algonaut_encoding", version = "0.4.2" }
-serde = "^1.0"
-serde_derive = "^1.0"
-serde_json = "^1.0"
-url = "^2.5"
-uuid = { version = "^1.23", features = ["serde"] }
-[dependencies.reqwest]
-version = "^0.13"
-features = ["json", "multipart", "query"]
+algonaut_crypto = { workspace = true }
+algonaut_encoding = { workspace = true }
+reqwest = { workspace = true, features = ["json", "multipart", "query"] }
+serde = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true }

--- a/algonaut_kmd/Cargo.toml
+++ b/algonaut_kmd/Cargo.toml
@@ -12,25 +12,25 @@ repository = "https://github.com/manuelmauro/algonaut"
 version = "0.4.2"
 
 [dependencies]
-algonaut_model = { path = "../algonaut_model", version = "0.4.2" }
-algonaut_core = { path = "../algonaut_core", version = "0.4.2" }
-algonaut_crypto = { path = "../algonaut_crypto", version = "0.4.2" }
-algonaut_encoding = { path = "../algonaut_encoding", version = "0.4.2" }
-data-encoding = "2.11.0"
-derive_more = { version = "2.1.1", features = ["display"] }
-reqwest = { version = "0.13", features = ["json"], default-features = false }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.149"
-thiserror = "2.0.18"
-url = "2.5.8"
-async-trait = "0.1.89"
-rmp-serde = "1.3.1"
+algonaut_core = { workspace = true }
+algonaut_crypto = { workspace = true }
+algonaut_encoding = { workspace = true }
+algonaut_model = { workspace = true }
+async-trait = { workspace = true }
+data-encoding = { workspace = true }
+derive_more = { workspace = true, features = ["display"] }
+reqwest = { version = "0.13.3", default-features = false, features = ["json"] }
+rmp-serde = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
-dotenv = "0.15.0"
-rand = "0.8.5"
-getrandom = { version = "0.2", features = ["js"] }
-tokio = { version = "1.52.3", features = ["macros"] }
+dotenv = { workspace = true }
+getrandom = { workspace = true, features = ["js"] }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
 
 [features]
 default = ["native"]

--- a/algonaut_model/Cargo.toml
+++ b/algonaut_model/Cargo.toml
@@ -12,12 +12,11 @@ repository = "https://github.com/manuelmauro/algonaut"
 version = "0.4.2"
 
 [dependencies]
-algonaut_core = { path = "../algonaut_core", version = "0.4.2" }
-algonaut_crypto = { path = "../algonaut_crypto", version = "0.4.2" }
-algonaut_encoding = { path = "../algonaut_encoding", version = "0.4.2" }
-data-encoding = "2.11.0"
-# derive_more = "0.99.13"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.149"
-serde_bytes = "0.11.19"
-serde_with = "3.20.0"
+algonaut_core = { workspace = true }
+algonaut_crypto = { workspace = true }
+algonaut_encoding = { workspace = true }
+data-encoding = { workspace = true }
+serde = { workspace = true }
+serde_bytes = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true }

--- a/algonaut_transaction/Cargo.toml
+++ b/algonaut_transaction/Cargo.toml
@@ -12,22 +12,22 @@ repository = "https://github.com/manuelmauro/algonaut"
 version = "0.4.2"
 
 [dependencies]
-algonaut_core = { path = "../algonaut_core", version = "0.4.2" }
-algonaut_crypto = { path = "../algonaut_crypto", version = "0.4.2" }
-algonaut_encoding = { path = "../algonaut_encoding", version = "0.4.2" }
-algonaut_model = { path = "../algonaut_model", version = "0.4.2" }
-algonaut_abi = { path = "../algonaut_abi", version = "0.4.2" }
-data-encoding = "2.11.0"
-derive_more = "2.1.1"
-rand = "0.8.5"
-getrandom = { version = "0.2", features = ["js"] }
-ring = "0.17.14"
-rmp-serde = "1.3.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_bytes = "0.11.19"
-sha2 = "0.11.0"
-thiserror = "2.0.18"
-url = "2.5.8"
-urlencoding = "2.1.3"
-num-traits = "0.2.19"
-num-bigint = "0.4.6"
+algonaut_abi = { workspace = true }
+algonaut_core = { workspace = true }
+algonaut_crypto = { workspace = true }
+algonaut_encoding = { workspace = true }
+algonaut_model = { workspace = true }
+data-encoding = { workspace = true }
+derive_more = { workspace = true }
+getrandom = { workspace = true, features = ["js"] }
+num-bigint = { workspace = true }
+num-traits = { workspace = true }
+rand = { workspace = true }
+ring = { workspace = true }
+rmp-serde = { workspace = true }
+serde = { workspace = true }
+serde_bytes = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+url = { workspace = true }
+urlencoding = { workspace = true }


### PR DESCRIPTION
3/4 in the stack. **Base: \`chore/edition-2024\` (#243).** Merge that one first; once it lands this PR should be retargeted to \`main\`.

## Summary
- Move every external crate version (and the internal \`algonaut_*\` path entries) into the root \`[workspace.dependencies]\` table.
- Subcrates now inherit via \`{ workspace = true }\`, adding only the per-crate feature flags they need (e.g. \`derive_more\` features, \`reqwest\` endpoint features, \`getrandom\`'s \`js\`).
- Adding a new external dep is now a one-line change in the root manifest.

## Caveat
\`algonaut_kmd\` keeps an inline \`reqwest\` entry. Cargo doesn't allow a workspace member to override \`default-features\` from the workspace baseline (and kmd needs \`default-features = false\` so its \`native\`/\`rustls\` features control the TLS backend). The other reqwest consumers (algod, indexer, root) inherit cleanly.

## Test plan
- [x] \`make ci\` passes
- [x] Single \`cargo build --workspace\` resolves the lockfile identically to before