### PR TITLE
chore(release): bump workspace to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-20
+
 ### Added
 
 - `MicroAlgos::checked_add`, `MicroAlgos::checked_sub`, and `MicroAlgos::checked_mul` — overflow- and underflow-safe arithmetic returning `Option<MicroAlgos>`, so callers no longer need to reach into the inner `u64` (#152)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["Algorand", "sdk"]
 license = "MIT OR Apache-2.0"
 name = "algonaut"
 repository = "https://github.com/manuelmauro/algonaut"
-version = "0.6.0"
+version = "0.7.0"
 
 [workspace]
 members = [
@@ -25,15 +25,15 @@ members = [
 ]
 
 [workspace.dependencies]
-algonaut_abi = { path = "algonaut_abi", version = "0.6.0" }
-algonaut_algod = { path = "algonaut_algod", version = "0.6.0" }
-algonaut_core = { path = "algonaut_core", version = "0.6.0" }
-algonaut_crypto = { path = "algonaut_crypto", version = "0.6.0" }
-algonaut_encoding = { path = "algonaut_encoding", version = "0.6.0" }
-algonaut_indexer = { path = "algonaut_indexer", version = "0.6.0" }
-algonaut_kmd = { path = "algonaut_kmd", version = "0.6.0", default-features = false }
-algonaut_model = { path = "algonaut_model", version = "0.6.0" }
-algonaut_transaction = { path = "algonaut_transaction", version = "0.6.0" }
+algonaut_abi = { path = "algonaut_abi", version = "0.7.0" }
+algonaut_algod = { path = "algonaut_algod", version = "0.7.0" }
+algonaut_core = { path = "algonaut_core", version = "0.7.0" }
+algonaut_crypto = { path = "algonaut_crypto", version = "0.7.0" }
+algonaut_encoding = { path = "algonaut_encoding", version = "0.7.0" }
+algonaut_indexer = { path = "algonaut_indexer", version = "0.7.0" }
+algonaut_kmd = { path = "algonaut_kmd", version = "0.7.0", default-features = false }
+algonaut_model = { path = "algonaut_model", version = "0.7.0" }
+algonaut_transaction = { path = "algonaut_transaction", version = "0.7.0" }
 
 async-trait = "0.1.89"
 cucumber = "0.23.0"

--- a/algonaut_abi/Cargo.toml
+++ b/algonaut_abi/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["Algorand", "sdk"]
 license = "MIT OR Apache-2.0"
 name = "algonaut_abi"
 repository = "https://github.com/manuelmauro/algonaut"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
 algonaut_core = { workspace = true }

--- a/algonaut_algod/Cargo.toml
+++ b/algonaut_algod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "algonaut_algod"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["contact@algorand.com"]
 description = "API endpoint for algod operations."
 # Override this license by providing a License Object in the OpenAPI.

--- a/algonaut_core/Cargo.toml
+++ b/algonaut_core/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["Algorand", "sdk"]
 license = "MIT OR Apache-2.0"
 name = "algonaut_core"
 repository = "https://github.com/manuelmauro/algonaut"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
 algonaut_crypto = { workspace = true }

--- a/algonaut_crypto/Cargo.toml
+++ b/algonaut_crypto/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["Algorand", "sdk"]
 license = "MIT OR Apache-2.0"
 name = "algonaut_crypto"
 repository = "https://github.com/manuelmauro/algonaut"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
 algonaut_encoding = { workspace = true }

--- a/algonaut_encoding/Cargo.toml
+++ b/algonaut_encoding/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["Algorand", "sdk"]
 license = "MIT OR Apache-2.0"
 name = "algonaut_encoding"
 repository = "https://github.com/manuelmauro/algonaut"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
 data-encoding = { workspace = true }

--- a/algonaut_indexer/Cargo.toml
+++ b/algonaut_indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "algonaut_indexer"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "Algorand ledger analytics API."
 # Override this license by providing a License Object in the OpenAPI.

--- a/algonaut_kmd/Cargo.toml
+++ b/algonaut_kmd/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["Algorand", "sdk"]
 license = "MIT OR Apache-2.0"
 name = "algonaut_kmd"
 repository = "https://github.com/manuelmauro/algonaut"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
 algonaut_core = { workspace = true }

--- a/algonaut_model/Cargo.toml
+++ b/algonaut_model/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["Algorand", "sdk"]
 license = "MIT OR Apache-2.0"
 name = "algonaut_model"
 repository = "https://github.com/manuelmauro/algonaut"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
 algonaut_core = { workspace = true }

--- a/algonaut_transaction/Cargo.toml
+++ b/algonaut_transaction/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["Algorand", "sdk"]
 license = "MIT OR Apache-2.0"
 name = "algonaut_transaction"
 repository = "https://github.com/manuelmauro/algonaut"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
 algonaut_abi = { workspace = true }


### PR DESCRIPTION
## Summary

Cuts the `[Unreleased]` block into a `0.7.0` release. Workspace + every sub-crate bumps `0.6.0 → 0.7.0`; CHANGELOG gains a `## [0.7.0] - 2026-05-20` heading with the existing bullets preserved verbatim.

### Breaking changes

- `Algod::account_apps` gains `include: Option<&[String]>` (#293)
- `Algod::pending_txns` / `address_pending_txns` gain `format: Option<&str>` (#293)
- `AssetParams.decimals` is `u32` instead of `u64` (#140, #285)
- `PendingTransactionResponse.txn` and `GetPendingTransactionsByAddress200Response.top_transactions` are now typed (`ext::transaction::TransactionHeader`) instead of `serde_json::Value` (#296)
- `{AppId, AssetId, TxId}` newtypes adopted across the hand-written crates (#281)

### Headline additions

- msgpack response-body support in `algonaut_algod`; heartbeat (`hb`) transactions decode in algod blocks (#296)
- live `v2algodclient_paths` / `v2indexerclient_paths` / `*_responses` cucumber feature suites (#292, #294, #296)
- reproducible OpenAPI client regeneration tooling under `openapi/` (#283, #285)
- indexer leniency for valid responses that omit fields the generated models marked mandatory (#295)

## Test plan

- [x] Workspace builds: `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] On merge: tag `v0.7.0` and publish to crates.io