### PR TITLE
chore(openapi): near-lossless regeneration templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ generate-clients:
 	  -i /local/openapi/generated/_specs/indexer.oas3.json -o /local/openapi/generated/indexer
 	@echo 'Formatting generated output so the diff reflects only semantic drift...'
 	find openapi/generated/algod openapi/generated/indexer -name '*.rs' \
-	  | xargs rustfmt --edition 2021
+	  | xargs rustfmt --edition 2024
 	@echo 'Regenerated into openapi/generated/. Review drift with e.g.:'
 	@echo '  git diff --no-index openapi/generated/algod/src algonaut_algod/src'
 

--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,11 @@ fetch-openapi-specs:
 generate-clients:
 	docker run --rm -v "$(CURDIR)":/local $(OPENAPI_IMAGE) generate \
 	  -c /local/openapi/config-algod.yaml --skip-validate-spec \
+	  -t /local/openapi/templates \
 	  -i /local/openapi/specs/algod.oas3.json -o /local/openapi/generated/algod
 	docker run --rm -v "$(CURDIR)":/local $(OPENAPI_IMAGE) generate \
 	  -c /local/openapi/config-indexer.yaml --skip-validate-spec \
+	  -t /local/openapi/templates \
 	  -i /local/openapi/specs/indexer.oas3.json -o /local/openapi/generated/indexer
 	@echo 'Regenerated into openapi/generated/. Review drift with e.g.:'
 	@echo '  git diff --no-index openapi/generated/algod/src algonaut_algod/src'

--- a/Makefile
+++ b/Makefile
@@ -92,14 +92,18 @@ fetch-openapi-specs:
 # overwrite algonaut_algod/ or algonaut_indexer/. See
 # docs/adr/openapi-client-regeneration.md.
 generate-clients:
+	python3 openapi/preprocess.py
 	docker run --rm -v "$(CURDIR)":/local $(OPENAPI_IMAGE) generate \
 	  -c /local/openapi/config-algod.yaml --skip-validate-spec \
 	  -t /local/openapi/templates \
-	  -i /local/openapi/specs/algod.oas3.json -o /local/openapi/generated/algod
+	  -i /local/openapi/generated/_specs/algod.oas3.json -o /local/openapi/generated/algod
 	docker run --rm -v "$(CURDIR)":/local $(OPENAPI_IMAGE) generate \
 	  -c /local/openapi/config-indexer.yaml --skip-validate-spec \
 	  -t /local/openapi/templates \
-	  -i /local/openapi/specs/indexer.oas3.json -o /local/openapi/generated/indexer
+	  -i /local/openapi/generated/_specs/indexer.oas3.json -o /local/openapi/generated/indexer
+	@echo 'Formatting generated output so the diff reflects only semantic drift...'
+	find openapi/generated/algod openapi/generated/indexer -name '*.rs' \
+	  | xargs rustfmt --edition 2021
 	@echo 'Regenerated into openapi/generated/. Review drift with e.g.:'
 	@echo '  git diff --no-index openapi/generated/algod/src algonaut_algod/src'
 

--- a/docs/adr/openapi-client-regeneration.md
+++ b/docs/adr/openapi-client-regeneration.md
@@ -85,22 +85,31 @@ review-able** process, staged in three phases.
 
 **Phase 2 — drive the regen toward near-lossless.**
 
-*Phase 2a (done).* Custom `model.mustache` and `reqwest/api.mustache`
-templates under `openapi/templates/` force every integer — scalar, array
-element, and operation parameter — to `u64`, since Algorand types its
-integers as 64-bit unsigned. With the integer dimension removed, **86 of the
-121 common model files regenerate byte-identical** to the committed crates
-(41/57 algod, 45/64 indexer).
+Custom templates under `openapi/templates/`, wired through `make
+generate-clients`:
 
-*Phase 2b (next).* The bulk of the remaining residual is the domain-type
-substitution — `format: byte` / `x-algorand-format` fields that the crates
-hand-type as `HashDigest`, `Bytes`, `Address`, `SignedTransaction`. Mustache
-cannot branch on a vendor extension's *value*, so this needs either a custom
-generator class or a post-generation patch step driven by the spec's
-`x-algorand-format`. The remaining hand-written extensions then move into
-`ext/` modules so the generated files carry no bespoke logic.
+- `model.mustache` / `reqwest/api.mustache` — every integer (model field,
+  `Vec` element, operation parameter) emits `u64`, since Algorand types its
+  integers as 64-bit unsigned.
+- `model.mustache` — `format: byte` fields emit `algonaut_encoding::Bytes`
+  instead of `String`. `openapi/preprocess.py` sets an `x-has-bytes` schema
+  flag so the template emits the `use` import only where it is used.
+- `make generate-clients` runs `rustfmt` over the output, so the review diff
+  reflects semantic drift rather than formatting.
 
-Goal: `make generate-clients` produces a diff small enough to review by eye.
+With these, **66 of the 121 common model files regenerate byte-identical**
+to the committed crates (25/57 algod, 41/64 indexer) — measured after
+formatting, ignoring the generated-header comment.
+
+The remaining ~55 files differ by per-field decisions the spec does not
+encode: the `format: byte` fields the crates narrow to `HashDigest` (with
+`deserialize_opt_hash` serde) or type as `Address` / `SignedTransaction`,
+plus genuinely new upstream models and fields. Distinguishing `HashDigest`
+from `Bytes`, or branching on an `x-algorand-format` *value*, is beyond what
+mustache can express — closing it fully would need a custom generator class
+or a post-generation patch table. Since the regen already serves its purpose
+(drift detection with a review-able diff), that last mile is left as
+documented hand-edits rather than further tooling.
 
 **Phase 3 — adopt upstream changes.**
 
@@ -115,8 +124,8 @@ Goal: `make generate-clients` produces a diff small enough to review by eye.
   risk and unblocks the later phases.
 - The committed specs add ~460 KB to the repo; that is the pinning mechanism
   and the price of reproducibility.
-- The Phase 2a templates cover every integer; the domain-type substitutions
-  (`HashDigest`, `Bytes`, `Address`, `SignedTransaction`) are the main
-  remaining residual and are addressed in Phase 2b.
+- The Phase 2 templates cover every integer and the `Bytes` fields; the
+  `HashDigest` / `Address` / `SignedTransaction` substitutions and their
+  bespoke serde remain as documented hand-edits.
 - The clients are still behind upstream after Phase 1 — closing that gap is
   deliberately deferred to Phase 3 so the API additions get a focused review.

--- a/docs/adr/openapi-client-regeneration.md
+++ b/docs/adr/openapi-client-regeneration.md
@@ -85,13 +85,22 @@ review-able** process, staged in three phases.
 
 **Phase 2 — drive the regen toward near-lossless.**
 
-- Add a custom model mustache template that maps format-less integers to
-  `u64` and reads `x-algorand-format` to emit the algonaut domain types
-  (`Address`, `SignedTransaction`, `CompiledTeal`, `HashDigest`/`Bytes`).
-- Move the remaining hand-written extensions into `ext/` modules so the
-  generated files contain no bespoke logic.
-- Goal: `make generate-clients` produces a diff against the committed crates
-  small enough to review by eye.
+*Phase 2a (done).* Custom `model.mustache` and `reqwest/api.mustache`
+templates under `openapi/templates/` force every integer — scalar, array
+element, and operation parameter — to `u64`, since Algorand types its
+integers as 64-bit unsigned. With the integer dimension removed, **86 of the
+121 common model files regenerate byte-identical** to the committed crates
+(41/57 algod, 45/64 indexer).
+
+*Phase 2b (next).* The bulk of the remaining residual is the domain-type
+substitution — `format: byte` / `x-algorand-format` fields that the crates
+hand-type as `HashDigest`, `Bytes`, `Address`, `SignedTransaction`. Mustache
+cannot branch on a vendor extension's *value*, so this needs either a custom
+generator class or a post-generation patch step driven by the spec's
+`x-algorand-format`. The remaining hand-written extensions then move into
+`ext/` modules so the generated files carry no bespoke logic.
+
+Goal: `make generate-clients` produces a diff small enough to review by eye.
 
 **Phase 3 — adopt upstream changes.**
 
@@ -106,8 +115,8 @@ review-able** process, staged in three phases.
   risk and unblocks the later phases.
 - The committed specs add ~460 KB to the repo; that is the pinning mechanism
   and the price of reproducibility.
-- `typeMappings` covers integers that carry an explicit `format`; format-less
-  integers and the domain-type substitutions remain hand-applied until the
-  Phase 2 template lands.
+- The Phase 2a templates cover every integer; the domain-type substitutions
+  (`HashDigest`, `Bytes`, `Address`, `SignedTransaction`) are the main
+  remaining residual and are addressed in Phase 2b.
 - The clients are still behind upstream after Phase 1 — closing that gap is
   deliberately deferred to Phase 3 so the API additions get a focused review.

--- a/docs/adr/openapi-client-regeneration.md
+++ b/docs/adr/openapi-client-regeneration.md
@@ -85,31 +85,34 @@ review-able** process, staged in three phases.
 
 **Phase 2 — drive the regen toward near-lossless.**
 
-Custom templates under `openapi/templates/`, wired through `make
-generate-clients`:
+Custom templates and a preprocessing step under `openapi/`, wired through
+`make generate-clients`:
 
 - `model.mustache` / `reqwest/api.mustache` — every integer (model field,
   `Vec` element, operation parameter) emits `u64`, since Algorand types its
   integers as 64-bit unsigned.
 - `model.mustache` — `format: byte` fields emit `algonaut_encoding::Bytes`
-  instead of `String`. `openapi/preprocess.py` sets an `x-has-bytes` schema
-  flag so the template emits the `use` import only where it is used.
-- `make generate-clients` runs `rustfmt` over the output, so the review diff
-  reflects semantic drift rather than formatting.
+  instead of `String`.
+- `openapi/type-overrides.json` — a per-field table for the domain types the
+  spec cannot express (`HashDigest`, `Vec<SignedTransaction>`, ...).
+  `openapi/preprocess.py` reads it and injects `x-rust-type` / `x-rust-serde`
+  / `x-rust-imports` vendor extensions into the spec, which the template
+  consumes; mustache cannot branch on an `x-algorand-format` *value*, so the
+  decision is made in the preprocessor instead. preprocess.py fails loudly
+  if a table entry stops matching the spec.
+- `make generate-clients` runs `rustfmt` (edition 2024, matching the
+  workspace) over the output, so the review diff reflects semantic drift
+  rather than formatting.
 
-With these, **66 of the 121 common model files regenerate byte-identical**
-to the committed crates (25/57 algod, 41/64 indexer) — measured after
+With these, **77 of the 121 common model files regenerate byte-identical**
+to the committed crates (33/57 algod, 44/64 indexer) — measured after
 formatting, ignoring the generated-header comment.
 
-The remaining ~55 files differ by per-field decisions the spec does not
-encode: the `format: byte` fields the crates narrow to `HashDigest` (with
-`deserialize_opt_hash` serde) or type as `Address` / `SignedTransaction`,
-plus genuinely new upstream models and fields. Distinguishing `HashDigest`
-from `Bytes`, or branching on an `x-algorand-format` *value*, is beyond what
-mustache can express — closing it fully would need a custom generator class
-or a post-generation patch table. Since the regen already serves its purpose
-(drift detection with a review-able diff), that last mile is left as
-documented hand-edits rather than further tooling.
+The remaining ~44 files carry genuinely new upstream models and fields — the
+drift the tool exists to surface — plus a few bespoke per-file hand-edits (a
+renamed field, an extra `skip_serializing_if`) not worth encoding in the
+table. The regen now serves drift detection with a tightly review-able diff;
+the last bespoke edits stay documented hand-edits.
 
 **Phase 3 — adopt upstream changes.**
 
@@ -124,8 +127,11 @@ documented hand-edits rather than further tooling.
   risk and unblocks the later phases.
 - The committed specs add ~460 KB to the repo; that is the pinning mechanism
   and the price of reproducibility.
-- The Phase 2 templates cover every integer and the `Bytes` fields; the
-  `HashDigest` / `Address` / `SignedTransaction` substitutions and their
-  bespoke serde remain as documented hand-edits.
+- The Phase 2 templates and `type-overrides.json` cover every integer, the
+  `Bytes` fields, and the domain-typed fields; only genuinely new upstream
+  content and a few bespoke per-file edits remain in the regen diff.
+- `type-overrides.json` is a maintenance surface: when upstream adds a
+  domain-typed field the regen emits the stock type, the diff reveals it,
+  and a table entry is added.
 - The clients are still behind upstream after Phase 1 — closing that gap is
   deliberately deferred to Phase 3 so the API additions get a focused review.

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -18,6 +18,9 @@ plan toward a near-lossless regen.
 | `specs/indexer.oas3.json` | Pinned snapshot of the indexer OpenAPI spec. |
 | `config-algod.yaml` | openapi-generator config for the algod client. |
 | `config-indexer.yaml` | openapi-generator config for the indexer client. |
+| `templates/` | Custom mustache templates (integer/`Bytes`/override emission). |
+| `type-overrides.json` | Per-field domain-type override table. |
+| `preprocess.py` | Injects the override table into the specs as vendor extensions. |
 | `generated/` | Regenerated output (git-ignored; for diffing only). |
 
 ## Specs

--- a/openapi/preprocess.py
+++ b/openapi/preprocess.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Preprocess the Algorand OpenAPI specs before openapi-generator runs.
+
+openapi-generator's mustache templates can branch on a property flag
+(`isByteArray`) but not emit a *file-level* `use` import conditionally. So
+this step sets a schema-level `x-has-bytes` vendor extension on every schema
+that has at least one `format: byte` property; the custom `model.mustache`
+reads it to emit `use algonaut_encoding::Bytes;`.
+
+Reads openapi/specs/*.oas3.json, writes the derived specs to
+openapi/generated/_specs/ (git-ignored). See
+docs/adr/openapi-client-regeneration.md.
+"""
+
+import json
+import pathlib
+
+SRC = pathlib.Path("openapi/specs")
+OUT = pathlib.Path("openapi/generated/_specs")
+
+
+def has_byte_format(prop: dict) -> bool:
+    """True if a property (or its array items) is `format: byte`."""
+    if prop.get("format") == "byte":
+        return True
+    items = prop.get("items")
+    return isinstance(items, dict) and items.get("format") == "byte"
+
+
+def main() -> None:
+    OUT.mkdir(parents=True, exist_ok=True)
+    for name in ("algod", "indexer"):
+        spec = json.loads((SRC / f"{name}.oas3.json").read_text())
+        schemas = spec.get("components", {}).get("schemas", {})
+        flagged = 0
+        for schema in schemas.values():
+            props = schema.get("properties") or {}
+            if any(has_byte_format(p) for p in props.values()):
+                schema["x-has-bytes"] = True
+                flagged += 1
+        (OUT / f"{name}.oas3.json").write_text(json.dumps(spec, indent=2))
+        print(f"{name}: flagged {flagged} schemas with x-has-bytes")
+
+
+if __name__ == "__main__":
+    main()

--- a/openapi/preprocess.py
+++ b/openapi/preprocess.py
@@ -1,25 +1,34 @@
 #!/usr/bin/env python3
 """Preprocess the Algorand OpenAPI specs before openapi-generator runs.
 
-openapi-generator's mustache templates can branch on a property flag
-(`isByteArray`) but not emit a *file-level* `use` import conditionally. So
-this step sets a schema-level `x-has-bytes` vendor extension on every schema
-that has at least one `format: byte` property; the custom `model.mustache`
-reads it to emit `use algonaut_encoding::Bytes;`.
+The custom mustache templates can branch on a property flag, but cannot on
+their own emit a file-level `use` import, nor pick the algonaut domain type
+for a field the spec types as a plain string/array. So this step injects
+vendor extensions the templates consume:
+
+  * `x-rust-imports` on a schema   -> the `use` lines its model file needs;
+  * `x-rust-type` on a property    -> the exact Rust type to emit;
+  * `x-rust-serde` on a property   -> extra `#[serde(..)]` attributes.
+
+`format: byte` properties pull in `use algonaut_encoding::Bytes;`; everything
+else comes from the per-field table in openapi/type-overrides.json.
 
 Reads openapi/specs/*.oas3.json, writes the derived specs to
-openapi/generated/_specs/ (git-ignored). See
-docs/adr/openapi-client-regeneration.md.
+openapi/generated/_specs/. See docs/adr/openapi-client-regeneration.md.
 """
 
 import json
 import pathlib
 
-SRC = pathlib.Path("openapi/specs")
-OUT = pathlib.Path("openapi/generated/_specs")
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SRC = ROOT / "openapi" / "specs"
+OUT = ROOT / "openapi" / "generated" / "_specs"
+TABLE = ROOT / "openapi" / "type-overrides.json"
+
+BYTES_IMPORT = "use algonaut_encoding::Bytes;"
 
 
-def has_byte_format(prop: dict) -> bool:
+def is_byte_format(prop: dict) -> bool:
     """True if a property (or its array items) is `format: byte`."""
     if prop.get("format") == "byte":
         return True
@@ -29,17 +38,45 @@ def has_byte_format(prop: dict) -> bool:
 
 def main() -> None:
     OUT.mkdir(parents=True, exist_ok=True)
+    table = json.loads(TABLE.read_text())["overrides"]
+
     for name in ("algod", "indexer"):
         spec = json.loads((SRC / f"{name}.oas3.json").read_text())
         schemas = spec.get("components", {}).get("schemas", {})
-        flagged = 0
-        for schema in schemas.values():
+        # overrides for this crate, keyed by (schema name, spec property name)
+        overrides = {(o["schema"], o["field"]): o for o in table if o["crate"] == name}
+        applied = 0
+
+        for schema_name, schema in schemas.items():
             props = schema.get("properties") or {}
-            if any(has_byte_format(p) for p in props.values()):
-                schema["x-has-bytes"] = True
-                flagged += 1
+            imports: set[str] = set()
+            for prop_name, prop in props.items():
+                override = overrides.get((schema_name, prop_name))
+                if override:
+                    prop["x-rust-type"] = override["type"]
+                    if override.get("serde"):
+                        prop["x-rust-serde"] = override["serde"]
+                    if override.get("import"):
+                        imports.add(override["import"])
+                    applied += 1
+                elif is_byte_format(prop):
+                    # a byte field with no override regenerates as `Bytes`
+                    imports.add(BYTES_IMPORT)
+            if imports:
+                schema["x-rust-imports"] = sorted(imports)
+
         (OUT / f"{name}.oas3.json").write_text(json.dumps(spec, indent=2))
-        print(f"{name}: flagged {flagged} schemas with x-has-bytes")
+        with_imports = sum("x-rust-imports" in s for s in schemas.values())
+        expected = sum(1 for o in table if o["crate"] == name)
+        print(
+            f"{name}: applied {applied}/{expected} overrides, "
+            f"{with_imports} schemas need imports"
+        )
+        if applied != expected:
+            raise SystemExit(
+                f"{name}: {expected - applied} override(s) in type-overrides.json "
+                f"did not match a schema/property — the spec may have changed."
+            )
 
 
 if __name__ == "__main__":

--- a/openapi/templates/model.mustache
+++ b/openapi/templates/model.mustache
@@ -1,0 +1,125 @@
+{{>partial_header}}
+{{!--
+  algonaut customization of the stock openapi-generator rust `model.mustache`.
+  Algorand types every integer as a 64-bit unsigned value, but the specs only
+  carry an explicit `format` on a minority of them, so the stock generator
+  emits `i32` for the rest. Here every integer/long leaf is forced to `u64`.
+  See docs/adr/openapi-client-regeneration.md.
+--}}
+{{#models}}
+{{#model}}
+{{#description}}
+/// {{{classname}}} : {{{description}}}
+{{/description}}
+
+{{!-- for enum schemas --}}
+{{#isEnum}}
+/// {{{description}}}
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+pub enum {{{classname}}} {
+{{#allowableValues}}
+{{#enumVars}}
+    #[serde(rename = "{{{value}}}")]
+    {{{name}}},
+{{/enumVars}}{{/allowableValues}}
+}
+
+impl ToString for {{{classname}}} {
+    fn to_string(&self) -> String {
+        match self {
+            {{#allowableValues}}
+            {{#enumVars}}
+            Self::{{{name}}} => String::from("{{{value}}}"),
+            {{/enumVars}}
+            {{/allowableValues}}
+        }
+    }
+}
+
+impl Default for {{{classname}}} {
+    fn default() -> {{{classname}}} {
+        {{#allowableValues}}
+        Self::{{ enumVars.0.name }}
+        {{/allowableValues}}
+    }
+}
+{{/isEnum}}
+
+{{!-- for schemas that have a discriminator --}}
+{{#discriminator}}
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "{{{vendorExtensions.x-tag-name}}}")]
+pub enum {{{classname}}} {
+{{#vendorExtensions}}
+    {{#x-mapped-models}}
+    #[serde(rename="{{mappingName}}")]
+    {{{modelName}}} {
+    {{#vars}}
+        {{#description}}
+        /// {{{.}}}
+        {{/description}}
+        #[serde(rename = "{{{baseName}}}"{{^required}}, skip_serializing_if = "Option::is_none"{{/required}})]
+        {{{name}}}: {{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{^required}}Option<{{/required}}{{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{#isModel}}Box<{{{dataType}}}>{{/isModel}}{{^isModel}}{{#isArray}}Vec<{{#items}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{^isInteger}}{{^isLong}}{{{dataType}}}{{/isLong}}{{/isInteger}}{{/items}}>{{/isArray}}{{^isArray}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{^isInteger}}{{^isLong}}{{{dataType}}}{{/isLong}}{{/isInteger}}{{/isArray}}{{/isModel}}{{/isEnum}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{^required}}>{{/required}},
+    {{/vars}}
+    },
+    {{/x-mapped-models}}
+{{/vendorExtensions}}
+}
+
+{{/discriminator}}
+
+{{!-- for non-enum schemas --}}
+{{^isEnum}}
+{{^discriminator}}
+#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+pub struct {{{classname}}} {
+{{#vars}}
+    {{#description}}
+    /// {{{.}}}
+    {{/description}}
+    #[serde(rename = "{{{baseName}}}"{{^required}}{{#isNullable}}, default, with = "::serde_with::rust::double_option"{{/isNullable}}{{/required}}{{^required}}, skip_serializing_if = "Option::is_none"{{/required}}{{#required}}{{#isNullable}}, deserialize_with = "Option::deserialize"{{/isNullable}}{{/required}})]
+    pub {{{name}}}: {{#isNullable}}Option<{{/isNullable}}{{^required}}Option<{{/required}}{{#isEnum}}{{#isArray}}{{#uniqueItems}}std::collections::HashSet<{{/uniqueItems}}{{^uniqueItems}}Vec<{{/uniqueItems}}{{/isArray}}{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{^isEnum}}{{#isModel}}Box<{{{dataType}}}>{{/isModel}}{{^isModel}}{{#isArray}}Vec<{{#items}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{^isInteger}}{{^isLong}}{{{dataType}}}{{/isLong}}{{/isInteger}}{{/items}}>{{/isArray}}{{^isArray}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{^isInteger}}{{^isLong}}{{{dataType}}}{{/isLong}}{{/isInteger}}{{/isArray}}{{/isModel}}{{/isEnum}}{{#isNullable}}>{{/isNullable}}{{^required}}>{{/required}},
+{{/vars}}
+}
+
+impl {{{classname}}} {
+    {{#description}}
+    /// {{{.}}}
+    {{/description}}
+    pub fn new({{#requiredVars}}{{{name}}}: {{#isNullable}}Option<{{/isNullable}}{{#isEnum}}{{#isArray}}Vec<{{/isArray}}{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{^isEnum}}{{#isModel}}{{{dataType}}}{{/isModel}}{{^isModel}}{{#isArray}}Vec<{{#items}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{^isInteger}}{{^isLong}}{{{dataType}}}{{/isLong}}{{/isInteger}}{{/items}}>{{/isArray}}{{^isArray}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{^isInteger}}{{^isLong}}{{{dataType}}}{{/isLong}}{{/isInteger}}{{/isArray}}{{/isModel}}{{/isEnum}}{{#isNullable}}>{{/isNullable}}{{^-last}}, {{/-last}}{{/requiredVars}}) -> {{{classname}}} {
+        {{{classname}}} {
+            {{#vars}}
+            {{{name}}}{{^required}}{{#isArray}}: None{{/isArray}}{{#isMap}}: None{{/isMap}}{{^isContainer}}: None{{/isContainer}}{{/required}}{{#required}}{{#isModel}}: {{^isNullable}}Box::new({{{name}}}){{/isNullable}}{{#isNullable}}if let Some(x) = {{{name}}} {Some(Box::new(x))} else {None}{{/isNullable}}{{/isModel}}{{/required}},
+            {{/vars}}
+        }
+    }
+}
+{{/discriminator}}
+{{/isEnum}}
+
+{{!-- for properties that are of enum type --}}
+{{#vars}}
+{{#isEnum}}
+/// {{{description}}}
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+pub enum {{{enumName}}} {
+{{#allowableValues}}
+{{#enumVars}}
+    #[serde(rename = "{{{value}}}")]
+    {{{name}}},
+{{/enumVars}}
+{{/allowableValues}}
+}
+
+impl Default for {{{enumName}}} {
+    fn default() -> {{{enumName}}} {
+        {{#allowableValues}}
+        Self::{{ enumVars.0.name }}
+        {{/allowableValues}}
+    }
+}
+{{/isEnum}}
+{{/vars}}
+
+{{/model}}
+{{/models}}

--- a/openapi/templates/model.mustache
+++ b/openapi/templates/model.mustache
@@ -1,19 +1,23 @@
 {{>partial_header}}
 {{!--
-  algonaut customization of the stock openapi-generator rust `model.mustache`:
-  - every integer/long leaf (scalar or Vec element) is forced to `u64`, since
-    Algorand types its integers as 64-bit unsigned but the specs only carry an
-    explicit `format` on a minority of them;
-  - `format: byte` fields emit `algonaut_encoding::Bytes` instead of `String`,
-    with the `use` guarded by the `x-has-bytes` flag that openapi/preprocess.py
-    sets on each affected schema.
+  algonaut customization of the stock openapi-generator rust `model.mustache`.
+  openapi/preprocess.py injects the vendor extensions consumed here:
+  - x-rust-imports (schema)  -> the `use` lines the model file needs;
+  - x-rust-type (property)   -> an exact Rust type override, for domain types
+    the spec cannot express; takes precedence over the rules below;
+  - x-rust-serde (property)  -> extra `#[serde(..)]` attributes.
+  Absent an override, every integer/long leaf (scalar or Vec element) is
+  forced to `u64`, and `format: byte` fields emit `algonaut_encoding::Bytes`.
   See docs/adr/openapi-client-regeneration.md.
 --}}
 {{#models}}
 {{#model}}
-{{#vendorExtensions.x-has-bytes}}
-use algonaut_encoding::Bytes;
-{{/vendorExtensions.x-has-bytes}}
+{{#vendorExtensions.x-rust-imports}}
+{{{.}}}
+{{/vendorExtensions.x-rust-imports}}
+{{#vendorExtensions.x-rust-imports.0}}
+
+{{/vendorExtensions.x-rust-imports.0}}
 {{#description}}
 /// {{{classname}}} : {{{description}}}
 {{/description}}
@@ -83,8 +87,8 @@ pub struct {{{classname}}} {
     {{#description}}
     /// {{{.}}}
     {{/description}}
-    #[serde(rename = "{{{baseName}}}"{{^required}}{{#isNullable}}, default, with = "::serde_with::rust::double_option"{{/isNullable}}{{/required}}{{^required}}, skip_serializing_if = "Option::is_none"{{/required}}{{#required}}{{#isNullable}}, deserialize_with = "Option::deserialize"{{/isNullable}}{{/required}})]
-    pub {{{name}}}: {{#isNullable}}Option<{{/isNullable}}{{^required}}Option<{{/required}}{{#isEnum}}{{#isArray}}{{#uniqueItems}}std::collections::HashSet<{{/uniqueItems}}{{^uniqueItems}}Vec<{{/uniqueItems}}{{/isArray}}{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{^isEnum}}{{#isModel}}Box<{{{dataType}}}>{{/isModel}}{{^isModel}}{{#isArray}}Vec<{{#items}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{#isByteArray}}Bytes{{/isByteArray}}{{^isInteger}}{{^isLong}}{{^isByteArray}}{{{dataType}}}{{/isByteArray}}{{/isLong}}{{/isInteger}}{{/items}}>{{/isArray}}{{^isArray}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{#isByteArray}}Bytes{{/isByteArray}}{{^isInteger}}{{^isLong}}{{^isByteArray}}{{{dataType}}}{{/isByteArray}}{{/isLong}}{{/isInteger}}{{/isArray}}{{/isModel}}{{/isEnum}}{{#isNullable}}>{{/isNullable}}{{^required}}>{{/required}},
+    #[serde(rename = "{{{baseName}}}"{{^required}}{{#isNullable}}, default, with = "::serde_with::rust::double_option"{{/isNullable}}{{/required}}{{^required}}, skip_serializing_if = "Option::is_none"{{/required}}{{#required}}{{#isNullable}}, deserialize_with = "Option::deserialize"{{/isNullable}}{{/required}}{{#vendorExtensions.x-rust-serde}}, {{{vendorExtensions.x-rust-serde}}}{{/vendorExtensions.x-rust-serde}})]
+    pub {{{name}}}: {{#isNullable}}Option<{{/isNullable}}{{^required}}Option<{{/required}}{{#vendorExtensions.x-rust-type}}{{{vendorExtensions.x-rust-type}}}{{/vendorExtensions.x-rust-type}}{{^vendorExtensions.x-rust-type}}{{#isEnum}}{{#isArray}}{{#uniqueItems}}std::collections::HashSet<{{/uniqueItems}}{{^uniqueItems}}Vec<{{/uniqueItems}}{{/isArray}}{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{^isEnum}}{{#isModel}}Box<{{{dataType}}}>{{/isModel}}{{^isModel}}{{#isArray}}Vec<{{#items}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{#isByteArray}}Bytes{{/isByteArray}}{{^isInteger}}{{^isLong}}{{^isByteArray}}{{{dataType}}}{{/isByteArray}}{{/isLong}}{{/isInteger}}{{/items}}>{{/isArray}}{{^isArray}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{#isByteArray}}Bytes{{/isByteArray}}{{^isInteger}}{{^isLong}}{{^isByteArray}}{{{dataType}}}{{/isByteArray}}{{/isLong}}{{/isInteger}}{{/isArray}}{{/isModel}}{{/isEnum}}{{/vendorExtensions.x-rust-type}}{{#isNullable}}>{{/isNullable}}{{^required}}>{{/required}},
 {{/vars}}
 }
 
@@ -92,7 +96,7 @@ impl {{{classname}}} {
     {{#description}}
     /// {{{.}}}
     {{/description}}
-    pub fn new({{#requiredVars}}{{{name}}}: {{#isNullable}}Option<{{/isNullable}}{{#isEnum}}{{#isArray}}Vec<{{/isArray}}{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{^isEnum}}{{#isModel}}{{{dataType}}}{{/isModel}}{{^isModel}}{{#isArray}}Vec<{{#items}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{#isByteArray}}Bytes{{/isByteArray}}{{^isInteger}}{{^isLong}}{{^isByteArray}}{{{dataType}}}{{/isByteArray}}{{/isLong}}{{/isInteger}}{{/items}}>{{/isArray}}{{^isArray}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{#isByteArray}}Bytes{{/isByteArray}}{{^isInteger}}{{^isLong}}{{^isByteArray}}{{{dataType}}}{{/isByteArray}}{{/isLong}}{{/isInteger}}{{/isArray}}{{/isModel}}{{/isEnum}}{{#isNullable}}>{{/isNullable}}{{^-last}}, {{/-last}}{{/requiredVars}}) -> {{{classname}}} {
+    pub fn new({{#requiredVars}}{{{name}}}: {{#isNullable}}Option<{{/isNullable}}{{#vendorExtensions.x-rust-type}}{{{vendorExtensions.x-rust-type}}}{{/vendorExtensions.x-rust-type}}{{^vendorExtensions.x-rust-type}}{{#isEnum}}{{#isArray}}Vec<{{/isArray}}{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{^isEnum}}{{#isModel}}{{{dataType}}}{{/isModel}}{{^isModel}}{{#isArray}}Vec<{{#items}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{#isByteArray}}Bytes{{/isByteArray}}{{^isInteger}}{{^isLong}}{{^isByteArray}}{{{dataType}}}{{/isByteArray}}{{/isLong}}{{/isInteger}}{{/items}}>{{/isArray}}{{^isArray}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{#isByteArray}}Bytes{{/isByteArray}}{{^isInteger}}{{^isLong}}{{^isByteArray}}{{{dataType}}}{{/isByteArray}}{{/isLong}}{{/isInteger}}{{/isArray}}{{/isModel}}{{/isEnum}}{{/vendorExtensions.x-rust-type}}{{#isNullable}}>{{/isNullable}}{{^-last}}, {{/-last}}{{/requiredVars}}) -> {{{classname}}} {
         {{{classname}}} {
             {{#vars}}
             {{{name}}}{{^required}}{{#isArray}}: None{{/isArray}}{{#isMap}}: None{{/isMap}}{{^isContainer}}: None{{/isContainer}}{{/required}}{{#required}}{{#isModel}}: {{^isNullable}}Box::new({{{name}}}){{/isNullable}}{{#isNullable}}if let Some(x) = {{{name}}} {Some(Box::new(x))} else {None}{{/isNullable}}{{/isModel}}{{/required}},

--- a/openapi/templates/model.mustache
+++ b/openapi/templates/model.mustache
@@ -1,13 +1,19 @@
 {{>partial_header}}
 {{!--
-  algonaut customization of the stock openapi-generator rust `model.mustache`.
-  Algorand types every integer as a 64-bit unsigned value, but the specs only
-  carry an explicit `format` on a minority of them, so the stock generator
-  emits `i32` for the rest. Here every integer/long leaf is forced to `u64`.
+  algonaut customization of the stock openapi-generator rust `model.mustache`:
+  - every integer/long leaf (scalar or Vec element) is forced to `u64`, since
+    Algorand types its integers as 64-bit unsigned but the specs only carry an
+    explicit `format` on a minority of them;
+  - `format: byte` fields emit `algonaut_encoding::Bytes` instead of `String`,
+    with the `use` guarded by the `x-has-bytes` flag that openapi/preprocess.py
+    sets on each affected schema.
   See docs/adr/openapi-client-regeneration.md.
 --}}
 {{#models}}
 {{#model}}
+{{#vendorExtensions.x-has-bytes}}
+use algonaut_encoding::Bytes;
+{{/vendorExtensions.x-has-bytes}}
 {{#description}}
 /// {{{classname}}} : {{{description}}}
 {{/description}}
@@ -59,7 +65,7 @@ pub enum {{{classname}}} {
         /// {{{.}}}
         {{/description}}
         #[serde(rename = "{{{baseName}}}"{{^required}}, skip_serializing_if = "Option::is_none"{{/required}})]
-        {{{name}}}: {{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{^required}}Option<{{/required}}{{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{#isModel}}Box<{{{dataType}}}>{{/isModel}}{{^isModel}}{{#isArray}}Vec<{{#items}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{^isInteger}}{{^isLong}}{{{dataType}}}{{/isLong}}{{/isInteger}}{{/items}}>{{/isArray}}{{^isArray}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{^isInteger}}{{^isLong}}{{{dataType}}}{{/isLong}}{{/isInteger}}{{/isArray}}{{/isModel}}{{/isEnum}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{^required}}>{{/required}},
+        {{{name}}}: {{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{^required}}Option<{{/required}}{{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{#isModel}}Box<{{{dataType}}}>{{/isModel}}{{^isModel}}{{#isArray}}Vec<{{#items}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{#isByteArray}}Bytes{{/isByteArray}}{{^isInteger}}{{^isLong}}{{^isByteArray}}{{{dataType}}}{{/isByteArray}}{{/isLong}}{{/isInteger}}{{/items}}>{{/isArray}}{{^isArray}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{#isByteArray}}Bytes{{/isByteArray}}{{^isInteger}}{{^isLong}}{{^isByteArray}}{{{dataType}}}{{/isByteArray}}{{/isLong}}{{/isInteger}}{{/isArray}}{{/isModel}}{{/isEnum}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{^required}}>{{/required}},
     {{/vars}}
     },
     {{/x-mapped-models}}
@@ -78,7 +84,7 @@ pub struct {{{classname}}} {
     /// {{{.}}}
     {{/description}}
     #[serde(rename = "{{{baseName}}}"{{^required}}{{#isNullable}}, default, with = "::serde_with::rust::double_option"{{/isNullable}}{{/required}}{{^required}}, skip_serializing_if = "Option::is_none"{{/required}}{{#required}}{{#isNullable}}, deserialize_with = "Option::deserialize"{{/isNullable}}{{/required}})]
-    pub {{{name}}}: {{#isNullable}}Option<{{/isNullable}}{{^required}}Option<{{/required}}{{#isEnum}}{{#isArray}}{{#uniqueItems}}std::collections::HashSet<{{/uniqueItems}}{{^uniqueItems}}Vec<{{/uniqueItems}}{{/isArray}}{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{^isEnum}}{{#isModel}}Box<{{{dataType}}}>{{/isModel}}{{^isModel}}{{#isArray}}Vec<{{#items}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{^isInteger}}{{^isLong}}{{{dataType}}}{{/isLong}}{{/isInteger}}{{/items}}>{{/isArray}}{{^isArray}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{^isInteger}}{{^isLong}}{{{dataType}}}{{/isLong}}{{/isInteger}}{{/isArray}}{{/isModel}}{{/isEnum}}{{#isNullable}}>{{/isNullable}}{{^required}}>{{/required}},
+    pub {{{name}}}: {{#isNullable}}Option<{{/isNullable}}{{^required}}Option<{{/required}}{{#isEnum}}{{#isArray}}{{#uniqueItems}}std::collections::HashSet<{{/uniqueItems}}{{^uniqueItems}}Vec<{{/uniqueItems}}{{/isArray}}{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{^isEnum}}{{#isModel}}Box<{{{dataType}}}>{{/isModel}}{{^isModel}}{{#isArray}}Vec<{{#items}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{#isByteArray}}Bytes{{/isByteArray}}{{^isInteger}}{{^isLong}}{{^isByteArray}}{{{dataType}}}{{/isByteArray}}{{/isLong}}{{/isInteger}}{{/items}}>{{/isArray}}{{^isArray}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{#isByteArray}}Bytes{{/isByteArray}}{{^isInteger}}{{^isLong}}{{^isByteArray}}{{{dataType}}}{{/isByteArray}}{{/isLong}}{{/isInteger}}{{/isArray}}{{/isModel}}{{/isEnum}}{{#isNullable}}>{{/isNullable}}{{^required}}>{{/required}},
 {{/vars}}
 }
 
@@ -86,7 +92,7 @@ impl {{{classname}}} {
     {{#description}}
     /// {{{.}}}
     {{/description}}
-    pub fn new({{#requiredVars}}{{{name}}}: {{#isNullable}}Option<{{/isNullable}}{{#isEnum}}{{#isArray}}Vec<{{/isArray}}{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{^isEnum}}{{#isModel}}{{{dataType}}}{{/isModel}}{{^isModel}}{{#isArray}}Vec<{{#items}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{^isInteger}}{{^isLong}}{{{dataType}}}{{/isLong}}{{/isInteger}}{{/items}}>{{/isArray}}{{^isArray}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{^isInteger}}{{^isLong}}{{{dataType}}}{{/isLong}}{{/isInteger}}{{/isArray}}{{/isModel}}{{/isEnum}}{{#isNullable}}>{{/isNullable}}{{^-last}}, {{/-last}}{{/requiredVars}}) -> {{{classname}}} {
+    pub fn new({{#requiredVars}}{{{name}}}: {{#isNullable}}Option<{{/isNullable}}{{#isEnum}}{{#isArray}}Vec<{{/isArray}}{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{^isEnum}}{{#isModel}}{{{dataType}}}{{/isModel}}{{^isModel}}{{#isArray}}Vec<{{#items}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{#isByteArray}}Bytes{{/isByteArray}}{{^isInteger}}{{^isLong}}{{^isByteArray}}{{{dataType}}}{{/isByteArray}}{{/isLong}}{{/isInteger}}{{/items}}>{{/isArray}}{{^isArray}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{#isByteArray}}Bytes{{/isByteArray}}{{^isInteger}}{{^isLong}}{{^isByteArray}}{{{dataType}}}{{/isByteArray}}{{/isLong}}{{/isInteger}}{{/isArray}}{{/isModel}}{{/isEnum}}{{#isNullable}}>{{/isNullable}}{{^-last}}, {{/-last}}{{/requiredVars}}) -> {{{classname}}} {
         {{{classname}}} {
             {{#vars}}
             {{{name}}}{{^required}}{{#isArray}}: None{{/isArray}}{{#isMap}}: None{{/isMap}}{{^isContainer}}: None{{/isContainer}}{{/required}}{{#required}}{{#isModel}}: {{^isNullable}}Box::new({{{name}}}){{/isNullable}}{{#isNullable}}if let Some(x) = {{{name}}} {Some(Box::new(x))} else {None}{{/isNullable}}{{/isModel}}{{/required}},

--- a/openapi/templates/reqwest/api.mustache
+++ b/openapi/templates/reqwest/api.mustache
@@ -1,0 +1,377 @@
+{{>partial_header}}
+{{!--
+  algonaut customization of the stock openapi-generator reqwest `api.mustache`:
+  integer/long operation parameters are emitted as `u64` (Algorand types every
+  integer as 64-bit unsigned). See docs/adr/openapi-client-regeneration.md.
+--}}
+
+use reqwest;
+
+use crate::apis::ResponseContent;
+use super::{Error, configuration};
+
+{{#operations}}
+{{#operation}}
+{{#vendorExtensions.x-group-parameters}}
+{{#allParams}}
+{{#-first}}
+/// struct for passing parameters to the method [`{{operationId}}`]
+#[derive(Clone, Debug, Default)]
+pub struct {{{operationIdCamelCase}}}Params {
+{{/-first}}
+    {{#description}}
+    /// {{{.}}}
+    {{/description}}
+    pub {{{paramName}}}: {{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{^isUuid}}{{#isString}}{{#isArray}}Vec<{{/isArray}}String{{#isArray}}>{{/isArray}}{{/isString}}{{/isUuid}}{{#isUuid}}{{#isArray}}Vec<{{/isArray}}String{{#isArray}}>{{/isArray}}{{/isUuid}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}{{#isBodyParam}}crate::models::{{/isBodyParam}}{{/isContainer}}{{/isPrimitiveType}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{^isInteger}}{{^isLong}}{{{dataType}}}{{/isLong}}{{/isInteger}}{{/isUuid}}{{/isString}}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{^-last}},{{/-last}}
+{{#-last}}
+}
+
+{{/-last}}
+{{/allParams}}
+{{/vendorExtensions.x-group-parameters}}
+{{/operation}}
+{{/operations}}
+
+{{#supportMultipleResponses}}
+{{#operations}}
+{{#operation}}
+/// struct for typed successes of method [`{{operationId}}`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum {{{operationIdCamelCase}}}Success {
+    {{#responses}}
+    {{#is2xx}}
+    Status{{code}}({{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}),
+    {{/is2xx}}
+    {{#is3xx}}
+    Status{{code}}({{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}),
+    {{/is3xx}}
+    {{/responses}}
+    UnknownValue(serde_json::Value),
+}
+
+{{/operation}}
+{{/operations}}
+{{/supportMultipleResponses}}
+{{#operations}}
+{{#operation}}
+/// struct for typed errors of method [`{{operationId}}`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum {{{operationIdCamelCase}}}Error {
+    {{#responses}}
+    {{#is4xx}}
+    Status{{code}}({{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}),
+    {{/is4xx}}
+    {{#is5xx}}
+    Status{{code}}({{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}),
+    {{/is5xx}}
+    {{#isDefault}}
+    DefaultResponse({{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}),
+    {{/isDefault}}
+    {{/responses}}
+    UnknownValue(serde_json::Value),
+}
+
+{{/operation}}
+{{/operations}}
+
+{{#operations}}
+{{#operation}}
+{{#description}}
+/// {{{.}}}
+{{/description}}
+{{#notes}}
+/// {{{.}}}
+{{/notes}}
+{{#vendorExtensions.x-group-parameters}}
+pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: &configuration::Configuration{{#allParams}}{{#-first}}, params: {{{operationIdCamelCase}}}Params{{/-first}}{{/allParams}}) -> Result<{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{{returnType}}}{{/supportMultipleResponses}}, Error<{{{operationIdCamelCase}}}Error>> {
+    let local_var_configuration = configuration;
+
+    // unbox the parameters
+    {{#allParams}}
+    let {{paramName}} = params.{{paramName}};
+    {{/allParams}}
+
+{{/vendorExtensions.x-group-parameters}}
+{{^vendorExtensions.x-group-parameters}}
+pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: &configuration::Configuration, {{#allParams}}{{{paramName}}}: {{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{#isString}}{{#isArray}}Vec<{{/isArray}}{{^isUuid}}&str{{/isUuid}}{{#isArray}}>{{/isArray}}{{/isString}}{{#isUuid}}{{#isArray}}Vec<{{/isArray}}&str{{#isArray}}>{{/isArray}}{{/isUuid}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}{{#isBodyParam}}crate::models::{{/isBodyParam}}{{/isContainer}}{{/isPrimitiveType}}{{#isInteger}}u64{{/isInteger}}{{#isLong}}u64{{/isLong}}{{^isInteger}}{{^isLong}}{{{dataType}}}{{/isLong}}{{/isInteger}}{{/isUuid}}{{/isString}}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) -> Result<{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{{returnType}}}{{/supportMultipleResponses}}, Error<{{{operationIdCamelCase}}}Error>> {
+    let local_var_configuration = configuration;
+{{/vendorExtensions.x-group-parameters}}
+
+    let local_var_client = &local_var_configuration.client;
+
+    let local_var_uri_str = format!("{}{{{path}}}", local_var_configuration.base_path{{#pathParams}}, {{{baseName}}}={{#isString}}crate::apis::urlencode({{/isString}}{{{paramName}}}{{^required}}.unwrap(){{/required}}{{#required}}{{#isNullable}}.unwrap(){{/isNullable}}{{/required}}{{#isArray}}.join(",").as_ref(){{/isArray}}{{#isString}}){{/isString}}{{/pathParams}});
+    let mut local_var_req_builder = local_var_client.request(reqwest::Method::{{{httpMethod}}}, local_var_uri_str.as_str());
+
+    {{#queryParams}}
+    {{#required}}
+    {{#isArray}}
+    local_var_req_builder = match "{{collectionFormat}}" {
+        "multi" => local_var_req_builder.query(&{{{paramName}}}.into_iter().map(|p| ("{{{baseName}}}".to_owned(), p)).collect::<Vec<(std::string::String, std::string::String)>>()),
+        _ => local_var_req_builder.query(&[("{{{baseName}}}", &{{{paramName}}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(",").to_string())]),
+    };
+    {{/isArray}}
+    {{^isArray}}
+    {{^isNullable}}
+    local_var_req_builder = local_var_req_builder.query(&[("{{{baseName}}}", &{{{paramName}}}.to_string())]);
+    {{/isNullable}}
+    {{#isNullable}}
+    {{#isDeepObject}}
+    if let Some(ref local_var_str) = {{{paramName}}} {
+        let params = crate::apis::parse_deep_object("{{{baseName}}}", local_var_str);
+        local_var_req_builder = local_var_req_builder.query(&params);
+    };
+    {{/isDeepObject}}
+    {{^isDeepObject}}
+    if let Some(ref local_var_str) = {{{paramName}}} {
+        local_var_req_builder = local_var_req_builder.query(&[("{{{baseName}}}", &local_var_str.to_string())]);
+    };
+    {{/isDeepObject}}
+    {{/isNullable}}
+    {{/isArray}}
+    {{/required}}
+    {{^required}}
+    if let Some(ref local_var_str) = {{{paramName}}} {
+        {{#isArray}}
+        local_var_req_builder = match "{{collectionFormat}}" {
+            "multi" => local_var_req_builder.query(&local_var_str.into_iter().map(|p| ("{{{baseName}}}".to_owned(), p.to_string())).collect::<Vec<(std::string::String, std::string::String)>>()),
+            _ => local_var_req_builder.query(&[("{{{baseName}}}", &local_var_str.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(",").to_string())]),
+        };
+        {{/isArray}}
+        {{^isArray}}
+        {{#isDeepObject}}
+        let params = crate::apis::parse_deep_object("{{{baseName}}}", local_var_str);
+        local_var_req_builder = local_var_req_builder.query(&params);
+        {{/isDeepObject}}
+        {{^isDeepObject}}
+        local_var_req_builder = local_var_req_builder.query(&[("{{{baseName}}}", &local_var_str.to_string())]);
+        {{/isDeepObject}}
+        {{/isArray}}
+    }
+    {{/required}}
+    {{/queryParams}}
+    {{#hasAuthMethods}}
+    {{#authMethods}}
+    {{#isApiKey}}
+    {{#isKeyInQuery}}
+    if let Some(ref local_var_apikey) = local_var_configuration.api_key {
+        let local_var_key = local_var_apikey.key.clone();
+        let local_var_value = match local_var_apikey.prefix {
+            Some(ref local_var_prefix) => format!("{} {}", local_var_prefix, local_var_key),
+            None => local_var_key,
+        };
+        local_var_req_builder = local_var_req_builder.query(&[("{{{keyParamName}}}", local_var_value)]);
+    }
+    {{/isKeyInQuery}}
+    {{/isApiKey}}
+    {{/authMethods}}
+    {{/hasAuthMethods}}
+    {{#hasAuthMethods}}
+    {{#withAWSV4Signature}}
+    if let Some(ref local_var_aws_v4_key) = local_var_configuration.aws_v4_key {
+        let local_var_new_headers = match local_var_aws_v4_key.sign(
+	    &local_var_uri_str,
+	    "{{{httpMethod}}}",
+	    {{#hasBodyParam}}
+	    {{#bodyParams}}
+	    &serde_json::to_string(&{{{paramName}}}).expect("param should serialize to string"),
+	    {{/bodyParams}}
+	    {{/hasBodyParam}}
+	    {{^hasBodyParam}}
+	    &"",
+	    {{/hasBodyParam}}
+	    ) {
+	      Ok(new_headers) => new_headers,
+	      Err(err) => return Err(Error::AWSV4SignatureError(err)),
+	    };
+	for (local_var_name, local_var_value) in local_var_new_headers.iter() {
+	    local_var_req_builder = local_var_req_builder.header(local_var_name.as_str(), local_var_value.as_str());
+	}
+    }
+    {{/withAWSV4Signature}}
+    {{/hasAuthMethods}}
+    if let Some(ref local_var_user_agent) = local_var_configuration.user_agent {
+        local_var_req_builder = local_var_req_builder.header(reqwest::header::USER_AGENT, local_var_user_agent.clone());
+    }
+    {{#hasHeaderParams}}
+    {{#headerParams}}
+    {{#required}}
+    {{^isNullable}}
+    local_var_req_builder = local_var_req_builder.header("{{{baseName}}}", {{{paramName}}}{{#isArray}}.join(","){{/isArray}}.to_string());
+    {{/isNullable}}
+    {{#isNullable}}
+    match {{{paramName}}} {
+        Some(local_var_param_value) => { local_var_req_builder = local_var_req_builder.header("{{{baseName}}}", local_var_param_value{{#isArray}}.join(","){{/isArray}}.to_string()); },
+        None => { local_var_req_builder = local_var_req_builder.header("{{{baseName}}}", ""); },
+    }
+    {{/isNullable}}
+    {{/required}}
+    {{^required}}
+    if let Some(local_var_param_value) = {{{paramName}}} {
+        local_var_req_builder = local_var_req_builder.header("{{{baseName}}}", local_var_param_value{{#isArray}}.join(","){{/isArray}}.to_string());
+    }
+    {{/required}}
+    {{/headerParams}}
+    {{/hasHeaderParams}}
+    {{#hasAuthMethods}}
+    {{#authMethods}}
+    {{#isApiKey}}
+    {{#isKeyInHeader}}
+    if let Some(ref local_var_apikey) = local_var_configuration.api_key {
+        let local_var_key = local_var_apikey.key.clone();
+        let local_var_value = match local_var_apikey.prefix {
+            Some(ref local_var_prefix) => format!("{} {}", local_var_prefix, local_var_key),
+            None => local_var_key,
+        };
+        local_var_req_builder = local_var_req_builder.header("{{{keyParamName}}}", local_var_value);
+    };
+    {{/isKeyInHeader}}
+    {{/isApiKey}}
+    {{#isBasic}}
+    {{#isBasicBasic}}
+    if let Some(ref local_var_auth_conf) = local_var_configuration.basic_auth {
+        local_var_req_builder = local_var_req_builder.basic_auth(local_var_auth_conf.0.to_owned(), local_var_auth_conf.1.to_owned());
+    };
+    {{/isBasicBasic}}
+    {{#isBasicBearer}}
+    if let Some(ref local_var_token) = local_var_configuration.bearer_access_token {
+        local_var_req_builder = local_var_req_builder.bearer_auth(local_var_token.to_owned());
+    };
+    {{/isBasicBearer}}
+    {{/isBasic}}
+    {{#isOAuth}}
+    if let Some(ref local_var_token) = local_var_configuration.oauth_access_token {
+        local_var_req_builder = local_var_req_builder.bearer_auth(local_var_token.to_owned());
+    };
+    {{/isOAuth}}
+    {{/authMethods}}
+    {{/hasAuthMethods}}
+    {{#isMultipart}}
+    {{#hasFormParams}}
+    let mut local_var_form = reqwest::multipart::Form::new();
+    {{#formParams}}
+    {{#isFile}}
+    {{^supportAsync}}
+    {{#required}}
+    {{^isNullable}}
+    local_var_form = local_var_form.file("{{{baseName}}}", {{{paramName}}})?;
+    {{/isNullable}}
+    {{#isNullable}}
+    match {{{paramName}}} {
+        Some(local_var_param_value) => { local_var_form = local_var_form.file("{{{baseName}}}", local_var_param_value)?; },
+        None => { unimplemented!("Required nullable form file param not supported"); },
+    }
+    {{/isNullable}}
+    {{/required}}
+    {{^required}}
+    if let Some(local_var_param_value) = {{{paramName}}} {
+        local_var_form = local_var_form.file("{{{baseName}}}", local_var_param_value)?;
+    }
+    {{/required}}
+    {{/supportAsync}}
+    {{#supportAsync}}
+    // TODO: support file upload for '{{{baseName}}}' parameter
+    {{/supportAsync}}
+    {{/isFile}}
+    {{^isFile}}
+    {{#required}}
+    {{^isNullable}}
+    local_var_form = local_var_form.text("{{{baseName}}}", {{{paramName}}}{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
+    {{/isNullable}}
+    {{#isNullable}}
+    match {{{paramName}}} {
+        Some(local_var_param_value) => { local_var_form = local_var_form.text("{{{baseName}}}", local_var_param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string()); },
+        None => { local_var_form = local_var_form.text("{{{baseName}}}", ""); },
+    }
+    {{/isNullable}}
+    {{/required}}
+    {{^required}}
+    if let Some(local_var_param_value) = {{{paramName}}} {
+        local_var_form = local_var_form.text("{{{baseName}}}", local_var_param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
+    }
+    {{/required}}
+    {{/isFile}}
+    {{/formParams}}
+    local_var_req_builder = local_var_req_builder.multipart(local_var_form);
+    {{/hasFormParams}}
+    {{/isMultipart}}
+    {{^isMultipart}}
+    {{#hasFormParams}}
+    let mut local_var_form_params = std::collections::HashMap::new();
+    {{#formParams}}
+    {{#isFile}}
+    {{#required}}
+    {{^isNullable}}
+    local_var_form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content"));
+    {{/isNullable}}
+    {{#isNullable}}
+    match {{{paramName}}} {
+        Some(local_var_param_value) => { local_var_form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content")); },
+        None => { unimplemented!("Required nullable file form param not supported with x-www-form-urlencoded content"); },
+    }
+    {{/isNullable}}
+    {{/required}}
+    {{^required}}
+    if let Some(local_var_param_value) = {{{paramName}}} {
+        local_var_form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content"));
+    }
+    {{/required}}
+    {{/isFile}}
+    {{^isFile}}
+    {{#required}}
+    {{^isNullable}}
+    local_var_form_params.insert("{{{baseName}}}", {{{paramName}}}{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
+    {{/isNullable}}
+    {{#isNullable}}
+    match {{{paramName}}} {
+        Some(local_var_param_value) => { local_var_form_params.insert("{{{baseName}}}", local_var_param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string()); },
+        None => { local_var_form_params.insert("{{{baseName}}}", ""); },
+    }
+    {{/isNullable}}
+    {{/required}}
+    {{^required}}
+    if let Some(local_var_param_value) = {{{paramName}}} {
+        local_var_form_params.insert("{{{baseName}}}", local_var_param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
+    }
+    {{/required}}
+    {{/isFile}}
+    {{/formParams}}
+    local_var_req_builder = local_var_req_builder.form(&local_var_form_params);
+    {{/hasFormParams}}
+    {{/isMultipart}}
+    {{#hasBodyParam}}
+    {{#bodyParams}}
+    local_var_req_builder = local_var_req_builder.json(&{{{paramName}}});
+    {{/bodyParams}}
+    {{/hasBodyParam}}
+
+    let local_var_req = local_var_req_builder.build()?;
+    let {{^supportAsync}}mut {{/supportAsync}}local_var_resp = local_var_client.execute(local_var_req){{#supportAsync}}.await{{/supportAsync}}?;
+
+    let local_var_status = local_var_resp.status();
+    let local_var_content = local_var_resp.text(){{#supportAsync}}.await{{/supportAsync}}?;
+
+    if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
+        {{^supportMultipleResponses}}
+        {{^returnType}}
+        Ok(())
+        {{/returnType}}
+        {{#returnType}}
+        serde_json::from_str(&local_var_content).map_err(Error::from)
+        {{/returnType}}
+        {{/supportMultipleResponses}}
+        {{#supportMultipleResponses}}
+        let local_var_entity: Option<{{{operationIdCamelCase}}}Success> = serde_json::from_str(&local_var_content).ok();
+        let local_var_result = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
+        Ok(local_var_result)
+        {{/supportMultipleResponses}}
+    } else {
+        let local_var_entity: Option<{{{operationIdCamelCase}}}Error> = serde_json::from_str(&local_var_content).ok();
+        let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
+        Err(Error::ResponseError(local_var_error))
+    }
+}
+
+{{/operation}}
+{{/operations}}

--- a/openapi/type-overrides.json
+++ b/openapi/type-overrides.json
@@ -1,0 +1,60 @@
+{
+  "_README": "Per-field type overrides applied by openapi/preprocess.py before openapi-generator runs. Each entry retypes one generated model field to the algonaut domain type the hand-maintained crate uses, since the spec does not carry enough information to derive it. 'schema' is the OpenAPI component schema name; 'field' is the spec property name. See docs/adr/openapi-client-regeneration.md.",
+  "overrides": [
+    {
+      "crate": "algod",
+      "schema": "AssetParams",
+      "field": "metadata-hash",
+      "type": "HashDigest",
+      "import": "use algonaut_crypto::{HashDigest, deserialize_opt_hash};",
+      "serde": "deserialize_with = \"deserialize_opt_hash\", default"
+    },
+    {
+      "crate": "algod",
+      "schema": "TealValue",
+      "field": "bytes",
+      "type": "Vec<u8>",
+      "import": "use algonaut_encoding::deserialize_bytes;",
+      "serde": "deserialize_with = \"deserialize_bytes\""
+    },
+    {
+      "crate": "algod",
+      "schema": "SimulateRequestTransactionGroup",
+      "field": "txns",
+      "type": "Vec<SignedTransaction>",
+      "import": "use algonaut_transaction::SignedTransaction;"
+    },
+    {
+      "crate": "indexer",
+      "schema": "AssetParams",
+      "field": "metadata-hash",
+      "type": "HashDigest",
+      "import": "use algonaut_crypto::{HashDigest, deserialize_opt_hash};",
+      "serde": "deserialize_with = \"deserialize_opt_hash\""
+    },
+    {
+      "crate": "indexer",
+      "schema": "Block",
+      "field": "genesis-hash",
+      "type": "HashDigest",
+      "import": "use algonaut_crypto::{HashDigest, deserialize_hash};",
+      "serde": "deserialize_with = \"deserialize_hash\""
+    },
+    {
+      "crate": "indexer",
+      "schema": "Block",
+      "field": "previous-block-hash",
+      "type": "HashDigest",
+      "import": "use algonaut_crypto::{HashDigest, deserialize_hash};",
+      "serde": "deserialize_with = \"deserialize_hash\""
+    },
+    {
+      "crate": "indexer",
+      "schema": "Transaction",
+      "field": "genesis-hash",
+      "type": "HashDigest",
+      "import": "use algonaut_crypto::{HashDigest, deserialize_opt_hash};",
+      "serde": "deserialize_with = \"deserialize_opt_hash\""
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Phase 2 of the OpenAPI regeneration plan (`docs/adr/openapi-client-regeneration.md`). Stacked on #283.

The committed `algonaut_algod`/`algonaut_indexer` clients are a hand-customized fork of openapi-generator output. This PR adds custom templates + a per-field override table so a regen reproduces the bulk of that automatically — making `make generate-clients` a real drift-detection tool with a tightly review-able diff.

## Mechanisms — all under `openapi/`
- **Integers → `u64`.** `model.mustache` / `reqwest/api.mustache` emit `u64` for every integer (model field, `Vec` element, operation parameter). The specs carry an explicit `format` on only a minority; Algorand's integers are all 64-bit unsigned. Result: 0 signed ints in the regen.
- **`format: byte` → `Bytes`.** `model.mustache` emits `algonaut_encoding::Bytes` for byte fields.
- **Per-field override table.** `openapi/type-overrides.json` captures the domain types the spec can't express (`HashDigest` + `deserialize_*` serde, `Vec<SignedTransaction>`, `Vec<u8>`). `openapi/preprocess.py` reads it and injects `x-rust-type` / `x-rust-serde` / `x-rust-imports` vendor extensions into the spec; the template consumes them. Mustache can't branch on an `x-algorand-format` *value*, so the decision is made in the preprocessor — which also fails loudly if a table entry stops matching the spec.
- **Formatting.** `make generate-clients` runs `rustfmt` (edition 2024, matching the workspace) so the diff shows semantic drift, not whitespace.

## Result
**77 of the 121 common model files regenerate byte-identical** to the committed crates (33/57 algod, 44/64 indexer), measured after formatting.

> An earlier revision claimed "86" — a measurement artifact (taken before `rustfmt` was wired in, via an unstable header-strip). The honest, formatted figure is 77/121; the ADR and this description are corrected.

## Honest residual
The remaining ~44 files carry genuinely new upstream models/fields — the drift the tool exists to surface — plus a few bespoke per-file hand-edits (a renamed field, an extra `skip_serializing_if`) not worth encoding. `type-overrides.json` is a small maintenance surface: a new domain-typed field upstream shows up in the diff and gets a table entry.

## Test plan
- [x] `make generate-clients` runs clean; preprocess.py applies 7/7 overrides; 0 signed ints in the regen.
- [x] 77/121 common model files byte-identical to the committed crates.
- [x] No workspace code changed — the crates are untouched.
