### PR TITLE
chore(ci): compile-check features_runner in make ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,12 @@ test-release:
 integration:
 	cargo test --test features_runner --
 
+# Compile-check the cucumber runner without invoking it (it would need
+# a live harness). Catches type errors that `cargo check` skips because
+# `[[test]] test = false` for features_runner.
+check-integration:
+	cargo test --test features_runner --no-run
+
 # Bring the integration test harness up
 harness:
 	./test-harness.sh up
@@ -70,8 +76,8 @@ docker-rustsdk-run:
 # Run the full docker test (harness + build + run)
 docker-test: harness docker-rustsdk-build docker-rustsdk-run
 
-# Run all CI checks (fmt-check, clippy, test, build)
-ci: fmt-check clippy test build
+# Run all CI checks (fmt-check, clippy, test, check-integration, build)
+ci: fmt-check clippy test check-integration build
 
 # Generate documentation
 doc:


### PR DESCRIPTION
## Summary
- Adds a \`check-integration\` Makefile target that runs \`cargo test --test features_runner --no-run\`
- Includes it in \`make ci\` so the pre-commit hook (and any local \`make ci\`) catches type errors in \`tests/step_defs/integration/\` that plain \`cargo check\` skips
- \`features_runner\` has \`[[test]] test = false\` because cucumber drives its own output (not libtest), so it stays out of the default cargo-test discovery and was bypassing the local checks

## Why
While landing #251–#257 we hit two cases where local \`make ci\` was green but CI failed at the integration job's compile step (\`MicroAlgos: From<u64>\` not implemented; \`Account.assets\` is \`Option<Vec<AssetHolding>>\`). This closes that gap.

## Test plan
- [x] \`make check-integration\` succeeds locally
- [x] \`make ci\` succeeds (pre-commit hook on this PR's commit ran it green)