### PR TITLE
feat(core): add AppId, AssetId and TxId id newtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `algonaut_indexer` no longer fails to deserialize valid responses that omit a field the generated models marked mandatory. `Account`'s `total-*` count fields and the `genesis-hash` / `metadata-hash` / `transactions-root-sha256` fields on `Transaction`, `Block`, and `AssetParams` gained `#[serde(default)]`, so an absent value decodes (counts to `0`, optional hashes to `None`) instead of erroring. This brings `v2indexerclient_responses.feature` fully live (13/13 scenarios, none excluded)
 
+### Changed
+
+- **Breaking:** introduced the `algonaut_core::{AppId, AssetId, TxId}` newtypes and adopted them across the hand-written crates for full type safety. `AppId`/`AssetId` wrap `u64` and `TxId` wraps `String`; all three serialize transparently (wire-identical to the bare value). Application and asset ids — and transaction ids — in the transaction builders (`UpdateAsset`, `DestroyAsset`, `TransferAsset`, `AcceptAsset`, `ClawbackAsset`, `FreezeAsset`, `CreateApplication`, `UpdateApplication`, `CallApplication`, `OptInApplication`, `ClearApplication`, `CloseApplication`, `DeleteApplication`), the `Transaction`/`SignedTransaction` types and `Transaction::id`, the `algonaut_model` API transaction models, the `algonaut_abi::AbiContractNetworkInfo` type, and the `AtomicTransactionComposer` (`AddMethodCallParams::app_id`, `AbiMethodResult::tx_id`) now use these newtypes instead of bare `u64`/`String`. Wrap literals with `AppId(..)`/`AssetId(..)`/`TxId(..)` or use `.into()`; unwrap at generated-crate boundaries with `id.0` / `u64::from(id)` / `txid.as_str()` (#160)
+
 ## [0.6.0] - 2026-05-18
 
 ### Added

--- a/algonaut_abi/src/abi_interactions.rs
+++ b/algonaut_abi/src/abi_interactions.rs
@@ -1,6 +1,6 @@
 use super::abi_type::AbiType;
 use crate::abi_error::AbiError;
-use algonaut_core::{TransactionTypeEnum, error::CoreError};
+use algonaut_core::{AppId, TransactionTypeEnum, error::CoreError};
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
 use std::{collections::HashMap, convert::TryInto};
@@ -376,7 +376,7 @@ pub struct AbiInterface {
 pub struct AbiContractNetworkInfo {
     /// The application ID of the contract for this network
     #[serde(rename = "appID")]
-    pub app_id: u64,
+    pub app_id: AppId,
 }
 
 /// Represents an ABI contract, which is a concrete set of methods implemented by a single app

--- a/algonaut_abi/src/abi_json_tests.rs
+++ b/algonaut_abi/src/abi_json_tests.rs
@@ -3,6 +3,7 @@ mod tests {
     use crate::abi_interactions::{
         AbiContract, AbiContractNetworkInfo, AbiInterface, AbiMethod, AbiMethodArg, AbiReturn,
     };
+    use algonaut_core::AppId;
 
     #[test]
     fn test_encode_json_method() {
@@ -187,7 +188,7 @@ mod tests {
             },
         };
 
-        let network = AbiContractNetworkInfo { app_id: 123 };
+        let network = AbiContractNetworkInfo { app_id: AppId(123) };
 
         let contract = AbiContract {
             name: "contract".to_owned(),
@@ -232,7 +233,7 @@ mod tests {
             },
         };
 
-        let network = AbiContractNetworkInfo { app_id: 123 };
+        let network = AbiContractNetworkInfo { app_id: AppId(123) };
 
         let contract = AbiContract {
             name: "contract".to_owned(),
@@ -376,7 +377,7 @@ mod tests {
                 description: Some("example description".to_owned()),
                 networks: [(
                     "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=".to_owned(),
-                    AbiContractNetworkInfo { app_id: 10 }
+                    AbiContractNetworkInfo { app_id: AppId(10) }
                 )]
                 .into(),
                 methods

--- a/algonaut_core/src/lib.rs
+++ b/algonaut_core/src/lib.rs
@@ -120,6 +120,91 @@ impl From<u64> for Round {
     }
 }
 
+/// Identifier of an Algorand application (smart contract).
+///
+/// A tuple struct over `u64`; unlike a bare integer it cannot be mixed up
+/// with an [`AssetId`] or any other numeric value. Serializes transparently
+/// as its inner `u64`, so the wire format matches a plain integer.
+#[derive(
+    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize, Display,
+)]
+pub struct AppId(pub u64);
+
+impl From<u64> for AppId {
+    fn from(id: u64) -> Self {
+        AppId(id)
+    }
+}
+
+impl From<AppId> for u64 {
+    fn from(id: AppId) -> Self {
+        id.0
+    }
+}
+
+/// Identifier of an Algorand Standard Asset.
+///
+/// A tuple struct over `u64`; unlike a bare integer it cannot be mixed up
+/// with an [`AppId`] or any other numeric value. Serializes transparently
+/// as its inner `u64`, so the wire format matches a plain integer.
+#[derive(
+    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize, Display,
+)]
+pub struct AssetId(pub u64);
+
+impl From<u64> for AssetId {
+    fn from(id: u64) -> Self {
+        AssetId(id)
+    }
+}
+
+impl From<AssetId> for u64 {
+    fn from(id: AssetId) -> Self {
+        id.0
+    }
+}
+
+/// Identifier of an Algorand transaction: the base32-encoded SHA-512/256
+/// hash of the transaction.
+///
+/// A tuple struct over `String`. Serializes transparently as its inner
+/// `String`.
+#[derive(
+    Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize, Display,
+)]
+pub struct TxId(pub String);
+
+impl TxId {
+    /// Borrows the identifier as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for TxId {
+    fn from(id: String) -> Self {
+        TxId(id)
+    }
+}
+
+impl From<&str> for TxId {
+    fn from(id: &str) -> Self {
+        TxId(id.to_owned())
+    }
+}
+
+impl From<TxId> for String {
+    fn from(id: TxId) -> Self {
+        id.0
+    }
+}
+
+impl AsRef<str> for TxId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 /// Participation public key used in key registration transactions
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct VotePk(pub [u8; 32]);
@@ -464,5 +549,37 @@ mod tests {
     fn micro_algos_checked_mul() {
         assert_eq!(MicroAlgos(7).checked_mul(3), Some(MicroAlgos(21)));
         assert_eq!(MicroAlgos(u64::MAX).checked_mul(2), None);
+    }
+
+    #[test]
+    fn id_newtypes_serialize_transparently() {
+        // AppId / AssetId must be wire-identical to a bare u64 in both
+        // JSON and msgpack, otherwise transaction signing breaks.
+        assert_eq!(serde_json::to_string(&AppId(42)).unwrap(), "42");
+        assert_eq!(serde_json::to_string(&AssetId(7)).unwrap(), "7");
+        assert_eq!(
+            rmp_serde::to_vec(&AppId(42)).unwrap(),
+            rmp_serde::to_vec(&42u64).unwrap()
+        );
+        assert_eq!(
+            rmp_serde::to_vec(&AssetId(7)).unwrap(),
+            rmp_serde::to_vec(&7u64).unwrap()
+        );
+        assert_eq!(
+            serde_json::to_string(&TxId("ABC".to_owned())).unwrap(),
+            "\"ABC\""
+        );
+    }
+
+    #[test]
+    fn id_newtypes_round_trip_and_convert() {
+        let app: AppId = 99u64.into();
+        assert_eq!(u64::from(app), 99);
+        let asset: AssetId = 99u64.into();
+        assert_eq!(u64::from(asset), 99);
+        let tx: TxId = "XYZ".into();
+        assert_eq!(tx.as_str(), "XYZ");
+        assert_eq!(String::from(tx.clone()), "XYZ");
+        assert_eq!(serde_json::from_str::<AppId>("5").unwrap(), AppId(5));
     }
 }

--- a/algonaut_model/src/transaction.rs
+++ b/algonaut_model/src/transaction.rs
@@ -1,5 +1,6 @@
 use algonaut_core::{
-    Address, MicroAlgos, MultisigSignature, Round, StateProofPk, ToMsgPack, VotePk, VrfPk,
+    Address, AppId, AssetId, MicroAlgos, MultisigSignature, Round, StateProofPk, ToMsgPack, TxId,
+    VotePk, VrfPk,
 };
 use algonaut_crypto::{HashDigest, HashType, Signature};
 use algonaut_encoding::{deserialize_bytes64, serialize_bytes};
@@ -51,7 +52,7 @@ pub struct ApiTransaction {
     pub asset_params: Option<ApiAssetParams>,
 
     #[serde(rename = "apas", skip_serializing_if = "Option::is_none")]
-    pub foreign_assets: Option<Vec<u64>>,
+    pub foreign_assets: Option<Vec<AssetId>>,
 
     #[serde(rename = "apat", skip_serializing_if = "Option::is_none")]
     pub accounts: Option<Vec<Address>>,
@@ -63,13 +64,13 @@ pub struct ApiTransaction {
     pub extra_pages: Option<u32>,
 
     #[serde(rename = "apfa", skip_serializing_if = "Option::is_none")]
-    pub foreign_apps: Option<Vec<u64>>,
+    pub foreign_apps: Option<Vec<AppId>>,
 
     #[serde(rename = "apgs", skip_serializing_if = "Option::is_none")]
     pub global_state_schema: Option<ApiStateSchema>,
 
     #[serde(rename = "apid", skip_serializing_if = "Option::is_none")]
-    pub app_id: Option<u64>,
+    pub app_id: Option<AppId>,
 
     #[serde(rename = "apls", skip_serializing_if = "Option::is_none")]
     pub local_state_schema: Option<ApiStateSchema>,
@@ -89,7 +90,7 @@ pub struct ApiTransaction {
     pub asset_sender: Option<Address>,
 
     #[serde(rename = "caid", skip_serializing_if = "Option::is_none")]
-    pub config_asset: Option<u64>,
+    pub config_asset: Option<AssetId>,
 
     #[serde(rename = "close", skip_serializing_if = "Option::is_none")]
     pub close_reminder_to: Option<Address>,
@@ -98,7 +99,7 @@ pub struct ApiTransaction {
     pub freeze_account: Option<Address>,
 
     #[serde(rename = "faid", skip_serializing_if = "Option::is_none")]
-    pub asset_id: Option<u64>,
+    pub asset_id: Option<AssetId>,
 
     #[serde(rename = "fee", skip_serializing_if = "Option::is_none")]
     pub fee: Option<MicroAlgos>, // optional for serialization zero value omission
@@ -172,7 +173,7 @@ pub struct ApiTransaction {
     pub vote_last: Option<Round>,
 
     #[serde(rename = "xaid", skip_serializing_if = "Option::is_none")]
-    pub xfer: Option<u64>,
+    pub xfer: Option<AssetId>,
 }
 
 #[derive(Default, Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
@@ -208,7 +209,7 @@ pub struct ApiSignedTransaction {
     pub auth_address: Option<Address>,
 
     #[serde(skip)]
-    pub transaction_id: String,
+    pub transaction_id: TxId,
 }
 
 #[derive(Default, Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]

--- a/algonaut_transaction/src/api_model.rs
+++ b/algonaut_transaction/src/api_model.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     tx_group::TxGroup,
 };
-use algonaut_core::{CompiledTeal, LogicSignature, MicroAlgos, Round, ToMsgPack};
+use algonaut_core::{AppId, AssetId, CompiledTeal, LogicSignature, MicroAlgos, Round, ToMsgPack};
 use algonaut_model::transaction::{
     ApiAssetParams, ApiBoxReference, ApiSignedLogic, ApiSignedLogicArg, ApiSignedTransaction,
     ApiStateSchema, ApiTransaction, AppArgument,
@@ -91,10 +91,14 @@ impl TryFrom<Transaction> for ApiTransaction {
             }
             TransactionType::AssetConfigurationTransaction(config) => {
                 api_t.asset_params = config.to_owned().params.map(|p| p.into());
-                api_t.config_asset = config.config_asset.and_then(num_as_api_option);
+                api_t.config_asset = config
+                    .config_asset
+                    .map(u64::from)
+                    .and_then(num_as_api_option)
+                    .map(AssetId::from);
             }
             TransactionType::AssetTransferTransaction(transfer) => {
-                api_t.xfer = num_as_api_option(transfer.xfer);
+                api_t.xfer = num_as_api_option(u64::from(transfer.xfer)).map(AssetId::from);
                 api_t.asset_amount = num_as_api_option(transfer.amount);
                 api_t.asset_receiver = Some(transfer.receiver);
                 api_t.asset_close_to = transfer.close_to;
@@ -112,11 +116,15 @@ impl TryFrom<Transaction> for ApiTransaction {
             }
             TransactionType::AssetFreezeTransaction(freeze) => {
                 api_t.freeze_account = Some(freeze.freeze_account);
-                api_t.asset_id = num_as_api_option(freeze.asset_id);
+                api_t.asset_id = num_as_api_option(u64::from(freeze.asset_id)).map(AssetId::from);
                 api_t.frozen = bool_as_api_option(freeze.frozen);
             }
             TransactionType::ApplicationCallTransaction(call) => {
-                api_t.app_id = call.app_id.and_then(num_as_api_option);
+                api_t.app_id = call
+                    .app_id
+                    .map(u64::from)
+                    .and_then(num_as_api_option)
+                    .map(AppId::from);
                 api_t.on_complete =
                     num_as_api_option(application_call_on_complete_to_int(&call.on_complete));
                 api_t.accounts = call.accounts.clone().and_then(vec_as_api_option);
@@ -254,7 +262,7 @@ impl TryFrom<ApiTransaction> for Transaction {
 
 fn parse_state_schema(
     on_complete: ApplicationCallOnComplete,
-    app_id: Option<u64>,
+    app_id: Option<AppId>,
     api_state_schema: Option<ApiStateSchema>,
 ) -> Option<StateSchema> {
     match (on_complete, app_id) {
@@ -574,26 +582,26 @@ fn int_to_application_call_on_complete(
 }
 
 trait AppCallMetadata {
-    fn current_app_id(&self) -> Option<u64>;
-    fn foreign_apps(&self) -> Option<&Vec<u64>>;
+    fn current_app_id(&self) -> Option<AppId>;
+    fn foreign_apps(&self) -> Option<&Vec<AppId>>;
 }
 
 impl AppCallMetadata for &ApplicationCallTransaction {
-    fn current_app_id(&self) -> Option<u64> {
+    fn current_app_id(&self) -> Option<AppId> {
         self.app_id
     }
 
-    fn foreign_apps(&self) -> Option<&Vec<u64>> {
+    fn foreign_apps(&self) -> Option<&Vec<AppId>> {
         self.foreign_apps.as_ref()
     }
 }
 
 impl AppCallMetadata for &ApiTransaction {
-    fn current_app_id(&self) -> Option<u64> {
+    fn current_app_id(&self) -> Option<AppId> {
         self.app_id
     }
 
-    fn foreign_apps(&self) -> Option<&Vec<u64>> {
+    fn foreign_apps(&self) -> Option<&Vec<AppId>> {
         self.foreign_apps.as_ref()
     }
 }
@@ -618,7 +626,7 @@ where
                 index = num_as_api_option(0);
             } else {
                 let mut idx = 0;
-                if app_id > 0 {
+                if app_id.0 > 0 {
                     let pos = info
                         .call_metadata
                         .foreign_apps()
@@ -731,16 +739,16 @@ mod tests {
     use super::*;
 
     struct DummyAppCall {
-        app_id: Option<u64>,
-        foreign_apps: Option<Vec<u64>>,
+        app_id: Option<AppId>,
+        foreign_apps: Option<Vec<AppId>>,
     }
 
     impl AppCallMetadata for &DummyAppCall {
-        fn current_app_id(&self) -> Option<u64> {
+        fn current_app_id(&self) -> Option<AppId> {
             self.app_id
         }
 
-        fn foreign_apps(&self) -> Option<&Vec<u64>> {
+        fn foreign_apps(&self) -> Option<&Vec<AppId>> {
             self.foreign_apps.as_ref()
         }
     }
@@ -793,21 +801,21 @@ mod tests {
     fn test_api_box_references_from_box_references() {
         let box_name = vec![1, 2, 3, 4];
         let dummy_app_call = DummyAppCall {
-            app_id: Some(6355),
-            foreign_apps: Some(vec![8577, 7466]),
+            app_id: Some(AppId(6355)),
+            foreign_apps: Some(vec![AppId(8577), AppId(7466)]),
         };
 
         let boxes = vec![
             BoxReference {
-                app_id: Some(6355),
+                app_id: Some(AppId(6355)),
                 name: box_name.clone(),
             },
             BoxReference {
-                app_id: Some(7466),
+                app_id: Some(AppId(7466)),
                 name: box_name.clone(),
             },
             BoxReference {
-                app_id: Some(8577),
+                app_id: Some(AppId(8577)),
                 name: box_name.clone(),
             },
         ];
@@ -831,11 +839,11 @@ mod tests {
         let box_name = vec![1, 2, 3, 4];
 
         let dummy_app_call = DummyAppCall {
-            app_id: Some(6355),
-            foreign_apps: Some(vec![8577, 7466]),
+            app_id: Some(AppId(6355)),
+            foreign_apps: Some(vec![AppId(8577), AppId(7466)]),
         };
         let boxes = vec![BoxReference {
-            app_id: Some(1234),
+            app_id: Some(AppId(1234)),
             name: box_name.clone(),
         }];
 

--- a/algonaut_transaction/src/builder.rs
+++ b/algonaut_transaction/src/builder.rs
@@ -7,7 +7,9 @@ use crate::{
         Transaction, TransactionType,
     },
 };
-use algonaut_core::{Address, CompiledTeal, MicroAlgos, Round, StateProofPk, VotePk, VrfPk};
+use algonaut_core::{
+    Address, AppId, AssetId, CompiledTeal, MicroAlgos, Round, StateProofPk, VotePk, VrfPk,
+};
 use algonaut_crypto::HashDigest;
 
 pub trait TransactionParams {
@@ -332,7 +334,7 @@ impl CreateAsset {
 /// A builder for [AssetConfigurationTransaction].
 pub struct UpdateAsset {
     sender: Address,
-    asset_id: u64,
+    asset_id: AssetId,
     total: Option<u64>,
     decimals: Option<u32>,
     default_frozen: Option<bool>,
@@ -347,7 +349,7 @@ pub struct UpdateAsset {
 }
 
 impl UpdateAsset {
-    pub fn new(sender: Address, asset_id: u64) -> Self {
+    pub fn new(sender: Address, asset_id: AssetId) -> Self {
         UpdateAsset {
             sender,
             asset_id,
@@ -444,11 +446,11 @@ impl UpdateAsset {
 /// A builder for [AssetConfigurationTransaction].
 pub struct DestroyAsset {
     sender: Address,
-    asset_id: u64,
+    asset_id: AssetId,
 }
 
 impl DestroyAsset {
-    pub fn new(sender: Address, asset_id: u64) -> Self {
+    pub fn new(sender: Address, asset_id: AssetId) -> Self {
         DestroyAsset { sender, asset_id }
     }
 
@@ -464,14 +466,14 @@ impl DestroyAsset {
 /// A builder for [AssetTransferTransaction].
 pub struct TransferAsset {
     sender: Address,
-    xfer: u64,
+    xfer: AssetId,
     amount: u64,
     receiver: Address,
     close_to: Option<Address>,
 }
 
 impl TransferAsset {
-    pub fn new(sender: Address, asset_id: u64, amount: u64, receiver: Address) -> Self {
+    pub fn new(sender: Address, asset_id: AssetId, amount: u64, receiver: Address) -> Self {
         TransferAsset {
             sender,
             xfer: asset_id,
@@ -500,11 +502,11 @@ impl TransferAsset {
 /// A builder for [AssetAcceptTransaction].
 pub struct AcceptAsset {
     sender: Address,
-    asset_id: u64,
+    asset_id: AssetId,
 }
 
 impl AcceptAsset {
-    pub fn new(sender: Address, asset_id: u64) -> Self {
+    pub fn new(sender: Address, asset_id: AssetId) -> Self {
         AcceptAsset { sender, asset_id }
     }
 
@@ -519,7 +521,7 @@ impl AcceptAsset {
 /// A builder for [AssetClawbackTransaction].
 pub struct ClawbackAsset {
     sender: Address,
-    asset_id: u64,
+    asset_id: AssetId,
     asset_amount: u64,
     asset_sender: Address,
     asset_receiver: Address,
@@ -529,7 +531,7 @@ pub struct ClawbackAsset {
 impl ClawbackAsset {
     pub fn new(
         sender: Address,
-        asset_id: u64,
+        asset_id: AssetId,
         asset_amount: u64,
         asset_sender: Address,
         asset_receiver: Address,
@@ -565,12 +567,12 @@ impl ClawbackAsset {
 pub struct FreezeAsset {
     sender: Address,
     freeze_account: Address,
-    asset_id: u64,
+    asset_id: AssetId,
     frozen: bool,
 }
 
 impl FreezeAsset {
-    pub fn new(sender: Address, freeze_account: Address, asset_id: u64, frozen: bool) -> Self {
+    pub fn new(sender: Address, freeze_account: Address, asset_id: AssetId, frozen: bool) -> Self {
         FreezeAsset {
             sender,
             freeze_account,
@@ -596,8 +598,8 @@ pub struct CreateApplication {
     approval_program: Option<CompiledTeal>,
     app_arguments: Option<Vec<Vec<u8>>>,
     clear_state_program: Option<CompiledTeal>,
-    foreign_apps: Option<Vec<u64>>,
-    foreign_assets: Option<Vec<u64>>,
+    foreign_apps: Option<Vec<AppId>>,
+    foreign_assets: Option<Vec<AssetId>>,
     global_state_schema: Option<StateSchema>,
     local_state_schema: Option<StateSchema>,
     extra_pages: u32,
@@ -637,12 +639,12 @@ impl CreateApplication {
         self
     }
 
-    pub fn foreign_apps(mut self, foreign_apps: Vec<u64>) -> Self {
+    pub fn foreign_apps(mut self, foreign_apps: Vec<AppId>) -> Self {
         self.foreign_apps = Some(foreign_apps);
         self
     }
 
-    pub fn foreign_assets(mut self, foreign_assets: Vec<u64>) -> Self {
+    pub fn foreign_assets(mut self, foreign_assets: Vec<AssetId>) -> Self {
         self.foreign_assets = Some(foreign_assets);
         self
     }
@@ -679,20 +681,20 @@ impl CreateApplication {
 /// A builder for [ApplicationCallTransaction].
 pub struct UpdateApplication {
     sender: Address,
-    app_id: u64,
+    app_id: AppId,
     accounts: Option<Vec<Address>>,
     approval_program: Option<CompiledTeal>,
     app_arguments: Option<Vec<Vec<u8>>>,
     clear_state_program: Option<CompiledTeal>,
-    foreign_apps: Option<Vec<u64>>,
-    foreign_assets: Option<Vec<u64>>,
+    foreign_apps: Option<Vec<AppId>>,
+    foreign_assets: Option<Vec<AssetId>>,
     boxes: Option<Vec<BoxReference>>,
 }
 
 impl UpdateApplication {
     pub fn new(
         sender: Address,
-        app_id: u64,
+        app_id: AppId,
         approval_program: CompiledTeal,
         clear_state_program: CompiledTeal,
     ) -> Self {
@@ -719,12 +721,12 @@ impl UpdateApplication {
         self
     }
 
-    pub fn foreign_apps(mut self, foreign_apps: Vec<u64>) -> Self {
+    pub fn foreign_apps(mut self, foreign_apps: Vec<AppId>) -> Self {
         self.foreign_apps = Some(foreign_apps);
         self
     }
 
-    pub fn foreign_assets(mut self, foreign_assets: Vec<u64>) -> Self {
+    pub fn foreign_assets(mut self, foreign_assets: Vec<AssetId>) -> Self {
         self.foreign_assets = Some(foreign_assets);
         self
     }
@@ -756,16 +758,16 @@ impl UpdateApplication {
 /// A builder for [ApplicationCallTransaction].
 pub struct CallApplication {
     sender: Address,
-    app_id: u64,
+    app_id: AppId,
     accounts: Option<Vec<Address>>,
     app_arguments: Option<Vec<Vec<u8>>>,
-    foreign_apps: Option<Vec<u64>>,
-    foreign_assets: Option<Vec<u64>>,
+    foreign_apps: Option<Vec<AppId>>,
+    foreign_assets: Option<Vec<AssetId>>,
     boxes: Option<Vec<BoxReference>>,
 }
 
 impl CallApplication {
-    pub fn new(sender: Address, app_id: u64) -> Self {
+    pub fn new(sender: Address, app_id: AppId) -> Self {
         CallApplication {
             sender,
             app_id,
@@ -787,12 +789,12 @@ impl CallApplication {
         self
     }
 
-    pub fn foreign_apps(mut self, foreign_apps: Vec<u64>) -> Self {
+    pub fn foreign_apps(mut self, foreign_apps: Vec<AppId>) -> Self {
         self.foreign_apps = Some(foreign_apps);
         self
     }
 
-    pub fn foreign_assets(mut self, foreign_assets: Vec<u64>) -> Self {
+    pub fn foreign_assets(mut self, foreign_assets: Vec<AssetId>) -> Self {
         self.foreign_assets = Some(foreign_assets);
         self
     }
@@ -824,16 +826,16 @@ impl CallApplication {
 /// A builder for [ApplicationCallTransaction].
 pub struct ClearApplication {
     sender: Address,
-    app_id: u64,
+    app_id: AppId,
     accounts: Option<Vec<Address>>,
     app_arguments: Option<Vec<Vec<u8>>>,
-    foreign_apps: Option<Vec<u64>>,
-    foreign_assets: Option<Vec<u64>>,
+    foreign_apps: Option<Vec<AppId>>,
+    foreign_assets: Option<Vec<AssetId>>,
     boxes: Option<Vec<BoxReference>>,
 }
 
 impl ClearApplication {
-    pub fn new(sender: Address, app_id: u64) -> Self {
+    pub fn new(sender: Address, app_id: AppId) -> Self {
         ClearApplication {
             sender,
             app_id,
@@ -855,12 +857,12 @@ impl ClearApplication {
         self
     }
 
-    pub fn foreign_apps(mut self, foreign_apps: Vec<u64>) -> Self {
+    pub fn foreign_apps(mut self, foreign_apps: Vec<AppId>) -> Self {
         self.foreign_apps = Some(foreign_apps);
         self
     }
 
-    pub fn foreign_assets(mut self, foreign_assets: Vec<u64>) -> Self {
+    pub fn foreign_assets(mut self, foreign_assets: Vec<AssetId>) -> Self {
         self.foreign_assets = Some(foreign_assets);
         self
     }
@@ -892,16 +894,16 @@ impl ClearApplication {
 /// A builder for [ApplicationCallTransaction].
 pub struct CloseApplication {
     sender: Address,
-    app_id: u64,
+    app_id: AppId,
     accounts: Option<Vec<Address>>,
     app_arguments: Option<Vec<Vec<u8>>>,
-    foreign_apps: Option<Vec<u64>>,
-    foreign_assets: Option<Vec<u64>>,
+    foreign_apps: Option<Vec<AppId>>,
+    foreign_assets: Option<Vec<AssetId>>,
     boxes: Option<Vec<BoxReference>>,
 }
 
 impl CloseApplication {
-    pub fn new(sender: Address, app_id: u64) -> Self {
+    pub fn new(sender: Address, app_id: AppId) -> Self {
         CloseApplication {
             sender,
             app_id,
@@ -923,12 +925,12 @@ impl CloseApplication {
         self
     }
 
-    pub fn foreign_apps(mut self, foreign_apps: Vec<u64>) -> Self {
+    pub fn foreign_apps(mut self, foreign_apps: Vec<AppId>) -> Self {
         self.foreign_apps = Some(foreign_apps);
         self
     }
 
-    pub fn foreign_assets(mut self, foreign_assets: Vec<u64>) -> Self {
+    pub fn foreign_assets(mut self, foreign_assets: Vec<AssetId>) -> Self {
         self.foreign_assets = Some(foreign_assets);
         self
     }
@@ -960,16 +962,16 @@ impl CloseApplication {
 /// A builder for [ApplicationCallTransaction].
 pub struct DeleteApplication {
     sender: Address,
-    app_id: u64,
+    app_id: AppId,
     accounts: Option<Vec<Address>>,
     app_arguments: Option<Vec<Vec<u8>>>,
-    foreign_apps: Option<Vec<u64>>,
-    foreign_assets: Option<Vec<u64>>,
+    foreign_apps: Option<Vec<AppId>>,
+    foreign_assets: Option<Vec<AssetId>>,
     boxes: Option<Vec<BoxReference>>,
 }
 
 impl DeleteApplication {
-    pub fn new(sender: Address, app_id: u64) -> Self {
+    pub fn new(sender: Address, app_id: AppId) -> Self {
         DeleteApplication {
             sender,
             app_id,
@@ -991,12 +993,12 @@ impl DeleteApplication {
         self
     }
 
-    pub fn foreign_apps(mut self, foreign_apps: Vec<u64>) -> Self {
+    pub fn foreign_apps(mut self, foreign_apps: Vec<AppId>) -> Self {
         self.foreign_apps = Some(foreign_apps);
         self
     }
 
-    pub fn foreign_assets(mut self, foreign_assets: Vec<u64>) -> Self {
+    pub fn foreign_assets(mut self, foreign_assets: Vec<AssetId>) -> Self {
         self.foreign_assets = Some(foreign_assets);
         self
     }
@@ -1028,16 +1030,16 @@ impl DeleteApplication {
 /// A builder for [ApplicationCallTransaction].
 pub struct OptInApplication {
     sender: Address,
-    app_id: u64,
+    app_id: AppId,
     accounts: Option<Vec<Address>>,
     app_arguments: Option<Vec<Vec<u8>>>,
-    foreign_apps: Option<Vec<u64>>,
-    foreign_assets: Option<Vec<u64>>,
+    foreign_apps: Option<Vec<AppId>>,
+    foreign_assets: Option<Vec<AssetId>>,
     boxes: Option<Vec<BoxReference>>,
 }
 
 impl OptInApplication {
-    pub fn new(sender: Address, app_id: u64) -> Self {
+    pub fn new(sender: Address, app_id: AppId) -> Self {
         OptInApplication {
             sender,
             app_id,
@@ -1059,12 +1061,12 @@ impl OptInApplication {
         self
     }
 
-    pub fn foreign_apps(mut self, foreign_apps: Vec<u64>) -> Self {
+    pub fn foreign_apps(mut self, foreign_apps: Vec<AppId>) -> Self {
         self.foreign_apps = Some(foreign_apps);
         self
     }
 
-    pub fn foreign_assets(mut self, foreign_assets: Vec<u64>) -> Self {
+    pub fn foreign_assets(mut self, foreign_assets: Vec<AssetId>) -> Self {
         self.foreign_assets = Some(foreign_assets);
         self
     }

--- a/algonaut_transaction/src/transaction.rs
+++ b/algonaut_transaction/src/transaction.rs
@@ -5,6 +5,7 @@ use algonaut_core::SuggestedTransactionParams;
 use algonaut_core::ToMsgPack;
 use algonaut_core::TransactionTypeEnum;
 use algonaut_core::{Address, MultisigSignature};
+use algonaut_core::{AppId, AssetId, TxId};
 use algonaut_core::{MicroAlgos, Round, StateProofPk, VotePk, VrfPk};
 use algonaut_crypto::HashDigest;
 use algonaut_crypto::Signature;
@@ -99,8 +100,8 @@ impl Transaction {
         Ok(HashDigest(hashed.into()))
     }
 
-    pub fn id(&self) -> Result<String, TransactionError> {
-        Ok(BASE32_NOPAD.encode(&self.raw_id()?.0))
+    pub fn id(&self) -> Result<TxId, TransactionError> {
+        Ok(TxId(BASE32_NOPAD.encode(&self.raw_id()?.0)))
     }
 
     pub fn assign_group_id(&mut self, group_id: HashDigest) {
@@ -211,7 +212,7 @@ pub struct AssetConfigurationTransaction {
     /// For re-configure or destroy transactions, this is the unique asset ID. On asset creation,
     /// the ID is set to zero.
     /// NOTE: Algorand's REST documentation seems incorrect. The ID has to be not set for creation to work.
-    pub config_asset: Option<u64>,
+    pub config_asset: Option<AssetId>,
 }
 
 /// This is used to create or configure an asset.
@@ -266,7 +267,7 @@ pub struct AssetTransferTransaction {
     pub sender: Address,
 
     /// The unique ID of the asset to be transferred.
-    pub xfer: u64,
+    pub xfer: AssetId,
 
     /// The amount of the asset to be transferred. A zero amount transferred to self allocates that
     /// asset in the account's Asset map.
@@ -287,7 +288,7 @@ pub struct AssetAcceptTransaction {
     pub sender: Address,
 
     /// The unique ID of the asset to be transferred.
-    pub xfer: u64,
+    pub xfer: AssetId,
 }
 
 /// This is a special form of an Asset Transfer Transaction.
@@ -297,7 +298,7 @@ pub struct AssetClawbackTransaction {
     pub sender: Address,
 
     /// The unique ID of the asset to be transferred.
-    pub xfer: u64,
+    pub xfer: AssetId,
 
     /// The amount of the asset to be transferred.
     pub asset_amount: u64,
@@ -323,7 +324,7 @@ pub struct AssetFreezeTransaction {
     pub freeze_account: Address,
 
     /// The asset ID being frozen or unfrozen.
-    pub asset_id: u64,
+    pub asset_id: AssetId,
 
     /// True to freeze the asset.
     pub frozen: bool,
@@ -335,7 +336,7 @@ pub struct ApplicationCallTransaction {
     pub sender: Address,
 
     /// ID of the application being configured or empty if creating.
-    pub app_id: Option<u64>,
+    pub app_id: Option<AppId>,
 
     /// Defines what additional actions occur with the transaction. See the OnComplete section of
     /// the TEAL spec for details.
@@ -361,11 +362,11 @@ pub struct ApplicationCallTransaction {
 
     /// Lists the applications in addition to the application-id whose global states may be accessed
     /// by this application's approval-program and clear-state-program. The access is read-only.
-    pub foreign_apps: Option<Vec<u64>>,
+    pub foreign_apps: Option<Vec<AppId>>,
 
     /// Lists the assets whose AssetParams may be accessed by this application's approval-program and
     /// clear-state-program. The access is read-only.
-    pub foreign_assets: Option<Vec<u64>>,
+    pub foreign_assets: Option<Vec<AssetId>>,
 
     /// Holds the maximum number of global state values defined within a StateSchema object.
     pub global_state_schema: Option<StateSchema>,
@@ -383,7 +384,7 @@ pub struct ApplicationCallTransaction {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BoxReference {
     /// The ID of the application that this box belongs to
-    pub app_id: Option<u64>,
+    pub app_id: Option<AppId>,
 
     /// The name of the box as bytes
     pub name: Vec<u8>,
@@ -434,7 +435,7 @@ pub struct StateSchema {
 #[derive(Clone, Debug, PartialEq)]
 pub struct SignedTransaction {
     pub transaction: Transaction,
-    pub transaction_id: String,
+    pub transaction_id: TxId,
     pub sig: TransactionSignature,
     pub auth_address: Option<Address>,
 }

--- a/examples/app_call.rs
+++ b/examples/app_call.rs
@@ -1,4 +1,5 @@
 use algonaut::algod::v2::Algod;
+use algonaut::core::AppId;
 use algonaut::transaction::TxnBuilder;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::builder::CallApplication;
@@ -26,7 +27,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let t = TxnBuilder::with(
         &params,
         // TODO set a correct app-id here
-        CallApplication::new(alice.address(), 5)
+        CallApplication::new(alice.address(), AppId(5))
             .app_arguments(vec![vec![1, 0], vec![255]])
             .build(),
     )

--- a/examples/app_clear_state.rs
+++ b/examples/app_clear_state.rs
@@ -1,4 +1,5 @@
 use algonaut::algod::v2::Algod;
+use algonaut::core::AppId;
 use algonaut::transaction::TxnBuilder;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::builder::ClearApplication;
@@ -25,8 +26,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     info!("building CreateApplication transaction");
     // to test this, create an application that sets local state and opt-in, for/with the account sending this transaction.
     // TODO set a correct app-id here
-    let t =
-        TxnBuilder::with(&params, ClearApplication::new(alice.address(), 11).build()).build()?;
+    let t = TxnBuilder::with(
+        &params,
+        ClearApplication::new(alice.address(), AppId(11)).build(),
+    )
+    .build()?;
 
     info!("signing transaction");
     let signed_t = alice.sign_transaction(t)?;

--- a/examples/app_close_out.rs
+++ b/examples/app_close_out.rs
@@ -1,4 +1,5 @@
 use algonaut::algod::v2::Algod;
+use algonaut::core::AppId;
 use algonaut::transaction::TxnBuilder;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::builder::CloseApplication;
@@ -26,7 +27,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // to test this, create an application that sets local state and opt-in, for/with the account sending this transaction.
     // the approval program has to return success for the local state to be cleared.
     // TODO set a correct app-id here
-    let t = TxnBuilder::with(&params, CloseApplication::new(alice.address(), 0).build()).build()?;
+    let t = TxnBuilder::with(
+        &params,
+        CloseApplication::new(alice.address(), AppId(0)).build(),
+    )
+    .build()?;
 
     info!("signing transaction");
     let signed_t = alice.sign_transaction(t)?;

--- a/examples/app_delete.rs
+++ b/examples/app_delete.rs
@@ -1,4 +1,5 @@
 use algonaut::algod::v2::Algod;
+use algonaut::core::AppId;
 use algonaut::transaction::TxnBuilder;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::builder::DeleteApplication;
@@ -25,7 +26,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     info!("building DeleteApplication transaction");
     let t = TxnBuilder::with(
         &params,
-        DeleteApplication::new(alice.address(), 3)
+        DeleteApplication::new(alice.address(), AppId(3))
             .app_arguments(vec![vec![1, 0], vec![255]])
             .build(),
     )

--- a/examples/app_optin.rs
+++ b/examples/app_optin.rs
@@ -1,4 +1,5 @@
 use algonaut::algod::v2::Algod;
+use algonaut::core::AppId;
 use algonaut::transaction::TxnBuilder;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::builder::OptInApplication;
@@ -26,7 +27,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let t = TxnBuilder::with(
         &params,
         // TODO set a correct app-id here
-        OptInApplication::new(alice.address(), 11)
+        OptInApplication::new(alice.address(), AppId(11))
             .app_arguments(vec![vec![1, 0], vec![255]])
             .build(),
     )

--- a/examples/app_update.rs
+++ b/examples/app_update.rs
@@ -1,4 +1,5 @@
 use algonaut::algod::v2::Algod;
+use algonaut::core::AppId;
 use algonaut::transaction::TxnBuilder;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::builder::UpdateApplication;
@@ -47,7 +48,7 @@ int 1
         &params,
         UpdateApplication::new(
             alice.address(),
-            5,
+            AppId(5),
             compiled_approval_program,
             compiled_clear_program,
         )

--- a/examples/asset_clawback.rs
+++ b/examples/asset_clawback.rs
@@ -1,4 +1,5 @@
 use algonaut::algod::v2::Algod;
+use algonaut::core::AssetId;
 use algonaut::transaction::ClawbackAsset;
 use algonaut::transaction::{TxnBuilder, account::Account};
 use dotenv::dotenv;
@@ -29,7 +30,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
     info!("building ClawbackAsset transaction");
     let t = TxnBuilder::with(
         &params,
-        ClawbackAsset::new(alice.address(), 21, 1, bob.address(), alice.address()).build(),
+        ClawbackAsset::new(
+            alice.address(),
+            AssetId(21),
+            1,
+            bob.address(),
+            alice.address(),
+        )
+        .build(),
     )
     .build()?;
 

--- a/examples/asset_optin.rs
+++ b/examples/asset_optin.rs
@@ -1,4 +1,5 @@
 use algonaut::algod::v2::Algod;
+use algonaut::core::AssetId;
 use algonaut::transaction::AcceptAsset;
 use algonaut::transaction::{TxnBuilder, account::Account};
 use dotenv::dotenv;
@@ -23,7 +24,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.txn_params().await?;
 
     info!("building AcceptAsset transaction");
-    let t = TxnBuilder::with(&params, AcceptAsset::new(bob.address(), 16).build()).build()?;
+    let t = TxnBuilder::with(
+        &params,
+        AcceptAsset::new(bob.address(), AssetId(16)).build(),
+    )
+    .build()?;
 
     info!("signing transaction");
     let sign_response = bob.sign_transaction(t)?;

--- a/examples/asset_transfer.rs
+++ b/examples/asset_transfer.rs
@@ -1,4 +1,5 @@
 use algonaut::algod::v2::Algod;
+use algonaut::core::AssetId;
 use algonaut::transaction::TransferAsset;
 use algonaut::transaction::{TxnBuilder, account::Account};
 use dotenv::dotenv;
@@ -25,7 +26,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     info!("building TransferAsset transaction");
     let t = TxnBuilder::with(
         &params,
-        TransferAsset::new(alice.address(), 16, 1, bob.address()).build(),
+        TransferAsset::new(alice.address(), AssetId(16), 1, bob.address()).build(),
     )
     .build()?;
 

--- a/examples/logic_sig_delegated.rs
+++ b/examples/logic_sig_delegated.rs
@@ -1,5 +1,5 @@
 use algonaut::algod::v2::Algod;
-use algonaut::core::{LogicSignature, MicroAlgos};
+use algonaut::core::{LogicSignature, MicroAlgos, TxId};
 use algonaut::transaction::transaction::TransactionSignature;
 use algonaut::transaction::{Pay, SignedTransaction};
 use algonaut::transaction::{TxnBuilder, account::Account};
@@ -52,7 +52,7 @@ int 1
     info!("delegating signature for the transaction");
     let signed_t = SignedTransaction {
         transaction: t,
-        transaction_id: "".to_owned(),
+        transaction_id: TxId::default(),
         sig: TransactionSignature::Logic(SignedLogic {
             logic: program,
             args: vec![],

--- a/examples/logic_sig_delegated_multi.rs
+++ b/examples/logic_sig_delegated_multi.rs
@@ -1,5 +1,5 @@
 use algonaut::algod::v2::Algod;
-use algonaut::core::{LogicSignature, MicroAlgos, MultisigAddress};
+use algonaut::core::{LogicSignature, MicroAlgos, MultisigAddress, TxId};
 use algonaut::transaction::transaction::TransactionSignature;
 use algonaut::transaction::{Pay, SignedTransaction};
 use algonaut::transaction::{TxnBuilder, account::Account};
@@ -68,7 +68,7 @@ int 1
     info!("signing transaction");
     let signed_t = SignedTransaction {
         transaction: t,
-        transaction_id: "".to_owned(),
+        transaction_id: TxId::default(),
         sig,
         auth_address: None,
     };

--- a/examples/multi_sig.rs
+++ b/examples/multi_sig.rs
@@ -1,5 +1,5 @@
 use algonaut::algod::v2::Algod;
-use algonaut::core::{MicroAlgos, MultisigAddress};
+use algonaut::core::{MicroAlgos, MultisigAddress, TxId};
 use algonaut::transaction::transaction::TransactionSignature;
 use algonaut::transaction::{Pay, SignedTransaction};
 use algonaut::transaction::{TxnBuilder, account::Account};
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     info!("signing transaction");
     let signed_t = SignedTransaction {
         transaction: t,
-        transaction_id: "".to_owned(),
+        transaction_id: TxId::default(),
         sig,
         auth_address: None,
     };

--- a/src/atomic_transaction_composer/mod.rs
+++ b/src/atomic_transaction_composer/mod.rs
@@ -12,7 +12,7 @@ use algonaut_algod::models::{
     PendingTransactionResponse, SimulateRequest, SimulateRequestTransactionGroup,
     SimulateTransaction200Response, TransactionParams200Response,
 };
-use algonaut_core::{Address, CompiledTeal, MicroAlgos};
+use algonaut_core::{Address, AppId, AssetId, CompiledTeal, MicroAlgos, TxId};
 use algonaut_crypto::HashDigest;
 use algonaut_transaction::{
     SignedTransaction, Transaction, TransactionType, TxnBuilder,
@@ -56,7 +56,7 @@ pub struct TransactionWithSigner {
 #[derive(Debug, Clone)]
 pub struct AbiMethodResult {
     /// The TxID of the transaction that invoked the ABI method call.
-    pub tx_id: String,
+    pub tx_id: TxId,
     /// Information about the confirmed transaction that invoked the ABI method call.
     pub tx_info: PendingTransactionResponse,
     /// The method's return value
@@ -75,7 +75,7 @@ pub enum AbiMethodReturnValue {
 /// Contains the parameters for the method AtomicTransactionComposer.AddMethodCall
 pub struct AddMethodCallParams {
     /// The ID of the smart contract to call. Set this to 0 to indicate an application creation call.
-    pub app_id: u64,
+    pub app_id: AppId,
     /// The method to call on the smart contract
     pub method: AbiMethod,
     /// The arguments to include in the method call. If omitted, no arguments will be passed to the method.
@@ -452,7 +452,7 @@ impl AtomicTransactionComposer {
     fn get_txs_ids(&self) -> Vec<String> {
         self.signed_txs
             .iter()
-            .map(|t| t.transaction_id.clone())
+            .map(|t| t.transaction_id.0.clone())
             .collect()
     }
 
@@ -487,8 +487,8 @@ impl AtomicTransactionComposer {
             }
         }
 
-        let tx_id = &self.signed_txs[index_to_wait].transaction_id;
-        let pending_tx = wait_for_pending_transaction(algod, tx_id).await?;
+        let tx_id = self.signed_txs[index_to_wait].transaction_id.clone();
+        let pending_tx = wait_for_pending_transaction(algod, tx_id.as_str()).await?;
 
         let mut return_list: Vec<AbiMethodResult> = vec![];
 
@@ -505,7 +505,7 @@ impl AtomicTransactionComposer {
             if i != index_to_wait {
                 let tx_id = self.signed_txs[i].transaction_id.clone();
 
-                match algod.pending_txn(&tx_id).await {
+                match algod.pending_txn(tx_id.as_str()).await {
                     Ok(p) => {
                         current_tx_id = tx_id;
                         current_pending_tx = p;
@@ -603,7 +603,7 @@ impl AtomicTransactionComposer {
 
 fn get_return_value_with_return_type(
     pending_tx: &PendingTransactionResponse,
-    tx_id: &str, // our txn in PendingTransaction currently has no fields, so the tx id is passed separately
+    tx_id: &TxId, // our txn in PendingTransaction currently has no fields, so the tx id is passed separately
     return_type: AbiReturnType,
 ) -> Result<AbiMethodResult, Error> {
     let return_value = match return_type {
@@ -698,14 +698,14 @@ fn add_ref_arg_to_method_call(
     arg_value: &AbiArgValue,
 
     foreign_accounts: &mut Vec<Address>,
-    foreign_assets: &mut Vec<u64>,
-    foreign_apps: &mut Vec<u64>,
+    foreign_assets: &mut Vec<AssetId>,
+    foreign_apps: &mut Vec<AppId>,
 
     method_types: &mut Vec<AbiType>,
     method_args: &mut Vec<AbiValue>,
 
     sender: Address,
-    app_id: u64,
+    app_id: AppId,
 ) -> Result<(), Error> {
     let index = add_to_foreign_array(
         arg_type,
@@ -729,10 +729,10 @@ fn add_to_foreign_array(
     arg_type: &ReferenceArgType,
     arg_value: &AbiArgValue,
     foreign_accounts: &mut Vec<Address>,
-    foreign_assets: &mut Vec<u64>,
-    foreign_apps: &mut Vec<u64>,
+    foreign_assets: &mut Vec<AssetId>,
+    foreign_apps: &mut Vec<AppId>,
     sender: Address,
-    app_id: u64,
+    app_id: AppId,
 ) -> Result<usize, Error> {
     match arg_type {
         ReferenceArgType::Account => match arg_value.address() {
@@ -751,7 +751,11 @@ fn add_to_foreign_array(
                     AbiError::Msg(format!("big int: {int} couldn't be converted to u64"))
                 })?;
 
-                Ok(populate_foreign_array(intu64, foreign_assets, None))
+                Ok(populate_foreign_array(
+                    AssetId(intu64),
+                    foreign_assets,
+                    None,
+                ))
             }
             _ => Err(Error::Msg(format!(
                 "Invalid value type: {arg_value:?} for arg type: {arg_type:?}"
@@ -763,7 +767,11 @@ fn add_to_foreign_array(
                     AbiError::Msg(format!("big int: {int} couldn't be converted to u64"))
                 })?;
 
-                Ok(populate_foreign_array(intu64, foreign_apps, Some(app_id)))
+                Ok(populate_foreign_array(
+                    AppId(intu64),
+                    foreign_apps,
+                    Some(app_id),
+                ))
             }
             _ => Err(Error::Msg(format!(
                 "Invalid value type: {arg_value:?} for arg type: {arg_type:?}"

--- a/src/util/dryrun_printer.rs
+++ b/src/util/dryrun_printer.rs
@@ -3,7 +3,7 @@ use algonaut_algod::models::{
     Application, ApplicationParams, ApplicationStateSchema, DryrunRequest, DryrunState,
     DryrunTxnResult, TealValue,
 };
-use algonaut_core::{Address, to_app_address};
+use algonaut_core::{Address, AppId, AssetId, to_app_address};
 use algonaut_encoding::Bytes;
 use algonaut_transaction::{
     SignedTransaction, TransactionType,
@@ -38,8 +38,8 @@ pub async fn create_dryrun_with_settings(
     let mut acct_infos = vec![];
 
     // These are populated from the transactions passed
-    let mut apps = HashSet::new();
-    let mut assets = HashSet::new();
+    let mut apps: HashSet<AppId> = HashSet::new();
+    let mut assets: HashSet<AssetId> = HashSet::new();
     let mut accts = HashSet::new();
 
     for signed_tx in signed_txs {
@@ -48,7 +48,7 @@ pub async fn create_dryrun_with_settings(
         if let TransactionType::ApplicationCallTransaction(app_call) = &tx.txn_type {
             if let Some(app_id) = app_call.app_id {
                 apps.insert(app_id);
-                accts.insert(to_app_address(app_id));
+                accts.insert(to_app_address(app_id.0));
             } else {
                 // Prepare and set param fields for Application being created
                 app_infos.push(to_application(app_call, &tx.sender()))
@@ -68,12 +68,12 @@ pub async fn create_dryrun_with_settings(
     }
 
     for asset_id in assets {
-        let asset = algod.asset(asset_id).await?;
+        let asset = algod.asset(asset_id.0).await?;
         accts.insert(asset.params.creator.parse().unwrap());
     }
 
     for app_id in apps {
-        let app = algod.app(app_id).await?;
+        let app = algod.app(app_id.0).await?;
         accts.insert(app.params.creator.parse().unwrap());
         app_infos.push(app);
     }

--- a/tests/step_defs/integration/abi.rs
+++ b/tests/step_defs/integration/abi.rs
@@ -12,7 +12,7 @@ use algonaut_abi::{
     abi_type::{AbiType, AbiValue},
 };
 use algonaut_algod::models::PendingTransactionResponse;
-use algonaut_core::{Address, MicroAlgos, to_app_address};
+use algonaut_core::{Address, AppId, MicroAlgos, to_app_address};
 use algonaut_transaction::{
     Pay, TxnBuilder,
     transaction::{ApplicationCallOnComplete, BoxReference, StateSchema},
@@ -182,7 +182,7 @@ async fn i_append_the_encoded_arguments_to_the_method_arguments_array(
     w: &mut World,
     comma_separated_b64_args: String,
 ) -> Result<(), Box<dyn Error>> {
-    let application_ids: &[u64] = w.app_ids.as_ref();
+    let application_ids: &[AppId] = w.app_ids.as_ref();
     let method_args = w.abi_method_arg_values.as_mut().expect("no method args");
 
     let abi_method_arg_types = w
@@ -210,7 +210,7 @@ async fn i_append_the_encoded_arguments_to_the_method_arguments_array(
                 );
             }
 
-            let arg = AbiValue::Int(application_ids[parsed_index].into());
+            let arg = AbiValue::Int(application_ids[parsed_index].0.into());
             method_args.push(AbiArgValue::AbiValue(arg));
         } else {
             let base64_decoded_arg = BASE64.decode(b64_arg.as_bytes()).unwrap();
@@ -335,7 +335,7 @@ async fn i_add_a_method_call_with_boxes(
     .await;
 }
 
-fn parse_box_references(s: &str, app_ids: &[u64]) -> Vec<BoxReference> {
+fn parse_box_references(s: &str, app_ids: &[AppId]) -> Vec<BoxReference> {
     if s.is_empty() {
         return Vec::new();
     }
@@ -818,7 +818,7 @@ async fn check_atomic_result_against_value(
 
 #[given(regex = r#"^an application id (\d+)$"#)]
 async fn an_application_id(w: &mut World, app_id: u64) {
-    w.app_id = Some(app_id);
+    w.app_id = Some(AppId(app_id));
 }
 
 #[then(regex = r#"^The (\d+)th atomic result for "([^"]*)" satisfies the regex "([^"]*)"$"#)]
@@ -872,7 +872,7 @@ async fn i_fund_the_current_applications_address(w: &mut World, micro_algos: u64
 
     let first_account = accounts[0];
 
-    let app_address = to_app_address(app_id);
+    let app_address = to_app_address(app_id.0);
 
     let tx_params = algod.txn_params().await.expect("couldn't get params");
 

--- a/tests/step_defs/integration/applications.rs
+++ b/tests/step_defs/integration/applications.rs
@@ -1,6 +1,7 @@
 use crate::step_defs::integration::world::World;
 use crate::step_defs::util::{parse_app_args, read_teal, split_addresses, split_uint64};
 use algonaut_algod::models::{Application, ApplicationLocalState};
+use algonaut_core::{AppId, AssetId};
 use algonaut_transaction::builder::{
     CallApplication, ClearApplication, CloseApplication, DeleteApplication, OptInApplication,
     UpdateApplication,
@@ -42,8 +43,14 @@ async fn i_build_an_application_transaction(
 
     let accounts = split_addresses(app_accounts)?;
 
-    let foreign_apps = split_uint64(&foreign_apps)?;
-    let foreign_assets = split_uint64(&foreign_assets)?;
+    let foreign_apps: Vec<AppId> = split_uint64(&foreign_apps)?
+        .into_iter()
+        .map(AppId)
+        .collect();
+    let foreign_assets: Vec<AssetId> = split_uint64(&foreign_assets)?
+        .into_iter()
+        .map(AssetId)
+        .collect();
 
     let params = algod.txn_params().await?;
 
@@ -154,11 +161,11 @@ async fn i_build_an_application_transaction(
 async fn i_remember_the_new_application_id(w: &mut World) {
     let algod = w.algod.as_ref().unwrap();
     let tx_id = w.tx_id.as_ref().unwrap();
-    let app_ids: &mut Vec<u64> = w.app_ids.as_mut();
+    let app_ids: &mut Vec<AppId> = w.app_ids.as_mut();
 
-    let p_tx = algod.pending_txn(tx_id).await.unwrap();
+    let p_tx = algod.pending_txn(tx_id.as_str()).await.unwrap();
     assert!(p_tx.application_index.is_some());
-    let app_id = p_tx.application_index.unwrap();
+    let app_id = AppId(p_tx.application_index.unwrap());
 
     w.app_id = Some(app_id);
     app_ids.push(app_id);
@@ -196,7 +203,7 @@ async fn the_transient_account_should_have(
         .created_apps
         .unwrap()
         .iter()
-        .any(|a| a.id == app_id);
+        .any(|a| a.id == app_id.0);
 
     match (app_created, app_in_account) {
         (true, false) => Err(format!("AppId {} is not found in the account", app_id))?,
@@ -218,7 +225,7 @@ async fn the_transient_account_should_have(
                 .apps_local_state
                 .unwrap()
                 .into_iter()
-                .filter(|s| s.id == app_id)
+                .filter(|s| s.id == app_id.0)
                 .collect::<Vec<ApplicationLocalState>>();
 
             let len = local_state.len();
@@ -237,7 +244,7 @@ async fn the_transient_account_should_have(
                 .created_apps
                 .unwrap()
                 .into_iter()
-                .filter(|s| s.id == app_id)
+                .filter(|s| s.id == app_id.0)
                 .collect::<Vec<Application>>();
 
             let len = apps.len();

--- a/tests/step_defs/integration/assets.rs
+++ b/tests/step_defs/integration/assets.rs
@@ -1,7 +1,7 @@
 use crate::step_defs::integration::world::World;
 use algonaut::error::Error;
 use algonaut_algod::models::AssetParams;
-use algonaut_core::Address;
+use algonaut_core::{Address, AssetId, TxId};
 use algonaut_transaction::{
     AcceptAsset, ClawbackAsset, CreateAsset, FreezeAsset, TransferAsset, TxnBuilder,
     builder::{DestroyAsset, UpdateAsset},
@@ -107,7 +107,7 @@ async fn i_send_the_kmd_signed_transaction(w: &mut World) -> Result<(), Error> {
         .expect("kmd-signed transaction not set");
     match algod.send_raw_txn(bytes).await {
         Ok(resp) => {
-            w.tx_id = Some(resp.tx_id);
+            w.tx_id = Some(TxId(resp.tx_id));
             w.last_send_succeeded = Some(true);
         }
         Err(e) => {
@@ -138,9 +138,9 @@ async fn i_send_the_bogus_kmd_signed_transaction(w: &mut World) -> Result<(), Er
 async fn i_update_the_asset_index(w: &mut World) -> Result<(), Error> {
     let algod = w.algod.as_ref().expect("algod not set");
     let tx_id = w.tx_id.as_ref().expect("no last tx id");
-    let pending = algod.pending_txn(tx_id).await?;
+    let pending = algod.pending_txn(tx_id.as_str()).await?;
     if let Some(asset_index) = pending.asset_index {
-        w.asset_id = Some(asset_index);
+        w.asset_id = Some(AssetId(asset_index));
     }
     Ok(())
 }
@@ -150,7 +150,7 @@ async fn i_update_the_asset_index(w: &mut World) -> Result<(), Error> {
 async fn i_get_the_asset_info(w: &mut World) -> Result<(), Error> {
     let algod = w.algod.as_ref().expect("algod not set");
     let asset_id = w.asset_id.expect("asset id not set");
-    let asset = algod.asset(asset_id).await?;
+    let asset = algod.asset(asset_id.0).await?;
     w.asset_info = Some(*asset.params);
     Ok(())
 }
@@ -211,7 +211,7 @@ async fn i_should_be_unable_to_get_the_asset_info(w: &mut World) {
     let algod = w.algod.as_ref().expect("algod not set");
     let asset_id = w.asset_id.expect("asset id not set");
     assert!(
-        algod.asset(asset_id).await.is_err(),
+        algod.asset(asset_id.0).await.is_err(),
         "expected asset info to be missing after destroy"
     );
 }
@@ -307,7 +307,7 @@ async fn the_creator_should_have_assets_remaining(
         .as_deref()
         .unwrap_or(&[])
         .iter()
-        .find(|h| h.asset_id == asset_id)
+        .find(|h| h.asset_id == asset_id.0)
         .ok_or_else(|| Error::Msg(format!("creator does not hold asset {asset_id}")))?;
     assert_eq!(
         holding.amount, expected,

--- a/tests/step_defs/integration/dryrun.rs
+++ b/tests/step_defs/integration/dryrun.rs
@@ -1,7 +1,7 @@
 use crate::step_defs::integration::world::World;
 use algonaut::dryrun::{DryrunRequestBuilder, field_name, result};
 use algonaut_algod::models::{Application, ApplicationParams, DryrunSource};
-use algonaut_core::{Address, CompiledTeal, MicroAlgos};
+use algonaut_core::{Address, AppId, CompiledTeal, MicroAlgos};
 use algonaut_encoding::Bytes;
 use algonaut_transaction::{
     Pay, TxnBuilder, builder::TransactionParams, contract_account::ContractAccount,
@@ -180,7 +180,7 @@ fn build_dryrun_test_case(program_path: &str, kind: &str) -> algonaut_algod::mod
                 algonaut_transaction::transaction::TransactionType::ApplicationCallTransaction(
                     algonaut_transaction::transaction::ApplicationCallTransaction {
                         sender: creator,
-                        app_id: Some(DRYRUN_APP_ID),
+                        app_id: Some(AppId(DRYRUN_APP_ID)),
                         on_complete:
                             algonaut_transaction::transaction::ApplicationCallOnComplete::NoOp,
                         accounts: None,

--- a/tests/step_defs/integration/general.rs
+++ b/tests/step_defs/integration/general.rs
@@ -3,7 +3,7 @@ use crate::step_defs::{
     util::{account_from_kmd_response, wait_for_pending_transaction},
 };
 use algonaut::{algod::v2::Algod, kmd::v1::Kmd};
-use algonaut_core::{Address, MicroAlgos};
+use algonaut_core::{Address, MicroAlgos, TxId};
 use algonaut_transaction::{Pay, TxnBuilder};
 use cucumber::{given, then, when};
 use rand::Rng;
@@ -174,7 +174,7 @@ async fn i_sign_and_submit_the_transaction_saving_the_tx_id_if_there_is_an_error
 
     match algod.send_txn(&s_tx).await {
         Ok(response) => {
-            w.tx_id = Some(response.tx_id);
+            w.tx_id = Some(TxId(response.tx_id));
         }
         Err(e) => {
             assert!(e.to_string().contains(&err));
@@ -189,7 +189,7 @@ async fn i_wait_for_the_transaction_to_be_confirmed(w: &mut World) {
     let algod = w.algod.as_ref().expect("algod not set");
     let tx_id = w.tx_id.as_ref().expect("tx id not set");
 
-    wait_for_pending_transaction(&algod, &tx_id)
+    wait_for_pending_transaction(&algod, tx_id.as_str())
         .await
         .expect("couldn't get pending tx");
 }

--- a/tests/step_defs/integration/send.rs
+++ b/tests/step_defs/integration/send.rs
@@ -1,5 +1,5 @@
 use crate::step_defs::{integration::world::World, util::account_from_kmd_response};
-use algonaut_core::{MicroAlgos, MultisigAddress, Round, StateProofPk, VotePk, VrfPk};
+use algonaut_core::{MicroAlgos, MultisigAddress, Round, StateProofPk, TxId, VotePk, VrfPk};
 use algonaut_transaction::{
     Pay, RegisterKey, SignedTransaction, TxnBuilder, transaction::TransactionSignature,
 };
@@ -139,7 +139,7 @@ async fn i_send_the_transaction(w: &mut World) {
 
     match algod.send_txn(signed).await {
         Ok(resp) => {
-            w.tx_id = Some(resp.tx_id);
+            w.tx_id = Some(TxId(resp.tx_id));
             w.last_send_succeeded = Some(true);
         }
         Err(_) => {

--- a/tests/step_defs/integration/simulate.rs
+++ b/tests/step_defs/integration/simulate.rs
@@ -364,7 +364,7 @@ async fn the_current_application_initial_state_should_be_empty(w: &mut World, st
         .expect("expected initial-states on response");
 
     let app_id = w.app_id.expect("no current app id");
-    let bucket = locate_app_initial_state(initial, app_id, &state_kind);
+    let bucket = locate_app_initial_state(initial, app_id.0, &state_kind);
     let empty = match &bucket {
         None => true,
         Some(serde_json::Value::Array(a)) => a.is_empty(),
@@ -394,7 +394,7 @@ async fn the_current_application_initial_state_should_contain(
         .expect("expected initial-states on response");
 
     let app_id = w.app_id.expect("no current app id");
-    let bucket = locate_app_initial_state(initial, app_id, &state_kind)
+    let bucket = locate_app_initial_state(initial, app_id.0, &state_kind)
         .expect("no initial state bucket found");
     let entries = bucket
         .as_array()

--- a/tests/step_defs/integration/world.rs
+++ b/tests/step_defs/integration/world.rs
@@ -12,7 +12,7 @@ use algonaut_algod::models::{
     AssetParams, SimulateRequest, SimulateTransaction200Response, TealDryrun200Response,
     TransactionParams200Response,
 };
-use algonaut_core::{Address, MultisigAddress};
+use algonaut_core::{Address, AppId, AssetId, MultisigAddress, TxId};
 use algonaut_crypto::Ed25519PublicKey;
 use algonaut_transaction::{
     SignedTransaction, Transaction,
@@ -34,10 +34,10 @@ pub struct World {
     pub transient_account: Option<Account>,
 
     pub tx: Option<Transaction>,
-    pub tx_id: Option<String>,
+    pub tx_id: Option<TxId>,
 
-    pub app_id: Option<u64>,
-    pub app_ids: Vec<u64>,
+    pub app_id: Option<AppId>,
+    pub app_ids: Vec<AppId>,
 
     pub tx_params: Option<TransactionParams200Response>,
 
@@ -81,7 +81,7 @@ pub struct World {
     pub kmd_signed_multisig_bytes: Option<Vec<u8>>,
     pub exported_multisig_pks: Option<Vec<Ed25519PublicKey>>,
 
-    pub asset_id: Option<u64>,
+    pub asset_id: Option<AssetId>,
     pub asset_info: Option<AssetParams>,
     pub expected_asset_params: Option<AssetParams>,
     pub asset_creator: Option<Address>,


### PR DESCRIPTION
## Summary
Closes #160.

Introduces three id newtypes in `algonaut_core` and adopts them across the hand-written crates, so application ids, asset ids and transaction ids can no longer be silently swapped for each other or for bare integers — the type-safety improvement the issue and its discussion ([tuple structs, per @ivnsch](https://github.com/manuelmauro/algonaut/issues/160)) asked for.

- `AppId(pub u64)`, `AssetId(pub u64)`, `TxId(pub String)` — modelled on the existing `Round` newtype.
- All three serialize **transparently** (wire-identical to the inner `u64`/`String`), so the msgpack/JSON formats are unchanged — verified by a dedicated round-trip test.
- `From`/`Into` conversions both ways for ergonomic use at boundaries.

## Migrated
- **`algonaut_transaction`** — every asset/app transaction-builder (`UpdateAsset`, `DestroyAsset`, `TransferAsset`, `AcceptAsset`, `ClawbackAsset`, `FreezeAsset`, `CreateApplication`, `UpdateApplication`, `CallApplication`, `OptInApplication`, `ClearApplication`, `CloseApplication`, `DeleteApplication`), the `Transaction`/`SignedTransaction` types, `Transaction::id` (now returns `TxId`), `foreign_apps`/`foreign_assets`, `BoxReference`.
- **`algonaut_model`** — `ApiTransaction` id fields and `ApiSignedTransaction.transaction_id`. The msgpack "omit zero values" rule is preserved exactly.
- **`algonaut_abi`** — `AbiContractNetworkInfo.app_id`.
- **`algonaut` (root)** — `AtomicTransactionComposer`: `AddMethodCallParams::app_id`, `AbiMethodResult::tx_id`.

Generated client crates (`algonaut_algod`/`indexer`/`kmd`) keep `u64`/`String`; conversions happen at the call boundary. Examples and the cucumber integration step-defs are updated.

## Breaking change
Ids in the public builder API, model types, ABI types and ATC are now `AppId`/`AssetId`/`TxId`. Wrap literals with `AppId(..)`/`AssetId(..)`/`TxId(..)` or `.into()`; unwrap with `id.0` / `u64::from(id)` / `txid.as_str()`. CHANGELOG `[Unreleased]` updated.

## Test plan
- [x] `cargo test --workspace --lib --examples --tests` — all pass, incl. the new `id_newtypes_serialize_transparently` wire-format test and the existing serialization round-trips.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo test --test features_runner --no-run` — integration suite compiles.
