### PR TITLE
chore(release): bump workspace to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-05-18
 
 ### Added
 
 - Hoist every external dependency version into the root `[workspace.dependencies]` table; subcrates inherit via `{ workspace = true }` (#244)
 - Add `lefthook.yml` running `make ci` on pre-commit and enforcing Conventional Commits on commit-msg (#242)
 - Expand the `Makefile` with `setup`, `fmt[-check]`, `clippy`, `check[-release]`, `check-wasm`, `build[-release]`, `test[-release]`, `ci`, `doc`, and `help` targets while preserving the existing integration/harness/docker targets (#242)
+- GitHub Actions runs the cucumber integration tests against an algorand sandbox harness, replacing the retired CircleCI job; promoted to a required check on `main` (#247, #248)
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["Algorand", "sdk"]
 license = "MIT"
 name = "algonaut"
 repository = "https://github.com/manuelmauro/algonaut"
-version = "0.4.2"
+version = "0.5.0"
 
 [workspace]
 members = [
@@ -25,15 +25,15 @@ members = [
 ]
 
 [workspace.dependencies]
-algonaut_abi = { path = "algonaut_abi", version = "0.4.2" }
-algonaut_algod = { path = "algonaut_algod", version = "0.4.2" }
-algonaut_core = { path = "algonaut_core", version = "0.4.2" }
-algonaut_crypto = { path = "algonaut_crypto", version = "0.4.2" }
-algonaut_encoding = { path = "algonaut_encoding", version = "0.4.2" }
-algonaut_indexer = { path = "algonaut_indexer", version = "0.4.2" }
-algonaut_kmd = { path = "algonaut_kmd", version = "0.4.2", default-features = false }
-algonaut_model = { path = "algonaut_model", version = "0.4.2" }
-algonaut_transaction = { path = "algonaut_transaction", version = "0.4.2" }
+algonaut_abi = { path = "algonaut_abi", version = "0.5.0" }
+algonaut_algod = { path = "algonaut_algod", version = "0.5.0" }
+algonaut_core = { path = "algonaut_core", version = "0.5.0" }
+algonaut_crypto = { path = "algonaut_crypto", version = "0.5.0" }
+algonaut_encoding = { path = "algonaut_encoding", version = "0.5.0" }
+algonaut_indexer = { path = "algonaut_indexer", version = "0.5.0" }
+algonaut_kmd = { path = "algonaut_kmd", version = "0.5.0", default-features = false }
+algonaut_model = { path = "algonaut_model", version = "0.5.0" }
+algonaut_transaction = { path = "algonaut_transaction", version = "0.5.0" }
 
 async-trait = "0.1.89"
 cucumber = "0.23.0"

--- a/algonaut_abi/Cargo.toml
+++ b/algonaut_abi/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["Algorand", "sdk"]
 license = "MIT"
 name = "algonaut_abi"
 repository = "https://github.com/manuelmauro/algonaut"
-version = "0.4.2"
+version = "0.5.0"
 
 [dependencies]
 algonaut_core = { workspace = true }

--- a/algonaut_algod/Cargo.toml
+++ b/algonaut_algod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "algonaut_algod"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["contact@algorand.com"]
 description = "API endpoint for algod operations."
 # Override this license by providing a License Object in the OpenAPI.

--- a/algonaut_core/Cargo.toml
+++ b/algonaut_core/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["Algorand", "sdk"]
 license = "MIT"
 name = "algonaut_core"
 repository = "https://github.com/manuelmauro/algonaut"
-version = "0.4.2"
+version = "0.5.0"
 
 [dependencies]
 algonaut_crypto = { workspace = true }

--- a/algonaut_crypto/Cargo.toml
+++ b/algonaut_crypto/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["Algorand", "sdk"]
 license = "MIT"
 name = "algonaut_crypto"
 repository = "https://github.com/manuelmauro/algonaut"
-version = "0.4.2"
+version = "0.5.0"
 
 [dependencies]
 algonaut_encoding = { workspace = true }

--- a/algonaut_encoding/Cargo.toml
+++ b/algonaut_encoding/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["Algorand", "sdk"]
 license = "MIT"
 name = "algonaut_encoding"
 repository = "https://github.com/manuelmauro/algonaut"
-version = "0.4.2"
+version = "0.5.0"
 
 [dependencies]
 data-encoding = { workspace = true }

--- a/algonaut_indexer/Cargo.toml
+++ b/algonaut_indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "algonaut_indexer"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "Algorand ledger analytics API."
 # Override this license by providing a License Object in the OpenAPI.

--- a/algonaut_kmd/Cargo.toml
+++ b/algonaut_kmd/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["Algorand", "sdk"]
 license = "MIT"
 name = "algonaut_kmd"
 repository = "https://github.com/manuelmauro/algonaut"
-version = "0.4.2"
+version = "0.5.0"
 
 [dependencies]
 algonaut_core = { workspace = true }

--- a/algonaut_model/Cargo.toml
+++ b/algonaut_model/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["Algorand", "sdk"]
 license = "MIT"
 name = "algonaut_model"
 repository = "https://github.com/manuelmauro/algonaut"
-version = "0.4.2"
+version = "0.5.0"
 
 [dependencies]
 algonaut_core = { workspace = true }

--- a/algonaut_transaction/Cargo.toml
+++ b/algonaut_transaction/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["Algorand", "sdk"]
 license = "MIT"
 name = "algonaut_transaction"
 repository = "https://github.com/manuelmauro/algonaut"
-version = "0.4.2"
+version = "0.5.0"
 
 [dependencies]
 algonaut_abi = { workspace = true }


### PR DESCRIPTION
## Summary
Release the deps/edition/workspace/wasm/CI sweep landed in #242, #244, #245, #246, #247, #248.

- Every workspace crate (10 total) bumped from 0.4.2 to 0.5.0.
- Internal path entries in \`[workspace.dependencies]\` bumped to match.
- CHANGELOG: \`[Unreleased]\` section moved to \`[0.5.0] - 2026-05-18\`.

Minor bump per 0.x semver: MSRV jumps to 1.85, \`Account\` internal shape changes (ring → ed25519-dalek), several dep majors are now exposed.

## Test plan
- [x] \`make ci\` passes locally
- [ ] All six required GitHub Actions checks pass on this PR