### PR TITLE
ci: run cucumber integration tests in GitHub Actions

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -68,10 +68,11 @@ jobs:
 
   cargo-test-integration:
     name: cargo-test-integration
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -79,6 +79,12 @@ jobs:
           key: integration
       - name: Bring up the algorand test harness
         run: ./test-harness.sh up
+      - name: Dump sandbox.log on harness failure
+        if: failure()
+        run: |
+          test -f test-harness/.sandbox/sandbox.log \
+            && cat test-harness/.sandbox/sandbox.log \
+            || echo "No sandbox.log to dump."
       - name: Run cucumber integration tests
         run: cargo test --test features_runner --
       - name: Tear down the algorand test harness

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -65,3 +65,21 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --lib --examples --tests
+
+  cargo-test-integration:
+    name: cargo-test-integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: integration
+      - name: Bring up the algorand test harness
+        run: ./test-harness.sh up
+      - name: Run cucumber integration tests
+        run: cargo test --test features_runner --
+      - name: Tear down the algorand test harness
+        if: always()
+        run: ./test-harness.sh down

--- a/test.env
+++ b/test.env
@@ -5,7 +5,7 @@ SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0
 
-VERBOSE_HARNESS=0
+VERBOSE_HARNESS=1
 
 # WARNING: If set to 1, new features will be LOST when downloading the test harness.
 # REGARDLESS: modified features are ALWAYS overwritten.


### PR DESCRIPTION
## Summary
Bring the cucumber integration suite into GH Actions (it disappeared with CircleCI in #247).

- New \`cargo-test-integration\` job: \`./test-harness.sh up\` (clones \`algorand/algorand-sdk-testing\` and brings up its docker sandbox), then \`cargo test --test features_runner --\` (= \`make integration\`).
- Tears the harness down on every exit path.
- Skips the legacy \`Dockerfile\` entirely — it pins Rust 1.65 which won't compile the 2024 edition.
- 30-minute timeout cap.

## Plan
1. Verify the job goes green on this PR.
2. Merge.
3. Add \`cargo-test-integration\` to branch protection's required status checks.

## Test plan
- [ ] All five existing checks pass
- [ ] \`cargo-test-integration\` passes