### PR TITLE
test(cucumber): wire assets.feature

### DIFF
--- a/tests/features_runner.rs
+++ b/tests/features_runner.rs
@@ -68,7 +68,7 @@ const INTEGRATION_FEATURES: &[Feature] = &[
     },
     Feature {
         path: "tests/features/integration/assets.feature",
-        gate: Some("step-defs pending; SDK supports asset create/transfer/freeze/destroy"),
+        gate: None,
         excluded_tags: &[],
     },
     Feature {

--- a/tests/step_defs/integration/assets.rs
+++ b/tests/step_defs/integration/assets.rs
@@ -1,0 +1,284 @@
+use crate::step_defs::integration::world::World;
+use algonaut::error::Error;
+use algonaut_algod::models::AssetParams;
+use algonaut_transaction::{
+    AcceptAsset, ClawbackAsset, CreateAsset, FreezeAsset, TransferAsset, TxnBuilder,
+    builder::{DestroyAsset, UpdateAsset},
+};
+use cucumber::{given, then, when};
+
+const UNIT_NAME: &str = "unit";
+const ASSET_NAME: &str = "name";
+const ASSET_URL: &str = "http://someurl";
+const METADATA_HASH: &[u8] = b"fACPO4nRgO55j1ndAK3W6Sgc4APkc";
+
+fn pad_metadata_hash() -> Vec<u8> {
+    let mut buf = METADATA_HASH.to_vec();
+    buf.resize(32, 0);
+    buf
+}
+
+#[given(expr = "asset test fixture")]
+async fn asset_test_fixture(w: &mut World) {
+    w.expected_asset_params = None;
+    w.asset_id = None;
+}
+
+async fn build_creation(w: &mut World, total: u64, default_frozen: bool) -> Result<(), Error> {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let accounts = w.accounts.as_ref().expect("accounts not set");
+    let creator = accounts[0];
+
+    let params = algod.txn_params().await?;
+    let create = CreateAsset::new(creator, total, 0, default_frozen)
+        .unit_name(UNIT_NAME.to_string())
+        .asset_name(ASSET_NAME.to_string())
+        .url(ASSET_URL.to_string())
+        .meta_data_hash(pad_metadata_hash())
+        .manager(creator)
+        .reserve(creator)
+        .freeze(creator)
+        .clawback(creator)
+        .build();
+
+    w.tx = Some(TxnBuilder::with(&params, create).build()?);
+
+    w.expected_asset_params = Some(AssetParams {
+        creator: creator.to_string(),
+        total,
+        decimals: 0,
+        default_frozen: Some(default_frozen),
+        unit_name: Some(UNIT_NAME.to_string()),
+        name: Some(ASSET_NAME.to_string()),
+        url: Some(ASSET_URL.to_string()),
+        manager: Some(creator.to_string()),
+        reserve: Some(creator.to_string()),
+        freeze: Some(creator.to_string()),
+        clawback: Some(creator.to_string()),
+        metadata_hash: None,
+        name_b64: None,
+        unit_name_b64: None,
+        url_b64: None,
+    });
+    Ok(())
+}
+
+#[given(regex = r"^default asset creation transaction with total issuance (\d+)$")]
+async fn default_asset_creation_transaction(w: &mut World, total: u64) -> Result<(), Error> {
+    build_creation(w, total, false).await
+}
+
+#[given(regex = r"^default-frozen asset creation transaction with total issuance (\d+)$")]
+async fn default_frozen_asset_creation_transaction(w: &mut World, total: u64) -> Result<(), Error> {
+    build_creation(w, total, true).await
+}
+
+#[when(expr = "I send the kmd-signed transaction")]
+#[then(expr = "I send the kmd-signed transaction")]
+async fn i_send_the_kmd_signed_transaction(w: &mut World) -> Result<(), Error> {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let bytes = w
+        .kmd_signed_tx_bytes
+        .as_ref()
+        .expect("kmd-signed transaction not set");
+    match algod.send_raw_txn(bytes).await {
+        Ok(resp) => {
+            w.tx_id = Some(resp.tx_id);
+            w.last_send_succeeded = Some(true);
+        }
+        Err(_) => {
+            w.last_send_succeeded = Some(false);
+        }
+    }
+    Ok(())
+}
+
+#[when(expr = "I send the bogus kmd-signed transaction")]
+async fn i_send_the_bogus_kmd_signed_transaction(w: &mut World) -> Result<(), Error> {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let bytes = w
+        .kmd_signed_tx_bytes
+        .as_ref()
+        .expect("kmd-signed transaction not set");
+    w.last_send_succeeded = Some(algod.send_raw_txn(bytes).await.is_ok());
+    Ok(())
+}
+
+#[when(expr = "I update the asset index")]
+async fn i_update_the_asset_index(w: &mut World) -> Result<(), Error> {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let tx_id = w.tx_id.as_ref().expect("no last tx id");
+    let pending = algod.pending_txn(tx_id).await?;
+    if let Some(asset_index) = pending.asset_index {
+        w.asset_id = Some(asset_index);
+    }
+    Ok(())
+}
+
+#[when(expr = "I get the asset info")]
+#[then(expr = "I get the asset info")]
+async fn i_get_the_asset_info(w: &mut World) -> Result<(), Error> {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let asset_id = w.asset_id.expect("asset id not set");
+    let asset = algod.asset(asset_id).await?;
+    w.asset_info = Some(*asset.params);
+    Ok(())
+}
+
+#[then(expr = "the asset info should match the expected asset info")]
+async fn the_asset_info_should_match_the_expected_asset_info(w: &mut World) {
+    let expected = w
+        .expected_asset_params
+        .as_ref()
+        .expect("expected asset params not set");
+    let actual = w.asset_info.as_ref().expect("asset info not fetched");
+    assert_eq!(expected.creator, actual.creator);
+    assert_eq!(expected.total, actual.total);
+    assert_eq!(expected.decimals, actual.decimals);
+    assert_eq!(
+        expected.default_frozen.unwrap_or(false),
+        actual.default_frozen.unwrap_or(false)
+    );
+    assert_eq!(expected.unit_name, actual.unit_name);
+    assert_eq!(expected.name, actual.name);
+    assert_eq!(expected.url, actual.url);
+    assert_eq!(expected.manager, actual.manager);
+    assert_eq!(expected.reserve, actual.reserve);
+    assert_eq!(expected.freeze, actual.freeze);
+    assert_eq!(expected.clawback, actual.clawback);
+}
+
+#[when(expr = "I create a no-managers asset reconfigure transaction")]
+async fn i_create_a_no_managers_asset_reconfigure_transaction(w: &mut World) -> Result<(), Error> {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let accounts = w.accounts.as_ref().expect("accounts not set");
+    let asset_id = w.asset_id.expect("asset id not set");
+    let params = algod.txn_params().await?;
+    let update = UpdateAsset::new(accounts[0], asset_id).build();
+    w.tx = Some(TxnBuilder::with(&params, update).build()?);
+    if let Some(exp) = w.expected_asset_params.as_mut() {
+        exp.manager = None;
+        exp.reserve = None;
+        exp.freeze = None;
+        exp.clawback = None;
+    }
+    Ok(())
+}
+
+#[when(expr = "I create an asset destroy transaction")]
+async fn i_create_an_asset_destroy_transaction(w: &mut World) -> Result<(), Error> {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let accounts = w.accounts.as_ref().expect("accounts not set");
+    let asset_id = w.asset_id.expect("asset id not set");
+    let params = algod.txn_params().await?;
+    let destroy = DestroyAsset::new(accounts[0], asset_id).build();
+    w.tx = Some(TxnBuilder::with(&params, destroy).build()?);
+    Ok(())
+}
+
+#[then(expr = "I should be unable to get the asset info")]
+async fn i_should_be_unable_to_get_the_asset_info(w: &mut World) {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let asset_id = w.asset_id.expect("asset id not set");
+    assert!(
+        algod.asset(asset_id).await.is_err(),
+        "expected asset info to be missing after destroy"
+    );
+}
+
+#[when(expr = "I create a transaction for a second account, signalling asset acceptance")]
+async fn i_create_a_transaction_for_a_second_account_signalling_asset_acceptance(
+    w: &mut World,
+) -> Result<(), Error> {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let accounts = w.accounts.as_ref().expect("accounts not set");
+    let asset_id = w.asset_id.expect("asset id not set");
+    let params = algod.txn_params().await?;
+    let optin = AcceptAsset::new(accounts[1], asset_id).build();
+    w.tx = Some(TxnBuilder::with(&params, optin).build()?);
+    Ok(())
+}
+
+#[when(
+    regex = r"^I create a transaction transferring (\d+) assets from creator to a second account$"
+)]
+async fn i_create_transfer_creator_to_second(w: &mut World, amount: u64) -> Result<(), Error> {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let accounts = w.accounts.as_ref().expect("accounts not set");
+    let asset_id = w.asset_id.expect("asset id not set");
+    let params = algod.txn_params().await?;
+    let xfer = TransferAsset::new(accounts[0], asset_id, amount, accounts[1]).build();
+    w.tx = Some(TxnBuilder::with(&params, xfer).build()?);
+    Ok(())
+}
+
+#[when(
+    regex = r"^I create a transaction transferring (\d+) assets from a second account to creator$"
+)]
+async fn i_create_transfer_second_to_creator(w: &mut World, amount: u64) -> Result<(), Error> {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let accounts = w.accounts.as_ref().expect("accounts not set");
+    let asset_id = w.asset_id.expect("asset id not set");
+    let params = algod.txn_params().await?;
+    let xfer = TransferAsset::new(accounts[1], asset_id, amount, accounts[0]).build();
+    w.tx = Some(TxnBuilder::with(&params, xfer).build()?);
+    Ok(())
+}
+
+#[when(regex = r"^I create a transaction revoking (\d+) assets from a second account to creator$")]
+async fn i_create_revocation(w: &mut World, amount: u64) -> Result<(), Error> {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let accounts = w.accounts.as_ref().expect("accounts not set");
+    let asset_id = w.asset_id.expect("asset id not set");
+    let params = algod.txn_params().await?;
+    let clawback =
+        ClawbackAsset::new(accounts[0], asset_id, amount, accounts[1], accounts[0]).build();
+    w.tx = Some(TxnBuilder::with(&params, clawback).build()?);
+    Ok(())
+}
+
+#[when(expr = "I create a freeze transaction targeting the second account")]
+async fn i_create_a_freeze_transaction(w: &mut World) -> Result<(), Error> {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let accounts = w.accounts.as_ref().expect("accounts not set");
+    let asset_id = w.asset_id.expect("asset id not set");
+    let params = algod.txn_params().await?;
+    let freeze = FreezeAsset::new(accounts[0], accounts[1], asset_id, true).build();
+    w.tx = Some(TxnBuilder::with(&params, freeze).build()?);
+    Ok(())
+}
+
+#[when(expr = "I create an un-freeze transaction targeting the second account")]
+async fn i_create_an_unfreeze_transaction(w: &mut World) -> Result<(), Error> {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let accounts = w.accounts.as_ref().expect("accounts not set");
+    let asset_id = w.asset_id.expect("asset id not set");
+    let params = algod.txn_params().await?;
+    let unfreeze = FreezeAsset::new(accounts[0], accounts[1], asset_id, false).build();
+    w.tx = Some(TxnBuilder::with(&params, unfreeze).build()?);
+    Ok(())
+}
+
+#[then(regex = r"^the creator should have (\d+) assets remaining$")]
+async fn the_creator_should_have_assets_remaining(
+    w: &mut World,
+    expected: u64,
+) -> Result<(), Error> {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let accounts = w.accounts.as_ref().expect("accounts not set");
+    let asset_id = w.asset_id.expect("asset id not set");
+    let info = algod.account(&accounts[0].to_string()).await?;
+    let holding = info
+        .assets
+        .as_deref()
+        .unwrap_or(&[])
+        .iter()
+        .find(|h| h.asset_id == asset_id)
+        .ok_or_else(|| Error::Msg(format!("creator does not hold asset {asset_id}")))?;
+    assert_eq!(
+        holding.amount, expected,
+        "creator holds {} of asset {asset_id}, expected {expected}",
+        holding.amount
+    );
+    Ok(())
+}

--- a/tests/step_defs/integration/mod.rs
+++ b/tests/step_defs/integration/mod.rs
@@ -1,6 +1,7 @@
 pub mod abi;
 pub mod algod;
 pub mod applications;
+pub mod assets;
 pub mod auction;
 pub mod compile;
 pub mod general;

--- a/tests/step_defs/integration/world.rs
+++ b/tests/step_defs/integration/world.rs
@@ -7,7 +7,7 @@ use algonaut::{
     kmd::v1::Kmd,
 };
 use algonaut_abi::{abi_interactions::AbiMethod, abi_type::AbiType};
-use algonaut_algod::models::TransactionParams200Response;
+use algonaut_algod::models::{AssetParams, TransactionParams200Response};
 use algonaut_core::{Address, MultisigAddress};
 use algonaut_crypto::Ed25519PublicKey;
 use algonaut_transaction::{
@@ -74,4 +74,8 @@ pub struct World {
     pub kmd_signed_tx_bytes: Option<Vec<u8>>,
     pub kmd_signed_multisig_bytes: Option<Vec<u8>>,
     pub exported_multisig_pks: Option<Vec<Ed25519PublicKey>>,
+
+    pub asset_id: Option<u64>,
+    pub asset_info: Option<AssetParams>,
+    pub expected_asset_params: Option<AssetParams>,
 }


### PR DESCRIPTION
**Stacked on top of #256.**

## Summary
- Covers all eight scenarios from \`assets.feature\`:
  - Asset creation (with full role set, name, unit, url, metadata hash)
  - Reconfigure with no managers (clears manager/reserve/freeze/clawback)
  - Destroy (assert asset info becomes unavailable after)
  - Acceptance + transfer
  - Non-acceptance (transfer to non-opted-in account fails)
  - Freeze / unfreeze cycle
  - Default-frozen → unfreeze cycle
  - Clawback (revocation)
- All flows sign through kmd and submit via \`algod.send_raw_txn\` over the bytes kmd hands back
- Asset IDs come from \`PendingTransactionResponse.asset_index\` after creation
- Reuses CreateAsset / UpdateAsset / DestroyAsset / AcceptAsset / TransferAsset / FreezeAsset / ClawbackAsset, all already in algonaut_transaction

## Test plan
- [ ] CI green on standard checks
- [ ] After harness boots, all eight assets scenarios run green