### PR TITLE
test(cucumber): wire auction.feature

### DIFF
--- a/tests/features_runner.rs
+++ b/tests/features_runner.rs
@@ -73,7 +73,7 @@ const INTEGRATION_FEATURES: &[Feature] = &[
     },
     Feature {
         path: "tests/features/integration/auction.feature",
-        gate: Some("step-defs pending; SDK ships algonaut_transaction::auction::Bid"),
+        gate: None,
         excluded_tags: &[],
     },
     Feature {

--- a/tests/step_defs/integration/auction.rs
+++ b/tests/step_defs/integration/auction.rs
@@ -1,0 +1,52 @@
+use crate::step_defs::integration::world::World;
+use algonaut_core::Address;
+use algonaut_transaction::{
+    account::Account,
+    auction::{Bid, SignedBid},
+};
+use cucumber::{then, when};
+use std::error::Error;
+
+const BIDDER: &str = "DN7MBMCL5JQ3PFUQS7TMX5AH4EEKOBJVDUF4TCV6WERATKFLQF4MQUPZTA";
+
+#[when(expr = "I create a bid")]
+async fn i_create_a_bid(w: &mut World) -> Result<(), Box<dyn Error>> {
+    let bidder: Address = BIDDER.parse()?;
+    let bid = Bid {
+        bidder_key: bidder,
+        bid_currency: 1000,
+        bid_id: 2,
+        auction_id: 3,
+        auction_key: bidder,
+        max_price: 4,
+    };
+    w.bid = Some(bid);
+    Ok(())
+}
+
+#[when(expr = "I sign the bid")]
+async fn i_sign_the_bid(w: &mut World) -> Result<(), Box<dyn Error>> {
+    let bid = w.bid.expect("bid not created");
+    // We sign with a freshly-generated account; the test verifies the
+    // signed-bid round-trips byte-for-byte, not that the signature
+    // checks against any particular key.
+    let account = Account::generate();
+    w.signed_bid = Some(account.sign_bid(bid)?);
+    Ok(())
+}
+
+#[when(expr = "I encode and decode the bid")]
+async fn i_encode_and_decode_the_bid(w: &mut World) -> Result<(), Box<dyn Error>> {
+    let signed = w.signed_bid.expect("signed bid not set");
+    let bytes = rmp_serde::to_vec_named(&signed)?;
+    let decoded: SignedBid = rmp_serde::from_slice(&bytes)?;
+    w.signed_bid_roundtrip = Some(decoded);
+    Ok(())
+}
+
+#[then(expr = "the bid should still be the same")]
+async fn the_bid_should_still_be_the_same(w: &mut World) {
+    let original = w.signed_bid.expect("signed bid not set");
+    let decoded = w.signed_bid_roundtrip.expect("decoded signed bid not set");
+    assert_eq!(original, decoded, "signed bid mismatch after roundtrip");
+}

--- a/tests/step_defs/integration/mod.rs
+++ b/tests/step_defs/integration/mod.rs
@@ -1,6 +1,7 @@
 pub mod abi;
 pub mod algod;
 pub mod applications;
+pub mod auction;
 pub mod compile;
 pub mod general;
 pub mod rekey;

--- a/tests/step_defs/integration/world.rs
+++ b/tests/step_defs/integration/world.rs
@@ -9,7 +9,11 @@ use algonaut::{
 use algonaut_abi::{abi_interactions::AbiMethod, abi_type::AbiType};
 use algonaut_algod::models::TransactionParams200Response;
 use algonaut_core::{Address, MultisigAddress};
-use algonaut_transaction::{SignedTransaction, Transaction, account::Account};
+use algonaut_transaction::{
+    SignedTransaction, Transaction,
+    account::Account,
+    auction::{Bid, SignedBid},
+};
 use cucumber;
 
 #[derive(Default, Debug, cucumber::World)]
@@ -56,4 +60,8 @@ pub struct World {
     pub last_send_succeeded: Option<bool>,
 
     pub rekey_target: Option<Address>,
+
+    pub bid: Option<Bid>,
+    pub signed_bid: Option<SignedBid>,
+    pub signed_bid_roundtrip: Option<SignedBid>,
 }


### PR DESCRIPTION
**Stacked on top of #254.**

## Summary
- Covers the single scenario from \`auction.feature\`: construct a \`Bid\`, sign with a fresh \`Account\`, msgpack roundtrip the \`SignedBid\`, assert byte-identical
- No SDK changes required — \`algonaut_transaction::auction::{Bid, SignedBid}\` and \`Account::sign_bid\` already exist

## Test plan
- [ ] CI green on standard checks
- [ ] After harness boots, the auction scenario runs (though it is effectively a unit test — no network calls)