### PR TITLE
test(cucumber): wire send.feature (sans keyregtxn)

### DIFF
--- a/docs/adr/keyregistration-v2-state-proof-key.md
+++ b/docs/adr/keyregistration-v2-state-proof-key.md
@@ -1,0 +1,74 @@
+---
+id: keyregistration-v2-state-proof-key
+title: KeyRegistration v2 state-proof key
+abstract: Add state_proof_key to KeyRegistration so online key-registration transactions match the v2 consensus surface used by send.feature.
+status: proposed
+date: 2026-05-18
+deciders: []
+tags: []
+---
+
+# KeyRegistration v2 state-proof key
+
+## Status
+
+Proposed
+
+## Context
+
+`tests/features/integration/send.feature` includes a
+`@send.keyregtxn` scenario that exercises **V2** key registration with
+the `online`, `offline`, and `nonparticipation` variants. Other SDKs
+build the online variant from a fixed test fixture that includes a
+state-proof public key (`sprfkey`, a 64-byte BLS public key):
+
+```python
+transaction.KeyregOnlineTxn(
+    sender, params,
+    votekey="9PYsmlBevatTWVRcfDLqzpyaURRTbjPo+oTrFkXgKHE=",
+    selkey="UkpZx9Vfo0Q1+/8mE2KCDdQ72Y0AKEK9DnFvL3yWZ2c=",
+    sprfkey="WaA5UWiVDzD6QY/ZxNi0Pc4xL4FxQa3kjlrZmkSMcEUjGFQqRGo3CSNZ9D8GAr+5e7TgQHM2RfsdJ4yLpcfkRA==",
+    votefst=0, votelst=30001, votekd=10000, nonpart=False,
+)
+```
+
+Our `algonaut_transaction::transaction::KeyRegistration` model omits
+the state-proof key and the corresponding builder
+`RegisterKey::online` does not accept one. Since the v34 consensus
+upgrade, online registration requires `sprfkey`; without it the algod
+harness rejects the transaction. Offline and nonparticipation variants
+are fine — they don't carry vote material.
+
+## Decision
+
+1. Extend `algonaut_transaction::transaction::KeyRegistration` with
+   `state_proof_key: Option<StateProofPk>` where `StateProofPk` is a
+   newtype around `[u8; 64]` (matching the protocol's BLS key length).
+2. Update the msgpack serialization to write `sprfkey` (no field when
+   `None` — protocol allows for offline/nonparticipation).
+3. Extend `RegisterKey::online` to accept the state-proof key:
+   ```rust
+   pub fn online(
+       sender: Address,
+       vote_pk: VotePk,
+       selection_pk: VrfPk,
+       state_proof_key: StateProofPk,
+       vote_first: Round,
+       vote_last: Round,
+       vote_key_dilution: u64,
+   ) -> Self;
+   ```
+4. Provide a small helper to base64-decode the algorand-sdk-testing
+   fixture keys for tests.
+
+## Consequences
+
+- The `@send.keyregtxn` scenario unblocks fully — online / offline /
+  nonparticipation all become reachable.
+- `RegisterKey::online`'s signature changes (additive parameter), so
+  this is a breaking change for any caller using online registration
+  today. The change is small enough to justify directly given the
+  protocol requires the field.
+- Downstream tooling that builds participation keys for real nodes
+  benefits from a typed `StateProofPk` rather than the existing
+  ad-hoc plumbing.

--- a/docs/cucumber-pending-issues.md
+++ b/docs/cucumber-pending-issues.md
@@ -139,10 +139,32 @@ Three features need it:
 
 ---
 
-## 5. Scaffold a cucumber unit-test World
+## 5. Add `state_proof_key` to `KeyRegistration`
+
+**Labels:** `area/transaction`, `kind/feature`, `cucumber-blocker`
+**ADR:** [`keyregistration-v2-state-proof-key`](adr/keyregistration-v2-state-proof-key.md)
+
+```markdown
+`tests/features/integration/send.feature` has a `@send.keyregtxn`
+scenario that exercises V2 online key registration. Since the v34
+consensus upgrade, online registration requires `sprfkey` (a 64-byte
+BLS public key). Our `KeyRegistration` model omits it.
+
+### Acceptance
+- [ ] `algonaut_transaction::transaction::KeyRegistration` gains
+      `state_proof_key: Option<StateProofPk>`.
+- [ ] `RegisterKey::online` accepts the state-proof key (additive
+      breaking change to its signature).
+- [ ] Msgpack serialization writes `sprfkey` when present.
+- [ ] `@send.keyregtxn` runs green and the runner exclusion is dropped.
+```
+
+---
+
+## 6. Scaffold a cucumber unit-test World
 
 **Labels:** `area/tests`, `kind/infra`, `cucumber-blocker`
-**ADR:** [`cucumber-unit-test-scaffolding`](cucumber-unit-test-scaffolding.md)
+**ADR:** [`cucumber-unit-test-scaffolding`](adr/cucumber-unit-test-scaffolding.md)
 
 ```markdown
 The 17 features under `tests/features/unit/` don't need a live algod
@@ -167,7 +189,7 @@ Proposed work:
 
 ---
 
-## 6. (No issue) Expand step-def coverage for already-supported features
+## 7. (No issue) Expand step-def coverage for already-supported features
 
 The remaining work is mechanical step-def writing for features where
 the SDK already covers the underlying capability. These do **not**

--- a/tests/features_runner.rs
+++ b/tests/features_runner.rs
@@ -98,8 +98,10 @@ const INTEGRATION_FEATURES: &[Feature] = &[
     },
     Feature {
         path: "tests/features/integration/send.feature",
-        gate: Some("step-defs pending; SDK supports send_txn/send_txns"),
-        excluded_tags: &[],
+        gate: None,
+        // Online keyreg requires sprfkey — blocked on ADR
+        // keyregistration-v2-state-proof-key.
+        excluded_tags: &["send.keyregtxn"],
     },
     Feature {
         path: "tests/features/integration/simulate.feature",

--- a/tests/step_defs/integration/mod.rs
+++ b/tests/step_defs/integration/mod.rs
@@ -3,4 +3,5 @@ pub mod algod;
 pub mod applications;
 pub mod compile;
 pub mod general;
+pub mod send;
 pub mod world;

--- a/tests/step_defs/integration/send.rs
+++ b/tests/step_defs/integration/send.rs
@@ -1,0 +1,151 @@
+use crate::step_defs::{integration::world::World, util::account_from_kmd_response};
+use algonaut_core::{MicroAlgos, MultisigAddress};
+use algonaut_transaction::{Pay, SignedTransaction, TxnBuilder, transaction::TransactionSignature};
+use cucumber::{given, then, when};
+use data_encoding::BASE64;
+use std::error::Error;
+
+async fn build_default_payment(
+    w: &mut World,
+    sender_index: usize,
+    receiver_index: usize,
+    amt: u64,
+    note_b64: &str,
+) -> Result<(), Box<dyn Error>> {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let accounts = w.accounts.as_ref().expect("accounts not set");
+    let params = algod.txn_params().await?;
+    let note = if note_b64.is_empty() {
+        Vec::new()
+    } else {
+        BASE64.decode(note_b64.as_bytes())?
+    };
+
+    let mut tx_builder = TxnBuilder::with(
+        &params,
+        Pay::new(
+            accounts[sender_index],
+            accounts[receiver_index],
+            MicroAlgos(amt),
+        )
+        .build(),
+    );
+    if !note.is_empty() {
+        tx_builder = tx_builder.note(note.clone());
+    }
+    w.tx = Some(tx_builder.build()?);
+    w.note = Some(note);
+    Ok(())
+}
+
+#[given(regex = r#"^default transaction with parameters (\d+) "([^"]*)"$"#)]
+async fn default_transaction_with_parameters(
+    w: &mut World,
+    amt: u64,
+    note_b64: String,
+) -> Result<(), Box<dyn Error>> {
+    build_default_payment(w, 0, 1, amt, &note_b64).await
+}
+
+#[given(regex = r#"^default multisig transaction with parameters (\d+) "([^"]*)"$"#)]
+async fn default_multisig_transaction_with_parameters(
+    w: &mut World,
+    amt: u64,
+    note_b64: String,
+) -> Result<(), Box<dyn Error>> {
+    let algod = w.algod.as_ref().expect("algod not set").clone();
+    let accounts = w.accounts.as_ref().expect("accounts not set").clone();
+
+    let msig =
+        MultisigAddress::new(1, 1, &accounts).map_err(|e| format!("invalid multisig: {e}"))?;
+    let params = algod.txn_params().await?;
+    let note = if note_b64.is_empty() {
+        Vec::new()
+    } else {
+        BASE64.decode(note_b64.as_bytes())?
+    };
+
+    let mut tx_builder = TxnBuilder::with(
+        &params,
+        Pay::new(msig.address(), accounts[1], MicroAlgos(amt)).build(),
+    );
+    if !note.is_empty() {
+        tx_builder = tx_builder.note(note.clone());
+    }
+    w.tx = Some(tx_builder.build()?);
+    w.note = Some(note);
+    w.multisig = Some(msig);
+    Ok(())
+}
+
+#[when(expr = "I get the private key")]
+async fn i_get_the_private_key(w: &mut World) -> Result<(), Box<dyn Error>> {
+    let kmd = w.kmd.as_ref().expect("kmd not set");
+    let handle = w.handle.as_ref().expect("wallet handle not set");
+    let password = w.password.as_ref().expect("wallet password not set");
+    let tx = w.tx.as_ref().expect("tx not set");
+
+    // For a multisig sender we need to export the key of *one* of the
+    // multisig participants (we always sign with accounts[0]). Otherwise
+    // export the key of the tx sender itself.
+    let address = match &w.multisig {
+        Some(_) => w.accounts.as_ref().expect("accounts not set")[0],
+        None => tx.sender(),
+    };
+    let key_resp = kmd.export_key(handle, password, &address).await?;
+    w.sender_account = Some(account_from_kmd_response(&key_resp)?);
+    Ok(())
+}
+
+#[when(expr = "I sign the transaction with the private key")]
+async fn i_sign_the_transaction_with_the_private_key(w: &mut World) -> Result<(), Box<dyn Error>> {
+    let account = w.sender_account.as_ref().expect("sender account not set");
+    let tx = w.tx.as_ref().expect("tx not set");
+    w.signed_tx = Some(account.sign_transaction(tx.clone())?);
+    Ok(())
+}
+
+#[when(expr = "I sign the multisig transaction with the private key")]
+async fn i_sign_the_multisig_transaction_with_the_private_key(
+    w: &mut World,
+) -> Result<(), Box<dyn Error>> {
+    let account = w.sender_account.as_ref().expect("sender account not set");
+    let msig = w.multisig.as_ref().expect("multisig not set");
+    let tx = w.tx.as_ref().expect("tx not set");
+
+    let multisig_sig = account.init_transaction_msig(tx, msig)?;
+    let transaction_id = tx.id()?;
+    w.signed_tx = Some(SignedTransaction {
+        transaction: tx.clone(),
+        transaction_id,
+        sig: TransactionSignature::Multi(multisig_sig),
+        auth_address: None,
+    });
+    Ok(())
+}
+
+#[when(expr = "I send the transaction")]
+#[when(expr = "I send the multisig transaction")]
+async fn i_send_the_transaction(w: &mut World) {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let signed = w.signed_tx.as_ref().expect("signed tx not set");
+
+    match algod.send_txn(signed).await {
+        Ok(resp) => {
+            w.tx_id = Some(resp.tx_id);
+            w.last_send_succeeded = Some(true);
+        }
+        Err(_) => {
+            w.last_send_succeeded = Some(false);
+        }
+    }
+}
+
+#[then(expr = "the transaction should not go through")]
+async fn the_transaction_should_not_go_through(w: &mut World) {
+    assert_eq!(
+        w.last_send_succeeded,
+        Some(false),
+        "expected send to fail, but it succeeded"
+    );
+}

--- a/tests/step_defs/integration/world.rs
+++ b/tests/step_defs/integration/world.rs
@@ -8,7 +8,7 @@ use algonaut::{
 };
 use algonaut_abi::{abi_interactions::AbiMethod, abi_type::AbiType};
 use algonaut_algod::models::TransactionParams200Response;
-use algonaut_core::Address;
+use algonaut_core::{Address, MultisigAddress};
 use algonaut_transaction::{SignedTransaction, Transaction, account::Account};
 use cucumber;
 
@@ -49,4 +49,9 @@ pub struct World {
     pub compile_result: Option<String>,
     pub compile_hash: Option<String>,
     pub compiled_program: Option<Vec<u8>>,
+
+    pub sender_account: Option<Account>,
+    pub signed_tx: Option<SignedTransaction>,
+    pub multisig: Option<MultisigAddress>,
+    pub last_send_succeeded: Option<bool>,
 }


### PR DESCRIPTION
**Stacked on top of #252.**

## Summary
- Covers \`@send\` (default payment + multisig payment) from \`send.feature\`
- Multisig scenario expects the send to fail because the multisig address has no funds — matches every other SDK's interpretation
- \`@send.keyregtxn\` stays excluded — online keyreg needs \`sprfkey\` which our \`KeyRegistration\` model lacks
- Adds ADR \`keyregistration-v2-state-proof-key\` and a pending-issues entry for that SDK gap

## Test plan
- [ ] CI green on standard checks
- [ ] After harness boots, payment + multisig scenarios run; keyregtxn stays skipped