### PR TITLE
test(cucumber): wire compile.feature (sans source-map)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ cucumber = { workspace = true }
 dotenv = { workspace = true }
 getrandom = { workspace = true, features = ["js"] }
 rand = { workspace = true }
+regex = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [features]

--- a/tests/features_runner.rs
+++ b/tests/features_runner.rs
@@ -13,7 +13,8 @@
 //! either:
 //!
 //! - **Live** (`gate: None`) — wired to a step-def module and exercised
-//!   by CI.
+//!   by CI. Individual scenarios can still be excluded with
+//!   `excluded_tags` while the rest of the feature runs.
 //! - **Stubbed** (`gate: Some(reason)`) — listed for visibility, skipped
 //!   at runtime until the gating ADR lands.
 //!
@@ -33,56 +34,72 @@ struct Feature {
     path: &'static str,
     /// `None` => live, `Some(reason)` => skipped with rationale.
     gate: Option<&'static str>,
+    /// Scenario tags to *exclude* from the run (e.g. ones blocked on an
+    /// ADR while the rest of the feature is live).
+    excluded_tags: &'static [&'static str],
 }
 
 const INTEGRATION_FEATURES: &[Feature] = &[
     Feature {
         path: "tests/features/integration/applications.feature",
         gate: None,
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/integration/abi.feature",
         gate: None,
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/integration/c2c.feature",
         gate: None,
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/integration/algod.feature",
         gate: None,
+        excluded_tags: &[],
+    },
+    Feature {
+        path: "tests/features/integration/compile.feature",
+        gate: None,
+        // Source-map scenario is blocked on ADR teal-source-map-decoder.
+        excluded_tags: &["compile.sourcemap"],
     },
     Feature {
         path: "tests/features/integration/assets.feature",
         gate: Some("step-defs pending; SDK supports asset create/transfer/freeze/destroy"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/integration/auction.feature",
         gate: Some("step-defs pending; SDK ships algonaut_transaction::auction::Bid"),
-    },
-    Feature {
-        path: "tests/features/integration/compile.feature",
-        gate: Some("partial: source-map decoder missing — ADR teal-source-map-decoder"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/integration/dryrun.feature",
         gate: Some("blocked on ADR dryrun-request-builder"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/integration/dryrun_testing.feature",
         gate: Some("blocked on ADR dryrun-request-builder"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/integration/kmd.feature",
         gate: Some("step-defs pending; SDK has the kmd v1 surface"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/integration/rekey.feature",
         gate: Some("step-defs pending; SDK supports rekey_to on TxnBuilder"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/integration/send.feature",
         gate: Some("step-defs pending; SDK supports send_txn/send_txns"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/integration/simulate.feature",
@@ -90,6 +107,7 @@ const INTEGRATION_FEATURES: &[Feature] = &[
             "blocked on ADRs simulaterequest-model-needs-power-pack-fields and \
              atomictransactioncomposer-simulate-convenience",
         ),
+        excluded_tags: &[],
     },
 ];
 
@@ -97,77 +115,96 @@ const UNIT_FEATURES: &[Feature] = &[
     Feature {
         path: "tests/features/unit/abijson.feature",
         gate: Some("blocked on ADR cucumber-unit-test-scaffolding"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/unit/algodclient_paths.feature",
         gate: Some("blocked on ADR cucumber-unit-test-scaffolding"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/unit/atomic_transaction_composer.feature",
         gate: Some("blocked on ADR cucumber-unit-test-scaffolding"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/unit/client-no-headers.feature",
         gate: Some("blocked on ADR cucumber-unit-test-scaffolding"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/unit/dryrun_trace.feature",
         gate: Some("blocked on ADRs dryrun-request-builder and cucumber-unit-test-scaffolding"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/unit/feetest.feature",
         gate: Some("blocked on ADR cucumber-unit-test-scaffolding"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/unit/offline.feature",
         gate: Some("blocked on ADR cucumber-unit-test-scaffolding"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/unit/program_sanity_check.feature",
         gate: Some("blocked on ADR cucumber-unit-test-scaffolding"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/unit/rekey.feature",
         gate: Some("blocked on ADR cucumber-unit-test-scaffolding"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/unit/responses.feature",
         gate: Some("blocked on ADR cucumber-unit-test-scaffolding"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/unit/sourcemap.feature",
         gate: Some("blocked on ADRs teal-source-map-decoder and cucumber-unit-test-scaffolding"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/unit/tealsign.feature",
         gate: Some("blocked on ADR cucumber-unit-test-scaffolding"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/unit/transactions.feature",
         gate: Some("blocked on ADR cucumber-unit-test-scaffolding"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/unit/v2algodclient_paths.feature",
         gate: Some("blocked on ADR cucumber-unit-test-scaffolding"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/unit/v2algodclient_responses.feature",
         gate: Some("blocked on ADR cucumber-unit-test-scaffolding"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/unit/v2indexerclient_paths.feature",
         gate: Some("blocked on ADR cucumber-unit-test-scaffolding"),
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/unit/v2indexerclient_responses.feature",
         gate: Some("blocked on ADR cucumber-unit-test-scaffolding"),
+        excluded_tags: &[],
     },
 ];
 
-async fn run_integration(path: &str) {
+async fn run_integration(path: &str, excluded_tags: &'static [&'static str]) {
     integration::world::World::cucumber()
         .max_concurrent_scenarios(1)
-        .run(path)
+        .filter_run(path, move |_, _, sc| {
+            !sc.tags.iter().any(|t| excluded_tags.iter().any(|x| x == t))
+        })
         .await;
 }
 
@@ -177,7 +214,7 @@ async fn main() {
 
     for feature in INTEGRATION_FEATURES.iter().chain(UNIT_FEATURES.iter()) {
         match feature.gate {
-            None => run_integration(feature.path).await,
+            None => run_integration(feature.path, feature.excluded_tags).await,
             Some(reason) => skipped.push((feature.path, reason)),
         }
     }

--- a/tests/step_defs/integration/compile.rs
+++ b/tests/step_defs/integration/compile.rs
@@ -1,0 +1,71 @@
+use crate::step_defs::integration::world::World;
+use algonaut_core::Address;
+use cucumber::{then, when};
+use data_encoding::BASE64;
+use std::fs;
+
+fn read_resource(name: &str) -> Vec<u8> {
+    fs::read(format!("tests/features/resources/{name}"))
+        .unwrap_or_else(|e| panic!("failed to read tests/features/resources/{name}: {e}"))
+}
+
+fn parse_status_from_error(err: &str) -> u16 {
+    regex::Regex::new(r"status:\s*(\d+)")
+        .unwrap()
+        .captures(err)
+        .and_then(|c| c.get(1))
+        .and_then(|m| m.as_str().parse().ok())
+        .unwrap_or(0)
+}
+
+#[when(regex = r#"^I compile a teal program "([^"]+)"$"#)]
+async fn i_compile_a_teal_program(w: &mut World, program: String) {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let source = read_resource(&program);
+
+    match algod.teal_compile(&source, None).await {
+        Ok(compiled) => {
+            let hash: Address = compiled.hash().into();
+            w.compile_status = Some(200);
+            w.compile_result = Some(BASE64.encode(&compiled.0));
+            w.compile_hash = Some(hash.to_string());
+            w.compiled_program = Some(compiled.0);
+        }
+        Err(e) => {
+            w.compile_status = Some(parse_status_from_error(&e.to_string()));
+            w.compile_result = Some(String::new());
+            w.compile_hash = Some(String::new());
+            w.compiled_program = None;
+        }
+    }
+}
+
+#[then(regex = r#"^it is compiled with (\d+) and "([^"]*)" and "([^"]*)"$"#)]
+async fn it_is_compiled_with(w: &mut World, status: u16, result: String, hash: String) {
+    assert_eq!(w.compile_status, Some(status), "compile status mismatch");
+    assert_eq!(w.compile_result.as_deref(), Some(result.as_str()));
+    assert_eq!(w.compile_hash.as_deref(), Some(hash.as_str()));
+}
+
+#[then(regex = r#"^base64 decoding the response is the same as the binary "([^"]+)"$"#)]
+async fn base64_decoding_response_matches_binary(w: &mut World, binary: String) {
+    let compiled = w
+        .compiled_program
+        .as_ref()
+        .expect("compiled program not set");
+    let expected = read_resource(&binary);
+    assert_eq!(compiled, &expected, "compiled bytes differ from {binary}");
+}
+
+#[then(regex = r#"^disassembly of "([^"]+)" matches "([^"]+)"$"#)]
+async fn disassembly_matches(w: &mut World, bytecode_filename: String, source_filename: String) {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let bytecode = read_resource(&bytecode_filename);
+    let expected_source = String::from_utf8(read_resource(&source_filename))
+        .expect("source filename is not valid UTF-8");
+    let resp = algod
+        .teal_disassemble(&bytecode)
+        .await
+        .expect("teal_disassemble failed");
+    assert_eq!(resp.result, expected_source, "disassembly mismatch");
+}

--- a/tests/step_defs/integration/mod.rs
+++ b/tests/step_defs/integration/mod.rs
@@ -1,5 +1,6 @@
 pub mod abi;
 pub mod algod;
 pub mod applications;
+pub mod compile;
 pub mod general;
 pub mod world;

--- a/tests/step_defs/integration/world.rs
+++ b/tests/step_defs/integration/world.rs
@@ -44,4 +44,9 @@ pub struct World {
     pub tx_composer_res: Option<ExecuteResult>,
 
     pub versions: Option<Vec<String>>,
+
+    pub compile_status: Option<u16>,
+    pub compile_result: Option<String>,
+    pub compile_hash: Option<String>,
+    pub compiled_program: Option<Vec<u8>>,
 }


### PR DESCRIPTION
**Stacked on top of #250 → algod PR.**

## Summary
- Covers \`@compile\` and \`@compile.disassemble\` scenarios from \`compile.feature\`
- \`@compile.sourcemap\` stays excluded via the new \`excluded_tags\` field on \`Feature\`, in line with ADR \`teal-source-map-decoder\`
- Adds \`excluded_tags\` to the runner struct and switches \`run_integration\` to \`filter_run\` so individual scenarios can be skipped while the rest of the feature runs
- Adds \`regex\` to dev-dependencies for parsing HTTP status out of debug-formatted algod errors

## Test plan
- [ ] CI green on standard checks
- [ ] After harness boots, \`cargo test --test features_runner --\` runs the compile scenarios and skips the sourcemap one