### PR TITLE
feat(transaction): add state_proof_key to KeyRegistration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ADR collection at `docs/adr/` managed by [`arkouda`](https://github.com/manuelmauro/arkouda); seeded with `cucumber-test-suite-coverage-strategy`, `simulaterequest-model-needs-power-pack-fields`, `atomictransactioncomposer-simulate-convenience`, `teal-source-map-decoder`, `dryrun-request-builder`, and `cucumber-unit-test-scaffolding`
 - `tests/features_runner.rs` now enumerates every `.feature` file in the algorand-sdk-testing suite (13 integration + 17 unit), gating un-implemented features behind explicit ADR references
 - Drafted upstream tickets in `docs/cucumber-pending-issues.md` ready for `gh issue create`
+- `algonaut_core::StateProofPk` (64-byte BLS public key) plus `algonaut_encoding::U8_64Visitor`
+- `state_proof_key: Option<StateProofPk>` field on `algonaut_transaction::transaction::KeyRegistration`, serialised as the `sprfkey` msgpack field
+- `@send.keyregtxn` scenarios (online, offline, nonparticipation) are now live in the cucumber runner
 
 ### Changed
 
 - The runner's "v1 only" comment for `algod`/`assets` is replaced with an accurate matrix — both features actually target v2 endpoints and only need step-def coverage
+- **Breaking:** `algonaut_transaction::RegisterKey::online` now takes a `StateProofPk` argument between `selection_pk` and `vote_first`. v34 consensus rejects online registrations without it
 
 ## [0.5.0] - 2026-05-18
 

--- a/algonaut_core/src/lib.rs
+++ b/algonaut_core/src/lib.rs
@@ -1,6 +1,6 @@
 use algonaut_crypto::HashDigest;
 use algonaut_crypto::Signature;
-use algonaut_encoding::U8_32Visitor;
+use algonaut_encoding::{U8_32Visitor, U8_64Visitor};
 use data_encoding::BASE64;
 use derive_more::{Add, Display, Sub};
 use error::CoreError;
@@ -171,6 +171,52 @@ impl Debug for VrfPk {
 impl VrfPk {
     pub fn from_base64_str(base64_str: &str) -> Result<VrfPk, CoreError> {
         Ok(VrfPk(base64_str_to_u8_array(base64_str)?))
+    }
+
+    pub fn to_base64_str(self) -> String {
+        BASE64.encode(&self.0)
+    }
+}
+
+/// State-proof (BLS) public key used in v2 online key registration
+/// transactions. Serialized as the 64-byte `sprfkey` field in msgpack
+/// and as base64 in JSON.
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct StateProofPk(pub [u8; 64]);
+
+impl Serialize for StateProofPk {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(&self.0[..])
+    }
+}
+
+impl<'de> Deserialize<'de> for StateProofPk {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(StateProofPk(deserializer.deserialize_bytes(U8_64Visitor)?))
+    }
+}
+
+impl Debug for StateProofPk {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_base64_str())
+    }
+}
+
+impl StateProofPk {
+    pub fn from_base64_str(base64_str: &str) -> Result<StateProofPk, CoreError> {
+        let bytes = BASE64
+            .decode(base64_str.as_bytes())
+            .map_err(|e| CoreError::General(e.to_string()))?;
+        let arr: [u8; 64] = bytes.try_into().map_err(|v: Vec<u8>| {
+            CoreError::General(format!("expected 64 bytes, got {}", v.len()))
+        })?;
+        Ok(StateProofPk(arr))
     }
 
     pub fn to_base64_str(self) -> String {

--- a/algonaut_encoding/src/lib.rs
+++ b/algonaut_encoding/src/lib.rs
@@ -60,6 +60,29 @@ impl<'de> Visitor<'de> for U8_32Visitor {
     }
 }
 
+pub struct U8_64Visitor;
+
+impl<'de> Visitor<'de> for U8_64Visitor {
+    type Value = [u8; 64];
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a 64 byte array")
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        if v.len() == 64 {
+            let mut bytes = [0; 64];
+            bytes.copy_from_slice(v);
+            Ok(bytes)
+        } else {
+            Err(E::custom(format!("Invalid byte array length: {}", v.len())))
+        }
+    }
+}
+
 pub fn deserialize_bytes32<'de, D>(deserializer: D) -> Result<[u8; 32], D::Error>
 where
     D: Deserializer<'de>,

--- a/algonaut_model/src/transaction.rs
+++ b/algonaut_model/src/transaction.rs
@@ -1,4 +1,6 @@
-use algonaut_core::{Address, MicroAlgos, MultisigSignature, Round, ToMsgPack, VotePk, VrfPk};
+use algonaut_core::{
+    Address, MicroAlgos, MultisigSignature, Round, StateProofPk, ToMsgPack, VotePk, VrfPk,
+};
 use algonaut_crypto::{HashDigest, HashType, Signature};
 use algonaut_encoding::{deserialize_bytes64, serialize_bytes};
 use serde::{Deserialize, Serialize};
@@ -141,6 +143,9 @@ pub struct ApiTransaction {
 
     #[serde(rename = "snd")]
     pub sender: Address,
+
+    #[serde(rename = "sprfkey", skip_serializing_if = "Option::is_none")]
+    pub state_proof_key: Option<StateProofPk>,
 
     #[serde(rename = "sp", skip_serializing_if = "Option::is_none")]
     pub state_proof: Option<StateProof>,

--- a/algonaut_transaction/src/api_model.rs
+++ b/algonaut_transaction/src/api_model.rs
@@ -60,6 +60,7 @@ impl TryFrom<Transaction> for ApiTransaction {
             asset_id: None,
             receiver: None,
             selection_pk: None,
+            state_proof_key: None,
             vote_first: None,
             vote_key_dilution: None,
             vote_pk: None,
@@ -82,6 +83,7 @@ impl TryFrom<Transaction> for ApiTransaction {
             TransactionType::KeyRegistration(reg) => {
                 api_t.vote_pk = reg.vote_pk;
                 api_t.selection_pk = reg.selection_pk;
+                api_t.state_proof_key = reg.state_proof_key;
                 api_t.vote_first = reg.vote_first;
                 api_t.vote_last = reg.vote_last;
                 api_t.vote_key_dilution = reg.vote_key_dilution.and_then(num_as_api_option);
@@ -169,6 +171,7 @@ impl TryFrom<ApiTransaction> for Transaction {
                 sender: api_t.sender,
                 vote_pk: api_t.vote_pk,
                 selection_pk: api_t.selection_pk,
+                state_proof_key: api_t.state_proof_key,
                 vote_first: api_t.vote_first,
                 vote_last: api_t.vote_last,
                 vote_key_dilution: Some(num_from_api_option(api_t.vote_key_dilution)),

--- a/algonaut_transaction/src/builder.rs
+++ b/algonaut_transaction/src/builder.rs
@@ -7,7 +7,7 @@ use crate::{
         Transaction, TransactionType,
     },
 };
-use algonaut_core::{Address, CompiledTeal, MicroAlgos, Round, VotePk, VrfPk};
+use algonaut_core::{Address, CompiledTeal, MicroAlgos, Round, StateProofPk, VotePk, VrfPk};
 use algonaut_crypto::HashDigest;
 
 pub trait TransactionParams {
@@ -164,14 +164,20 @@ pub struct RegisterKey {
     vote_first: Option<Round>,
     vote_last: Option<Round>,
     vote_key_dilution: Option<u64>,
+    state_proof_key: Option<StateProofPk>,
     nonparticipating: Option<bool>,
 }
 
 impl RegisterKey {
+    /// Build an **online** v2 key-registration transaction.
+    ///
+    /// Since the v34 consensus upgrade an online registration must carry
+    /// a state-proof (BLS) public key; pass it as `state_proof_key`.
     pub fn online(
         sender: Address,
         vote_pk: VotePk,
         selection_pk: VrfPk,
+        state_proof_key: StateProofPk,
         vote_first: Round,
         vote_last: Round,
         vote_key_dilution: u64,
@@ -183,6 +189,7 @@ impl RegisterKey {
             vote_first: Some(vote_first),
             vote_last: Some(vote_last),
             vote_key_dilution: Some(vote_key_dilution),
+            state_proof_key: Some(state_proof_key),
             nonparticipating: None,
         }
     }
@@ -195,6 +202,7 @@ impl RegisterKey {
             vote_first: None,
             vote_last: None,
             vote_key_dilution: None,
+            state_proof_key: None,
             nonparticipating: None,
         }
     }
@@ -207,6 +215,7 @@ impl RegisterKey {
             vote_first: None,
             vote_last: None,
             vote_key_dilution: None,
+            state_proof_key: None,
             nonparticipating: Some(nonparticipating),
         }
     }
@@ -219,6 +228,7 @@ impl RegisterKey {
             vote_first: self.vote_first,
             vote_last: self.vote_last,
             vote_key_dilution: self.vote_key_dilution,
+            state_proof_key: self.state_proof_key,
             nonparticipating: self.nonparticipating,
         })
     }

--- a/algonaut_transaction/src/transaction.rs
+++ b/algonaut_transaction/src/transaction.rs
@@ -5,7 +5,7 @@ use algonaut_core::SuggestedTransactionParams;
 use algonaut_core::ToMsgPack;
 use algonaut_core::TransactionTypeEnum;
 use algonaut_core::{Address, MultisigSignature};
-use algonaut_core::{MicroAlgos, Round, VotePk, VrfPk};
+use algonaut_core::{MicroAlgos, Round, StateProofPk, VotePk, VrfPk};
 use algonaut_crypto::HashDigest;
 use algonaut_crypto::Signature;
 use algonaut_model::transaction::ApiSignedLogic;
@@ -187,6 +187,11 @@ pub struct KeyRegistration {
 
     /// This is the dilution for the 2-level participation key.
     pub vote_key_dilution: Option<u64>,
+
+    /// The 64-byte state-proof (BLS) public key. Required for online key
+    /// registration since the v34 consensus upgrade; omit for offline or
+    /// nonparticipation registrations.
+    pub state_proof_key: Option<StateProofPk>,
 
     /// All new Algorand accounts are participating by default. This means that they earn rewards.
     /// Mark an account nonparticipating by setting this value to true and this account will no

--- a/docs/adr/keyregistration-v2-state-proof-key.md
+++ b/docs/adr/keyregistration-v2-state-proof-key.md
@@ -2,7 +2,7 @@
 id: keyregistration-v2-state-proof-key
 title: KeyRegistration v2 state-proof key
 abstract: Add state_proof_key to KeyRegistration so online key-registration transactions match the v2 consensus surface used by send.feature.
-status: proposed
+status: accepted
 date: 2026-05-18
 deciders: []
 tags: []
@@ -12,7 +12,7 @@ tags: []
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/cucumber-pending-issues.md
+++ b/docs/cucumber-pending-issues.md
@@ -139,25 +139,11 @@ Three features need it:
 
 ---
 
-## 5. Add `state_proof_key` to `KeyRegistration`
+## ~~5. Add `state_proof_key` to `KeyRegistration`~~
 
-**Labels:** `area/transaction`, `kind/feature`, `cucumber-blocker`
-**ADR:** [`keyregistration-v2-state-proof-key`](adr/keyregistration-v2-state-proof-key.md)
-
-```markdown
-`tests/features/integration/send.feature` has a `@send.keyregtxn`
-scenario that exercises V2 online key registration. Since the v34
-consensus upgrade, online registration requires `sprfkey` (a 64-byte
-BLS public key). Our `KeyRegistration` model omits it.
-
-### Acceptance
-- [ ] `algonaut_transaction::transaction::KeyRegistration` gains
-      `state_proof_key: Option<StateProofPk>`.
-- [ ] `RegisterKey::online` accepts the state-proof key (additive
-      breaking change to its signature).
-- [ ] Msgpack serialization writes `sprfkey` when present.
-- [ ] `@send.keyregtxn` runs green and the runner exclusion is dropped.
-```
+Landed — see ADR
+[`keyregistration-v2-state-proof-key`](adr/keyregistration-v2-state-proof-key.md)
+(status: accepted).
 
 ---
 

--- a/examples/key_reg.rs
+++ b/examples/key_reg.rs
@@ -1,5 +1,5 @@
 use algonaut::algod::v2::Algod;
-use algonaut::core::{Round, VotePk, VrfPk};
+use algonaut::core::{Round, StateProofPk, VotePk, VrfPk};
 use algonaut::transaction::RegisterKey;
 use algonaut::transaction::{TxnBuilder, account::Account};
 use dotenv::dotenv;
@@ -21,6 +21,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let vote_pk_str = "KgL5qW1jtHAQb1lQNIKuqHBqDWXRmb7GTmBN92a/sOQ=";
     let selection_pk_str = "A3s+2bgKlbG9qIaA4wJsrrJl8mVKGzTp/h6gGEyZmAg=";
+    // 64-byte BLS public key required since the v34 consensus upgrade.
+    let state_proof_key_str =
+        "WaA5UWiVDzD6QY/ZxNi0Pc4xL4FxQa3kjlrZmkSMcEUjGFQqRGo3CSNZ9D8GAr+5e7TgQHM2RfsdJ4yLpcfkRA==";
 
     info!("retrieving suggested params");
     let params = algod.txn_params().await?;
@@ -32,6 +35,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             alice.address(),
             VotePk::from_base64_str(vote_pk_str)?,
             VrfPk::from_base64_str(selection_pk_str)?,
+            StateProofPk::from_base64_str(state_proof_key_str)?,
             Round(params.last_round),
             Round(params.last_round + 3_000_000),
             10_000,

--- a/tests/features_runner.rs
+++ b/tests/features_runner.rs
@@ -99,9 +99,7 @@ const INTEGRATION_FEATURES: &[Feature] = &[
     Feature {
         path: "tests/features/integration/send.feature",
         gate: None,
-        // Online keyreg requires sprfkey — blocked on ADR
-        // keyregistration-v2-state-proof-key.
-        excluded_tags: &["send.keyregtxn"],
+        excluded_tags: &[],
     },
     Feature {
         path: "tests/features/integration/simulate.feature",

--- a/tests/step_defs/integration/send.rs
+++ b/tests/step_defs/integration/send.rs
@@ -1,9 +1,16 @@
 use crate::step_defs::{integration::world::World, util::account_from_kmd_response};
-use algonaut_core::{MicroAlgos, MultisigAddress};
-use algonaut_transaction::{Pay, SignedTransaction, TxnBuilder, transaction::TransactionSignature};
+use algonaut_core::{MicroAlgos, MultisigAddress, Round, StateProofPk, VotePk, VrfPk};
+use algonaut_transaction::{
+    Pay, RegisterKey, SignedTransaction, TxnBuilder, transaction::TransactionSignature,
+};
 use cucumber::{given, then, when};
 use data_encoding::BASE64;
 use std::error::Error;
+
+const TEST_VOTE_PK: &str = "9PYsmlBevatTWVRcfDLqzpyaURRTbjPo+oTrFkXgKHE=";
+const TEST_SELECTION_PK: &str = "UkpZx9Vfo0Q1+/8mE2KCDdQ72Y0AKEK9DnFvL3yWZ2c=";
+const TEST_STATE_PROOF_PK: &str =
+    "WaA5UWiVDzD6QY/ZxNi0Pc4xL4FxQa3kjlrZmkSMcEUjGFQqRGo3CSNZ9D8GAr+5e7TgQHM2RfsdJ4yLpcfkRA==";
 
 async fn build_default_payment(
     w: &mut World,
@@ -139,6 +146,35 @@ async fn i_send_the_transaction(w: &mut World) {
             w.last_send_succeeded = Some(false);
         }
     }
+}
+
+#[given(regex = r#"^default V2 key registration transaction "([^"]+)"$"#)]
+async fn default_v2_key_registration_transaction(
+    w: &mut World,
+    variant: String,
+) -> Result<(), Box<dyn Error>> {
+    let algod = w.algod.as_ref().expect("algod not set");
+    let accounts = w.accounts.as_ref().expect("accounts not set");
+    let params = algod.txn_params().await?;
+    let sender = accounts[0];
+
+    let keyreg = match variant.as_str() {
+        "online" => RegisterKey::online(
+            sender,
+            VotePk::from_base64_str(TEST_VOTE_PK)?,
+            VrfPk::from_base64_str(TEST_SELECTION_PK)?,
+            StateProofPk::from_base64_str(TEST_STATE_PROOF_PK)?,
+            Round(0),
+            Round(30_001),
+            10_000,
+        ),
+        "offline" => RegisterKey::offline(sender),
+        "nonparticipation" => RegisterKey::nonpartipating(sender, true),
+        other => return Err(format!("unknown keyreg variant: {other}").into()),
+    };
+
+    w.tx = Some(TxnBuilder::with(&params, keyreg.build()).build()?);
+    Ok(())
 }
 
 #[then(expr = "the transaction should not go through")]


### PR DESCRIPTION
Closes the gap tracked by ADR
[keyregistration-v2-state-proof-key](https://github.com/manuelmauro/algonaut/blob/main/docs/adr/keyregistration-v2-state-proof-key.md).

## Summary

- New 64-byte \`algonaut_core::StateProofPk\` (and a matching \`U8_64Visitor\` in \`algonaut_encoding\`) for the BLS state-proof public key
- \`algonaut_transaction::transaction::KeyRegistration\` gains \`state_proof_key: Option<StateProofPk>\`
- \`algonaut_model::transaction::ApiTransaction\` gains the matching \`sprfkey\` msgpack field (\`#[serde(skip_serializing_if = \"Option::is_none\")]\`, so offline/nonparticipation registrations stay byte-identical to before)
- The api-model conversion routes the field in both directions

## Breaking

- \`RegisterKey::online\` now takes a \`StateProofPk\` argument between \`selection_pk\` and \`vote_first\`. \`examples/key_reg.rs\` is updated to use the algorand-sdk-testing fixture key

## Cucumber wiring

- ADR marked Accepted; pending-issues entry struck through
- \`@send.keyregtxn\` exclusion removed from \`tests/features_runner.rs\`
- New \`default V2 key registration transaction \"<type>\"\` step covers online / offline / nonparticipation

## Test plan
- [x] \`cargo check --workspace --all-targets\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --test features_runner --no-run\`
- [x] \`arkouda check\`
- [ ] CI green (including integration job — verifies the three keyreg variants actually confirm on the sandbox harness)