### PR TITLE
fix(algod,indexer): make AssetParams.decimals a u32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `MicroAlgos::checked_add`, `MicroAlgos::checked_sub`, and `MicroAlgos::checked_mul` — overflow- and underflow-safe arithmetic returning `Option<MicroAlgos>`, so callers no longer need to reach into the inner `u64` (#152)
 
+### Changed
+
+- **Breaking:** `AssetParams.decimals` is now `u32` instead of `u64` in the `algonaut_algod` and `algonaut_indexer` clients, matching Algorand's documentation (the value is bounded to 0..=19). The hand-written `algonaut_transaction`/`algonaut_model` `AssetParams` types already used `u32` (#140)
+
 ## [0.6.0] - 2026-05-18
 
 ### Added

--- a/algonaut_algod/src/models/asset_params.rs
+++ b/algonaut_algod/src/models/asset_params.rs
@@ -23,7 +23,7 @@ pub struct AssetParams {
     pub creator: String,
     /// \\[dc\\] The number of digits to use after the decimal point when displaying this asset. If 0, the asset is not divisible. If 1, the base unit of the asset is in tenths. If 2, the base unit of the asset is in hundredths, and so on. This value must be between 0 and 19 (inclusive).
     #[serde(rename = "decimals")]
-    pub decimals: u64,
+    pub decimals: u32,
     /// \\[df\\] Whether holdings of this asset are frozen by default.
     #[serde(rename = "default-frozen", skip_serializing_if = "Option::is_none")]
     pub default_frozen: Option<bool>,
@@ -69,7 +69,7 @@ pub struct AssetParams {
 
 impl AssetParams {
     /// AssetParams specifies the parameters for an asset.  \\[apar\\] when part of an AssetConfig transaction.  Definition: data/transactions/asset.go : AssetParams
-    pub fn new(creator: String, decimals: u64, total: u64) -> AssetParams {
+    pub fn new(creator: String, decimals: u32, total: u64) -> AssetParams {
         AssetParams {
             clawback: None,
             creator,

--- a/algonaut_indexer/src/models/asset_params.rs
+++ b/algonaut_indexer/src/models/asset_params.rs
@@ -23,7 +23,7 @@ pub struct AssetParams {
     pub creator: String,
     /// \\[dc\\] The number of digits to use after the decimal point when displaying this asset. If 0, the asset is not divisible. If 1, the base unit of the asset is in tenths. If 2, the base unit of the asset is in hundredths, and so on. This value must be between 0 and 19 (inclusive).
     #[serde(rename = "decimals")]
-    pub decimals: u64,
+    pub decimals: u32,
     /// \\[df\\] Whether holdings of this asset are frozen by default.
     #[serde(rename = "default-frozen", skip_serializing_if = "Option::is_none")]
     pub default_frozen: Option<bool>,
@@ -68,7 +68,7 @@ pub struct AssetParams {
 
 impl AssetParams {
     /// AssetParams specifies the parameters for an asset.  \\[apar\\] when part of an AssetConfig transaction.  Definition: data/transactions/asset.go : AssetParams
-    pub fn new(creator: String, decimals: u64, total: u64) -> AssetParams {
+    pub fn new(creator: String, decimals: u32, total: u64) -> AssetParams {
         AssetParams {
             clawback: None,
             creator,


### PR DESCRIPTION
## Summary
Closes #140.

Algorand's [documentation](https://developer.algorand.org/docs/get-details/transactions/transactions/#decimals) defines an asset's `decimals` as a value bounded to `0..=19`, so `u32` is the correct type. The generated `algonaut_algod` and `algonaut_indexer` clients still typed `AssetParams.decimals` as `u64`.

(The hand-written `algonaut_transaction` and `algonaut_model` `AssetParams` types already used `u32` — this brings the generated clients in line.)

## Change
- `algonaut_algod::models::AssetParams.decimals`: `u64` → `u32` (field + `new()` constructor).
- `algonaut_indexer::models::AssetParams.decimals`: `u64` → `u32` (field + `new()` constructor).

These generated files are committed-and-hand-maintained (no live regeneration pipeline; `asset_params.rs` was already hand-patched in #237), so editing them directly is the established pattern.

## Breaking change
`AssetParams.decimals` and the `AssetParams::new(...)` signature in both client crates change from `u64` to `u32`.

## Test plan
- [x] `cargo check --workspace --all-targets` — clean (nothing relied on the `u64` width).
- [x] `cargo test --workspace --lib --examples --tests` — all pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
