### PR TITLE
feat(algod): adopt asynchronous raw-transaction endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Account-resource pagination endpoints on `Algod`: `account_apps` (`GET /v2/accounts/{address}/applications`) and `account_assets` (`GET /v2/accounts/{address}/assets`), each accepting `limit`/`next` pagination arguments. New `algonaut_algod` models `AccountApplicationsInformation200Response`, `AccountAssetsInformation200Response`, `AccountApplicationResource`, and `AccountAssetHolding`
 - Ledger state-delta endpoints on `Algod`: `txn_group_state_delta` (`GET /v2/deltas/txn/group/{id}`) and `txn_group_state_deltas_for_round` (`GET /v2/deltas/{round}/txn/group`). New `algonaut_algod` models `GetTransactionGroupLedgerStateDeltasForRound200Response` and `LedgerStateDeltaForTransactionGroup`
 - Node-administration endpoints on `Algod`: `generate_participation_keys` (`POST /v2/participation/generate/{address}`), `config` (`GET /debug/settings/config`), `debug_settings_prof` (`GET /debug/settings/pprof`), and `set_debug_settings_prof` (`PUT /debug/settings/pprof`). New `algonaut_algod` model `DebugSettingsProf`
+- Asynchronous transaction-broadcast endpoint on `Algod`: `send_raw_txn_async`, `send_txn_async`, and `send_txns_async` (`POST /v2/transactions/async`), which submit transactions to the network without ahead-of-time checks and without waiting for a transaction ID
 
 ## [0.6.0] - 2026-05-18
 

--- a/algonaut_algod/src/apis/experimental_api.rs
+++ b/algonaut_algod/src/apis/experimental_api.rs
@@ -35,6 +35,19 @@ pub enum GetLedgerStateDeltaError {
     UnknownValue(serde_json::Value),
 }
 
+/// struct for typed errors of method [`raw_transaction_async`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RawTransactionAsyncError {
+    Status400(crate::models::ErrorResponse),
+    Status401(crate::models::ErrorResponse),
+    Status404(),
+    Status500(crate::models::ErrorResponse),
+    Status503(crate::models::ErrorResponse),
+    DefaultResponse(),
+    UnknownValue(serde_json::Value),
+}
+
 pub async fn experimental_check(
     configuration: &configuration::Configuration,
 ) -> Result<(), Error<ExperimentalCheckError>> {
@@ -124,6 +137,57 @@ pub async fn get_ledger_state_delta(
         serde_json::from_str(&local_var_content).map_err(Error::from)
     } else {
         let local_var_entity: Option<GetLedgerStateDeltaError> =
+            serde_json::from_str(&local_var_content).ok();
+        let local_var_error = ResponseContent {
+            status: local_var_status,
+            content: local_var_content,
+            entity: local_var_entity,
+        };
+        Err(Error::ResponseError(local_var_error))
+    }
+}
+
+/// Broadcasts a raw transaction or transaction group to the network without ahead of time checks.
+pub async fn raw_transaction_async(
+    configuration: &configuration::Configuration,
+    rawtxn: &[u8],
+) -> Result<(), Error<RawTransactionAsyncError>> {
+    let local_var_configuration = configuration;
+
+    let local_var_client = &local_var_configuration.client;
+
+    let local_var_uri_str = format!(
+        "{}/v2/transactions/async",
+        local_var_configuration.base_path
+    );
+    let mut local_var_req_builder =
+        local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
+
+    if let Some(ref local_var_user_agent) = local_var_configuration.user_agent {
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::USER_AGENT, local_var_user_agent.clone());
+    }
+    if let Some(ref local_var_apikey) = local_var_configuration.api_key {
+        let local_var_key = local_var_apikey.key.clone();
+        let local_var_value = match local_var_apikey.prefix {
+            Some(ref local_var_prefix) => format!("{} {}", local_var_prefix, local_var_key),
+            None => local_var_key,
+        };
+        local_var_req_builder = local_var_req_builder.header("X-Algo-API-Token", local_var_value);
+    };
+    // TODO check for a better type that implements Into<Body>
+    local_var_req_builder = local_var_req_builder.body(rawtxn.to_vec());
+
+    let local_var_req = local_var_req_builder.build()?;
+    let local_var_resp = local_var_client.execute(local_var_req).await?;
+
+    let local_var_status = local_var_resp.status();
+    let local_var_content = local_var_resp.text().await?;
+
+    if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
+        Ok(())
+    } else {
+        let local_var_entity: Option<RawTransactionAsyncError> =
             serde_json::from_str(&local_var_content).ok();
         let local_var_error = ResponseContent {
             status: local_var_status,

--- a/algonaut_algod/src/apis/public_api.rs
+++ b/algonaut_algod/src/apis/public_api.rs
@@ -375,6 +375,19 @@ pub enum RawTransactionError {
     UnknownValue(serde_json::Value),
 }
 
+/// struct for typed errors of method [`raw_transaction_async`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RawTransactionAsyncError {
+    Status400(crate::models::ErrorResponse),
+    Status401(crate::models::ErrorResponse),
+    Status404(),
+    Status500(crate::models::ErrorResponse),
+    Status503(crate::models::ErrorResponse),
+    DefaultResponse(),
+    UnknownValue(serde_json::Value),
+}
+
 /// struct for typed errors of method [`set_block_time_stamp_offset`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -2205,6 +2218,57 @@ pub async fn raw_transaction(
         serde_json::from_str(&local_var_content).map_err(Error::from)
     } else {
         let local_var_entity: Option<RawTransactionError> =
+            serde_json::from_str(&local_var_content).ok();
+        let local_var_error = ResponseContent {
+            status: local_var_status,
+            content: local_var_content,
+            entity: local_var_entity,
+        };
+        Err(Error::ResponseError(local_var_error))
+    }
+}
+
+/// Broadcasts a raw transaction or transaction group to the network without ahead of time checks.
+pub async fn raw_transaction_async(
+    configuration: &configuration::Configuration,
+    rawtxn: &[u8],
+) -> Result<(), Error<RawTransactionAsyncError>> {
+    let local_var_configuration = configuration;
+
+    let local_var_client = &local_var_configuration.client;
+
+    let local_var_uri_str = format!(
+        "{}/v2/transactions/async",
+        local_var_configuration.base_path
+    );
+    let mut local_var_req_builder =
+        local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
+
+    if let Some(ref local_var_user_agent) = local_var_configuration.user_agent {
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::USER_AGENT, local_var_user_agent.clone());
+    }
+    if let Some(ref local_var_apikey) = local_var_configuration.api_key {
+        let local_var_key = local_var_apikey.key.clone();
+        let local_var_value = match local_var_apikey.prefix {
+            Some(ref local_var_prefix) => format!("{} {}", local_var_prefix, local_var_key),
+            None => local_var_key,
+        };
+        local_var_req_builder = local_var_req_builder.header("X-Algo-API-Token", local_var_value);
+    };
+    // TODO check for a better type that implements Into<Body>
+    local_var_req_builder = local_var_req_builder.body(rawtxn.to_vec());
+
+    let local_var_req = local_var_req_builder.build()?;
+    let local_var_resp = local_var_client.execute(local_var_req).await?;
+
+    let local_var_status = local_var_resp.status();
+    let local_var_content = local_var_resp.text().await?;
+
+    if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
+        Ok(())
+    } else {
+        let local_var_entity: Option<RawTransactionAsyncError> =
             serde_json::from_str(&local_var_content).ok();
         let local_var_error = ResponseContent {
             status: local_var_status,

--- a/src/algod/v2/mod.rs
+++ b/src/algod/v2/mod.rs
@@ -466,6 +466,33 @@ impl Algod {
         self.send_raw_txn(&bytes.concat()).await
     }
 
+    /// Broadcasts a raw transaction or transaction group to the network without
+    /// performing ahead-of-time checks. Returns as soon as the request is
+    /// accepted, without a transaction ID.
+    pub async fn send_raw_txn_async(&self, rawtxn: &[u8]) -> Result<(), Error> {
+        Ok(
+            algonaut_algod::apis::public_api::raw_transaction_async(&self.configuration, rawtxn)
+                .await
+                .map_err(Into::<AlgodError>::into)?,
+        )
+    }
+
+    /// Broadcasts a transaction to the network without ahead-of-time checks.
+    pub async fn send_txn_async(&self, txn: &SignedTransaction) -> Result<(), Error> {
+        self.send_raw_txn_async(&txn.to_msg_pack()?).await
+    }
+
+    /// Broadcasts a transaction group to the network without ahead-of-time checks.
+    ///
+    /// Atomic if the transactions share a [group](algonaut_transaction::transaction::Transaction::group)
+    pub async fn send_txns_async(&self, txns: &[SignedTransaction]) -> Result<(), Error> {
+        let mut bytes = vec![];
+        for t in txns {
+            bytes.push(t.to_msg_pack()?);
+        }
+        self.send_raw_txn_async(&bytes.concat()).await
+    }
+
     /// Sets the minimum sync round on the ledger.
     pub async fn sync(&self, round: u64) -> Result<(), Error> {
         Ok(


### PR DESCRIPTION
## Summary

Phase 3 increment **e**, stacked on `feat/algod-node-admin` (PR #289). Final increment of the stack.

Adopts the asynchronous transaction-broadcast endpoint into the `algonaut_algod` client and exposes wrappers on the high-level `Algod` client.

| `Algod` method | endpoint |
|----------------|----------|
| `send_raw_txn_async(rawtxn)` | `POST /v2/transactions/async` |
| `send_txn_async(txn)` | `POST /v2/transactions/async` |
| `send_txns_async(txns)` | `POST /v2/transactions/async` |

The async endpoint submits transactions without ahead-of-time checks and returns as soon as the request is accepted, without a transaction ID — so the wrappers return `Result<(), Error>`. They mirror the existing `send_raw_txn` / `send_txn` / `send_txns` trio.

## Changes

- New operation `fn` + `RawTransactionAsyncError` enum added to both `public_api.rs` and `experimental_api.rs` (the regen exposes it under both tags). The `fn` takes `rawtxn: &[u8]` and uses `.body(rawtxn.to_vec())`, matching the hand-adjusted committed `raw_transaction` (rather than the generator's `PathBuf` + `.json()` form for a binary body).
- Three wrapper methods added to the `Algod` impl in `src/algod/v2/mod.rs`.
- CHANGELOG `### Added` bullet.
- No new models — the endpoint returns no body.

## Test plan

- `cargo check --workspace --all-targets`
- `cargo test --workspace --lib --examples --tests`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all`

All four gates pass.