### PR TITLE
test(cucumber): wire algod.feature

### DIFF
--- a/tests/features_runner.rs
+++ b/tests/features_runner.rs
@@ -50,7 +50,7 @@ const INTEGRATION_FEATURES: &[Feature] = &[
     },
     Feature {
         path: "tests/features/integration/algod.feature",
-        gate: Some("step-defs pending; SDK supports get_supply/version"),
+        gate: None,
     },
     Feature {
         path: "tests/features/integration/assets.feature",

--- a/tests/step_defs/integration/algod.rs
+++ b/tests/step_defs/integration/algod.rs
@@ -1,0 +1,30 @@
+use crate::step_defs::integration::world::World;
+use cucumber::{then, when};
+
+#[then(expr = "the node should be healthy")]
+async fn the_node_should_be_healthy(w: &mut World) {
+    let algod = w.algod.as_ref().expect("algod not set");
+    algod.health().await.expect("health check failed");
+}
+
+#[then(expr = "I get the ledger supply")]
+async fn i_get_the_ledger_supply(w: &mut World) {
+    let algod = w.algod.as_ref().expect("algod not set");
+    algod.supply().await.expect("supply call failed");
+}
+
+#[when(expr = "I get versions with algod")]
+async fn i_get_versions_with_algod(w: &mut World) {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let version = algod.version().await.expect("version call failed");
+    w.versions = Some(version.versions);
+}
+
+#[then(regex = r#"^(v\d+) should be in the versions$"#)]
+async fn version_should_be_in_the_versions(w: &mut World, expected: String) {
+    let versions = w.versions.as_ref().expect("versions not fetched");
+    assert!(
+        versions.iter().any(|v| v == &expected),
+        "expected {expected} in versions, got {versions:?}"
+    );
+}

--- a/tests/step_defs/integration/mod.rs
+++ b/tests/step_defs/integration/mod.rs
@@ -1,4 +1,5 @@
 pub mod abi;
+pub mod algod;
 pub mod applications;
 pub mod general;
 pub mod world;

--- a/tests/step_defs/integration/world.rs
+++ b/tests/step_defs/integration/world.rs
@@ -42,4 +42,6 @@ pub struct World {
     pub abi_method_arg_types: Option<Vec<AbiType>>,
     pub abi_method_arg_values: Option<Vec<AbiArgValue>>,
     pub tx_composer_res: Option<ExecuteResult>,
+
+    pub versions: Option<Vec<String>>,
 }


### PR DESCRIPTION
**Stacked on top of #250.**

## Summary
- Covers the three scenarios from algorand-sdk-testing's \`algod.feature\`: node health, ledger supply, version listing
- Pure step-def glue — \`Algod::health\`, \`Algod::supply\`, \`Algod::version\` already exist
- Flips the runner gate for \`algod.feature\` from \`Some(...)\` to \`None\`

## Test plan
- [ ] CI green on standard checks
- [ ] After harness boots, \`cargo test --test features_runner --\` exercises the three new scenarios