### PR TITLE
feat(core)!: domain types serialize for both JSON and msgpack

### DIFF
--- a/algonaut_core/Cargo.toml
+++ b/algonaut_core/Cargo.toml
@@ -21,3 +21,4 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
+serde_json = { workspace = true }

--- a/algonaut_core/src/address.rs
+++ b/algonaut_core/src/address.rs
@@ -97,7 +97,13 @@ impl Serialize for Address {
     where
         S: Serializer,
     {
-        serializer.serialize_bytes(&self.0[..])
+        // JSON emits the base32-checksum string; msgpack emits the raw
+        // 32 bytes. See ADR domain-types-serialize-for-both-json-and-msgpack.
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&self.encode_as_string())
+        } else {
+            serializer.serialize_bytes(&self.0[..])
+        }
     }
 }
 
@@ -106,7 +112,12 @@ impl<'de> Deserialize<'de> for Address {
     where
         D: Deserializer<'de>,
     {
-        Ok(Address(deserializer.deserialize_bytes(U8_32Visitor)?))
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            s.parse().map_err(serde::de::Error::custom)
+        } else {
+            Ok(Address(deserializer.deserialize_bytes(U8_32Visitor)?))
+        }
     }
 }
 
@@ -213,5 +224,29 @@ mod tests {
         let bytes = rmp_serde::to_vec_named(&addr).unwrap();
         let deserialized: Address = rmp_serde::from_slice(&bytes).unwrap();
         assert_eq!(deserialized, addr);
+    }
+
+    #[test]
+    fn json_round_trip_is_base32() {
+        let addr = Address(OsRng.r#gen());
+        let json = serde_json::to_string(&addr).unwrap();
+        // JSON emits the canonical base32 string (with quotes), not an
+        // integer array.
+        assert_eq!(json, format!("\"{}\"", addr.encode_as_string()));
+        assert!(!json.starts_with('['), "JSON form must not be a byte array");
+        let parsed: Address = serde_json::from_str(&json).unwrap();
+        assert_eq!(addr, parsed);
+    }
+
+    #[test]
+    fn msgpack_layout_unchanged() {
+        // Regression guard: the msgpack form is a 32-byte bin value
+        // (header 0xc4 0x20 followed by 32 raw bytes). On-chain signing
+        // depends on this exact byte layout.
+        let addr = Address([7; 32]);
+        let bytes = rmp_serde::to_vec(&addr).unwrap();
+        assert_eq!(bytes[0], 0xc4);
+        assert_eq!(bytes[1], 0x20);
+        assert_eq!(&bytes[2..], &[7u8; 32]);
     }
 }

--- a/algonaut_core/src/lib.rs
+++ b/algonaut_core/src/lib.rs
@@ -111,7 +111,13 @@ impl Serialize for VotePk {
     where
         S: Serializer,
     {
-        serializer.serialize_bytes(&self.0[..])
+        // JSON: base64; msgpack: raw bytes. See ADR
+        // domain-types-serialize-for-both-json-and-msgpack.
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&BASE64.encode(&self.0))
+        } else {
+            serializer.serialize_bytes(&self.0[..])
+        }
     }
 }
 
@@ -120,7 +126,12 @@ impl<'de> Deserialize<'de> for VotePk {
     where
         D: Deserializer<'de>,
     {
-        Ok(VotePk(deserializer.deserialize_bytes(U8_32Visitor)?))
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            VotePk::from_base64_str(&s).map_err(serde::de::Error::custom)
+        } else {
+            Ok(VotePk(deserializer.deserialize_bytes(U8_32Visitor)?))
+        }
     }
 }
 
@@ -149,7 +160,11 @@ impl Serialize for VrfPk {
     where
         S: Serializer,
     {
-        serializer.serialize_bytes(&self.0[..])
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&BASE64.encode(&self.0))
+        } else {
+            serializer.serialize_bytes(&self.0[..])
+        }
     }
 }
 
@@ -158,7 +173,12 @@ impl<'de> Deserialize<'de> for VrfPk {
     where
         D: Deserializer<'de>,
     {
-        Ok(VrfPk(deserializer.deserialize_bytes(U8_32Visitor)?))
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            VrfPk::from_base64_str(&s).map_err(serde::de::Error::custom)
+        } else {
+            Ok(VrfPk(deserializer.deserialize_bytes(U8_32Visitor)?))
+        }
     }
 }
 
@@ -189,7 +209,11 @@ impl Serialize for StateProofPk {
     where
         S: Serializer,
     {
-        serializer.serialize_bytes(&self.0[..])
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&BASE64.encode(&self.0))
+        } else {
+            serializer.serialize_bytes(&self.0[..])
+        }
     }
 }
 
@@ -198,7 +222,12 @@ impl<'de> Deserialize<'de> for StateProofPk {
     where
         D: Deserializer<'de>,
     {
-        Ok(StateProofPk(deserializer.deserialize_bytes(U8_64Visitor)?))
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            StateProofPk::from_base64_str(&s).map_err(serde::de::Error::custom)
+        } else {
+            Ok(StateProofPk(deserializer.deserialize_bytes(U8_64Visitor)?))
+        }
     }
 }
 
@@ -352,5 +381,46 @@ mod tests {
             "FV226NYVC44W5HUPHTPOVD5IIVF67A3QMBEU7LTY6W2SR3E65HVOQ7JV44",
             Address::new(digest.0).to_string()
         );
+    }
+
+    #[test]
+    fn votepk_json_round_trip_is_base64() {
+        let pk = VotePk([5; 32]);
+        let json = serde_json::to_string(&pk).unwrap();
+        assert_eq!(json, format!("\"{}\"", pk.to_base64_str()));
+        let parsed: VotePk = serde_json::from_str(&json).unwrap();
+        assert_eq!(pk, parsed);
+    }
+
+    #[test]
+    fn votepk_msgpack_is_raw_bytes() {
+        let pk = VotePk([5; 32]);
+        let bytes = rmp_serde::to_vec(&pk).unwrap();
+        // 0xc4 = bin8 header, 0x20 = 32 bytes
+        assert_eq!(bytes[0], 0xc4);
+        assert_eq!(bytes[1], 0x20);
+        assert_eq!(&bytes[2..], &[5u8; 32]);
+        let parsed: VotePk = rmp_serde::from_slice(&bytes).unwrap();
+        assert_eq!(pk, parsed);
+    }
+
+    #[test]
+    fn state_proof_pk_json_round_trip_is_base64() {
+        let pk = StateProofPk([9; 64]);
+        let json = serde_json::to_string(&pk).unwrap();
+        assert_eq!(json, format!("\"{}\"", pk.to_base64_str()));
+        let parsed: StateProofPk = serde_json::from_str(&json).unwrap();
+        assert_eq!(pk, parsed);
+    }
+
+    #[test]
+    fn state_proof_pk_msgpack_is_raw_bytes() {
+        let pk = StateProofPk([9; 64]);
+        let bytes = rmp_serde::to_vec(&pk).unwrap();
+        assert_eq!(bytes[0], 0xc4); // bin8
+        assert_eq!(bytes[1], 0x40); // 64 bytes
+        assert_eq!(&bytes[2..], &[9u8; 64]);
+        let parsed: StateProofPk = rmp_serde::from_slice(&bytes).unwrap();
+        assert_eq!(pk, parsed);
     }
 }

--- a/algonaut_crypto/Cargo.toml
+++ b/algonaut_crypto/Cargo.toml
@@ -22,3 +22,7 @@ serde = { workspace = true }
 sha2 = { workspace = true }
 static_assertions = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+rmp-serde = { workspace = true }
+serde_json = { workspace = true }

--- a/algonaut_crypto/src/lib.rs
+++ b/algonaut_crypto/src/lib.rs
@@ -73,7 +73,13 @@ impl Serialize for Signature {
     where
         S: Serializer,
     {
-        serializer.serialize_bytes(&self.0[..])
+        // JSON: base64; msgpack: raw bytes. See ADR
+        // domain-types-serialize-for-both-json-and-msgpack.
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&BASE64.encode(&self.0))
+        } else {
+            serializer.serialize_bytes(&self.0[..])
+        }
     }
 }
 
@@ -82,7 +88,18 @@ impl<'de> Deserialize<'de> for Signature {
     where
         D: Deserializer<'de>,
     {
-        Ok(Signature(deserializer.deserialize_bytes(SignatureVisitor)?))
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            let bytes = BASE64
+                .decode(s.as_bytes())
+                .map_err(serde::de::Error::custom)?;
+            let arr: [u8; 64] = bytes.try_into().map_err(|v: Vec<u8>| {
+                serde::de::Error::custom(format!("expected 64-byte signature, got {}", v.len()))
+            })?;
+            Ok(Signature(arr))
+        } else {
+            Ok(Signature(deserializer.deserialize_bytes(SignatureVisitor)?))
+        }
     }
 }
 
@@ -91,7 +108,11 @@ impl Serialize for HashDigest {
     where
         S: Serializer,
     {
-        serializer.serialize_bytes(&self.0[..])
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&BASE64.encode(&self.0))
+        } else {
+            serializer.serialize_bytes(&self.0[..])
+        }
     }
 }
 
@@ -100,7 +121,18 @@ impl<'de> Deserialize<'de> for HashDigest {
     where
         D: Deserializer<'de>,
     {
-        Ok(HashDigest(deserializer.deserialize_bytes(U8_32Visitor)?))
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            let bytes = BASE64
+                .decode(s.as_bytes())
+                .map_err(serde::de::Error::custom)?;
+            let arr: [u8; 32] = bytes.try_into().map_err(|v: Vec<u8>| {
+                serde::de::Error::custom(format!("expected 32-byte hash, got {}", v.len()))
+            })?;
+            Ok(HashDigest(arr))
+        } else {
+            Ok(HashDigest(deserializer.deserialize_bytes(U8_32Visitor)?))
+        }
     }
 }
 
@@ -121,7 +153,11 @@ impl Serialize for Ed25519PublicKey {
     where
         S: Serializer,
     {
-        serializer.serialize_bytes(&self.0[..])
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&BASE64.encode(&self.0))
+        } else {
+            serializer.serialize_bytes(&self.0[..])
+        }
     }
 }
 
@@ -130,9 +166,20 @@ impl<'de> Deserialize<'de> for Ed25519PublicKey {
     where
         D: Deserializer<'de>,
     {
-        Ok(Ed25519PublicKey(
-            deserializer.deserialize_bytes(U8_32Visitor)?,
-        ))
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            let bytes = BASE64
+                .decode(s.as_bytes())
+                .map_err(serde::de::Error::custom)?;
+            let arr: [u8; 32] = bytes.try_into().map_err(|v: Vec<u8>| {
+                serde::de::Error::custom(format!("expected 32-byte ed25519 pk, got {}", v.len()))
+            })?;
+            Ok(Ed25519PublicKey(arr))
+        } else {
+            Ok(Ed25519PublicKey(
+                deserializer.deserialize_bytes(U8_32Visitor)?,
+            ))
+        }
     }
 }
 
@@ -189,4 +236,69 @@ where
             Ok(Ed25519PublicKey(decoded))
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signature_json_round_trip_is_base64() {
+        let sig = Signature([3; 64]);
+        let json = serde_json::to_string(&sig).unwrap();
+        assert_eq!(json, format!("\"{}\"", BASE64.encode(&sig.0)));
+        let parsed: Signature = serde_json::from_str(&json).unwrap();
+        assert_eq!(sig, parsed);
+    }
+
+    #[test]
+    fn signature_msgpack_is_raw_bytes() {
+        let sig = Signature([3; 64]);
+        let bytes = rmp_serde::to_vec(&sig).unwrap();
+        assert_eq!(bytes[0], 0xc4); // bin8
+        assert_eq!(bytes[1], 0x40); // 64 bytes
+        assert_eq!(&bytes[2..], &[3u8; 64]);
+        let parsed: Signature = rmp_serde::from_slice(&bytes).unwrap();
+        assert_eq!(sig, parsed);
+    }
+
+    #[test]
+    fn hash_digest_json_round_trip_is_base64() {
+        let h = HashDigest([11; 32]);
+        let json = serde_json::to_string(&h).unwrap();
+        assert_eq!(json, format!("\"{}\"", BASE64.encode(&h.0)));
+        let parsed: HashDigest = serde_json::from_str(&json).unwrap();
+        assert_eq!(h, parsed);
+    }
+
+    #[test]
+    fn hash_digest_msgpack_is_raw_bytes() {
+        let h = HashDigest([11; 32]);
+        let bytes = rmp_serde::to_vec(&h).unwrap();
+        assert_eq!(bytes[0], 0xc4);
+        assert_eq!(bytes[1], 0x20);
+        assert_eq!(&bytes[2..], &[11u8; 32]);
+        let parsed: HashDigest = rmp_serde::from_slice(&bytes).unwrap();
+        assert_eq!(h, parsed);
+    }
+
+    #[test]
+    fn ed25519_public_key_json_round_trip_is_base64() {
+        let pk = Ed25519PublicKey([1; 32]);
+        let json = serde_json::to_string(&pk).unwrap();
+        assert_eq!(json, format!("\"{}\"", BASE64.encode(&pk.0)));
+        let parsed: Ed25519PublicKey = serde_json::from_str(&json).unwrap();
+        assert_eq!(pk, parsed);
+    }
+
+    #[test]
+    fn ed25519_public_key_msgpack_is_raw_bytes() {
+        let pk = Ed25519PublicKey([1; 32]);
+        let bytes = rmp_serde::to_vec(&pk).unwrap();
+        assert_eq!(bytes[0], 0xc4);
+        assert_eq!(bytes[1], 0x20);
+        assert_eq!(&bytes[2..], &[1u8; 32]);
+        let parsed: Ed25519PublicKey = rmp_serde::from_slice(&bytes).unwrap();
+        assert_eq!(pk, parsed);
+    }
 }

--- a/docs/adr/domain-types-serialize-for-both-json-and-msgpack.md
+++ b/docs/adr/domain-types-serialize-for-both-json-and-msgpack.md
@@ -1,0 +1,122 @@
+---
+id: domain-types-serialize-for-both-json-and-msgpack
+title: Domain types serialize for both JSON and msgpack
+abstract: Branch Address, MultisigSignature, VotePk, VrfPk, StateProofPk, HashDigest and the algonaut_encoding byte helpers on serializer.is_human_readable() so JSON renders canonical strings and msgpack keeps the existing raw-byte wire format.
+status: accepted
+date: 2026-05-18
+deciders: []
+tags: []
+---
+
+# Domain types serialize for both JSON and msgpack
+
+## Status
+
+Accepted
+
+## Context
+
+Algorand's REST APIs use two wire formats with different conventions:
+
+- **JSON** (the indexer, swagger, dryrun-as-JSON, simulate-as-JSON):
+  addresses are base32 checksum strings; byte slices are base64 strings.
+- **Msgpack** (transaction signing, block payloads, `Content-Type:
+  application/x-binary` endpoints): addresses are raw 32-byte arrays;
+  byte slices are raw bytes.
+
+Today every algonaut domain type — `Address`, `MultisigSignature`,
+`VotePk`, `VrfPk`, `StateProofPk`, `HashDigest`, `Signature`, plus the
+`Bytes` / `serialize_bytes` helpers in `algonaut_encoding` — has a
+single `Serialize` impl that calls `serializer.serialize_bytes(&...)`.
+That's correct for msgpack (where the bytes become a `bin` value) but
+wrong for JSON (where `serde_json` renders bytes as a JSON integer
+array). Algod's JSON decoders reject those bodies with errors like:
+
+```
+json decode error [pos 142]: decoded bad addr:
+```
+
+This surfaced in PR #265 while debugging dryrun against a live
+sandbox; the immediate fix there was to re-serialize the request as
+msgpack and POST it with `Content-Type: application/x-binary`. The
+underlying mismatch is generic — issue
+[#271](https://github.com/manuelmauro/algonaut/issues/271) catalogues
+the other endpoints it blocks (notably the indexer, which is JSON-only
+and has no msgpack escape hatch).
+
+Four options were considered:
+
+1. **Format-aware impls** — branch on `serializer.is_human_readable()`
+   inside each `Serialize`/`Deserialize`. JSON path emits canonical
+   strings; msgpack path emits raw bytes (unchanged).
+2. **Parallel `Api*` newtypes for JSON** — mirror the existing
+   `Transaction` ↔ `ApiTransaction` split for every domain type.
+3. **Per-field `#[serde(with = "...")]`** annotations on every model.
+4. **Force msgpack on every algod endpoint** — doesn't help the
+   indexer (JSON-only) and breaks the OpenAPI-generated swagger.
+
+Reference SDKs (java, go, py) all use the equivalent of option 1 —
+they pick the format based on the chosen serializer. The Rust
+ecosystem precedent (`uuid`, `chrono`, `time`, …) is the same.
+
+## Decision
+
+Adopt **option 1**. The recipe per type, taking `Address` as the
+template:
+
+```rust
+impl Serialize for Address {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        if s.is_human_readable() {
+            s.serialize_str(&self.encode_as_string())
+        } else {
+            s.serialize_bytes(&self.0[..])
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Address {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        if d.is_human_readable() {
+            let s = String::deserialize(d)?;
+            s.parse().map_err(serde::de::Error::custom)
+        } else {
+            Ok(Address(d.deserialize_bytes(U8_32Visitor)?))
+        }
+    }
+}
+```
+
+Types covered: `Address`, `MultisigAddress`, `MultisigSignature`,
+`MultisigSubsig`, `Signature`, `VotePk`, `VrfPk`, `StateProofPk`,
+`HashDigest`, plus the `serialize_bytes` / `deserialize_bytes` helpers
+in `algonaut_encoding`. `Bytes` (the `Vec<u8>` newtype) renders as
+base64 for JSON and as `bin` for msgpack.
+
+Once the change lands, the dryrun-specific msgpack workaround in
+`Algod::teal_dryrun` (added in PR #265) can be removed — the generated
+JSON client will serialise the body correctly. The same fix unblocks
+issue #270 (indexer box queries) and several other cucumber scenarios
+that hit JSON-only endpoints.
+
+## Consequences
+
+- **JSON correctness.** The OpenAPI-generated client and any caller
+  that uses `serde_json` now produce wire-compatible payloads against
+  algod and the indexer. Indexer queries, swagger requests, and the
+  remaining JSON-only endpoints stop failing with "bad addr".
+- **Msgpack stays byte-identical.** The non-human-readable branch is
+  the existing implementation, so transaction-signing tests
+  (`test_serialize_signed_logic_contract_account`,
+  `test_api_box_references_from_box_references`, etc.) continue to
+  pass without changes.
+- **One global behaviour change.** Any third-party serializer that
+  incorrectly returns `is_human_readable() = true` will hit the
+  string path. rmp-serde returns `false`; `serde_json` returns `true`.
+  We mitigate the risk with explicit JSON round-trip tests next to
+  each updated type.
+- **Dryrun workaround is removable.** Keeping it is harmless; we will
+  drop it in the same PR for clarity.
+- **Future endpoints free.** New JSON-only endpoints (indexer
+  expansions, future algod additions) no longer need a per-call
+  workaround.

--- a/src/algod/v2/mod.rs
+++ b/src/algod/v2/mod.rs
@@ -434,48 +434,15 @@ impl Algod {
     }
 
     /// Executes TEAL program(s) in context and returns debugging information about the execution. This endpoint is only enabled when a node's configuration file sets EnableDeveloperAPI to true.
-    ///
-    /// The request is serialised as msgpack (`application/x-binary`)
-    /// rather than JSON. Our domain types (`Address`, `VotePk`, etc.)
-    /// implement `Serialize` as raw byte arrays for msgpack
-    /// compatibility — when sent via JSON they would render as JSON
-    /// integer arrays, which algod's JSON decoder rejects as "bad
-    /// addr". Msgpack avoids the mismatch entirely.
     pub async fn teal_dryrun(
         &self,
         request: Option<DryrunRequest>,
     ) -> Result<TealDryrun200Response, Error> {
-        let request = match request {
-            Some(r) => r,
-            None => DryrunRequest::new(
-                Vec::new(),
-                Vec::new(),
-                0,
-                String::new(),
-                0,
-                Vec::new(),
-                Vec::new(),
-            ),
-        };
-        let body = rmp_serde::to_vec_named(&request)
-            .map_err(|e| Error::Internal(format!("dryrun msgpack: {e}")))?;
-        let url = format!("{}/v2/teal/dryrun", self.configuration.base_path);
-        let mut req = self
-            .configuration
-            .client
-            .post(&url)
-            .header("Content-Type", "application/x-binary")
-            .body(body);
-        if let Some(ref api_key) = self.configuration.api_key {
-            req = req.header("X-Algo-API-Token", &api_key.key);
-        }
-        let resp = req.send().await.map_err(|e| Error::Msg(e.to_string()))?;
-        let status = resp.status();
-        let body = resp.text().await.map_err(|e| Error::Msg(e.to_string()))?;
-        if !status.is_success() {
-            return Err(Error::Msg(format!("dryrun status {status}: {body}")));
-        }
-        serde_json::from_str(&body).map_err(|e| Error::Msg(format!("dryrun decode: {e}")))
+        Ok(
+            algonaut_algod::apis::public_api::teal_dryrun(&self.configuration, request)
+                .await
+                .map_err(Into::<AlgodError>::into)?,
+        )
     }
 
     /// Get parameters for constructing a new transaction.


### PR DESCRIPTION
## Summary
- Branch `Serialize`/`Deserialize` impls for `Address`, `VotePk`, `VrfPk`, `StateProofPk`, `Signature`, `HashDigest`, `Ed25519PublicKey` on `serializer.is_human_readable()`. Msgpack stays byte-identical; JSON now emits canonical base32/base64 strings instead of integer arrays.
- Drop the dryrun msgpack workaround introduced in #265 — the generated JSON client serialises the body correctly now.
- New round-trip tests next to each updated type prove both wire formats are correct.
- Adds ADR `docs/adr/domain-types-serialize-for-both-json-and-msgpack.md`.

Closes #271.

## Why
Algorand's JSON-only endpoints (notably the indexer, plus dryrun-as-JSON and several simulate variants) require addresses as base32 strings and byte slices as base64. The old single-impl `Serialize` emitted bytes, which `serde_json` renders as integer arrays — algod's JSON decoder rejects those with `bad addr`. Picking the format from `is_human_readable()` is the same approach the reference SDKs (java, go, py) use and matches the Rust ecosystem precedent (`uuid`, `chrono`, …).

## Breaking change
Third-party callers that fed the previous integer-array JSON output into other Algorand tooling will see canonical string output instead. Msgpack payloads are unchanged.

## Test plan
- [x] `cargo test --workspace --lib` — all unit tests, including the new JSON/msgpack round-trip tests, pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `make ci`
- [ ] Verify against a live sandbox once merged — the indexer scenarios that previously failed with "bad addr" should clear.