### PR TITLE
docs(contributing): refresh submission checklist and adopt the test-suite section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,12 +22,15 @@ We are very happy to accept code contributions too! Please address issues in our
 Before submitting your pull request to the repository, please make sure you have done the following things first:
 
 1. You have ensured the pull request is based on a recent version of your respective branch.
-2. You have processed your source code with the code formatter.
-   1. `cargo fmt --all -- --check`
-3. All of the following commands completed without errors or warnings.
-   1. `cargo test --workspace --lib --examples --test test_logic_signature`
-   2. `cargo clippy -- -D warnings`
-   3. `make docker-test`
+2. `make ci` completes without errors or warnings. It runs, in order:
+   1. `make fmt-check` — `cargo fmt --all -- --check`
+   2. `make clippy` — `cargo clippy --workspace --all-targets -- -D warnings`
+   3. `make test` — `cargo test --workspace --lib --examples --tests`
+   4. `make check-integration` — compile-checks the cucumber runner
+   5. `make build` — `cargo build --workspace`
+
+   The `lefthook` pre-commit hook runs `make ci` for you; install it with `make setup`.
+3. If your change affects behaviour covered by the cucumber integration suite, you have run it against a local Algorand sandbox. See [Running the test suite](./README.md#running-the-test-suite) for how to boot the harness (`make harness`) and run the runner (`make integration`); `make docker-test` runs the whole flow in Docker.
 
 ## Writing Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,9 @@
   - [Submitting Issues](#submitting-issues)
   - [Pull Requests](#pull-requests)
     - [Submission Checklist](#submission-checklist)
+  - [Running the test suite](#running-the-test-suite)
   - [Writing Documentation](#writing-documentation)
+  - [Dependency Diagram](#dependency-diagram)
   - [Useful Resources](#useful-resources)
 
 ## Submitting Issues
@@ -30,7 +32,18 @@ Before submitting your pull request to the repository, please make sure you have
    5. `make build` — `cargo build --workspace`
 
    The `lefthook` pre-commit hook runs `make ci` for you; install it with `make setup`.
-3. If your change affects behaviour covered by the cucumber integration suite, you have run it against a local Algorand sandbox. See [Running the test suite](./README.md#running-the-test-suite) for how to boot the harness (`make harness`) and run the runner (`make integration`); `make docker-test` runs the whole flow in Docker.
+3. If your change affects behaviour covered by the cucumber integration suite, you have run it against a local Algorand sandbox. See [Running the test suite](#running-the-test-suite) below; `make docker-test` runs the whole flow in Docker.
+
+## Running the test suite
+
+```bash
+make setup           # rustfmt + clippy + lefthook hooks
+make ci              # fmt-check, clippy, unit tests, build, integration compile-check
+./test-harness.sh up # boot a local algorand sandbox (ports 60000/60001/60002)
+make integration     # run the cucumber suite against the sandbox
+```
+
+See `docs/adr/` for the architectural decisions behind the cross-SDK cucumber wiring, the simulate / dryrun builders, the V3 source-map decoder, and the dual-format (`JSON`/msgpack) domain-type serialization.
 
 ## Writing Documentation
 

--- a/README.md
+++ b/README.md
@@ -81,17 +81,6 @@ cargo run --example quickstart
 
 If you see `Error: NotPresent`, your environment variables aren't set — `cp examples.env .env` and edit as needed.
 
-## Running the test suite
-
-```bash
-make setup           # rustfmt + clippy + lefthook hooks
-make ci              # fmt-check, clippy, unit tests, build, integration compile-check
-./test-harness.sh up # boot a local algorand sandbox (ports 60000/60001/60002)
-make integration     # run the cucumber suite against the sandbox
-```
-
-See `docs/adr/` for the architectural decisions behind the cross-SDK cucumber wiring, the simulate / dryrun builders, the V3 source-map decoder, and the dual-format (`JSON`/msgpack) domain-type serialization.
-
 ## Changelog
 
 See [CHANGELOG.md](./CHANGELOG.md).


### PR DESCRIPTION
## Summary
A docs refresh for CONTRIBUTING.md, in two parts.

### Submission Checklist
The checklist had bit-rotted:

- `cargo test --workspace --lib --examples --test test_logic_signature` — singles out one integration test (`tests/test_logic_signature.rs`) and skips the rest. `make test` runs `--tests`, which covers that file *and* the other integration targets.
- `cargo clippy -- -D warnings` — missing `--workspace --all-targets`, so it didn't match what CI actually runs.
- It predates the `Makefile` `ci` target and the `lefthook` pre-commit hook (both added in 0.5.0).
- It told contributors to run the integration suite but never said how to start the harness/runner.

Rewrites the checklist around `make ci` as the single source of truth, enumerates the underlying targets it runs, and notes the `lefthook` pre-commit hook runs `make ci` automatically.

### Running the test suite
Moves the `Running the test suite` section out of README.md and into CONTRIBUTING.md — running the suite is a contributor concern, not end-user documentation. The Submission Checklist now links to it as an in-page anchor. Also adds the missing `Running the test suite` and `Dependency Diagram` entries to the CONTRIBUTING.md table of contents.
