### PR TITLE
docs(contributing): add missing algod -> transaction dependency edge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,7 @@ stateDiagram-v2
     kmd --> model
     transaction --> model
     transaction --> abi
+    algod --> transaction
 ```
 
 ## Useful Resources


### PR DESCRIPTION
## Summary
The dependency diagram in CONTRIBUTING.md was missing the `algod -> transaction` edge. `algonaut_algod/Cargo.toml` depends on `algonaut_transaction`, but the diagram omitted it.

This surfaced during the v0.6.0 release: publishing crates in the order implied by the diagram failed (`algonaut_algod` could not resolve `algonaut_transaction = ^0.6.0` because `transaction` had not been published yet).

## Change
Adds the single missing edge so the graph matches the actual `Cargo.toml` dependencies and yields a correct topological publish order.