### PR TITLE
feat: identifier newtypes and domain types at the client boundary

### DIFF
--- a/algonaut_core/src/lib.rs
+++ b/algonaut_core/src/lib.rs
@@ -130,6 +130,19 @@ impl From<u64> for Round {
 )]
 pub struct AppId(pub u64);
 
+impl AppId {
+    /// The address of this application's escrow account.
+    ///
+    /// Computed as `sha512_256("appID" || u64_be_bytes(self.0))`, packaged
+    /// in a 32-byte [`Address`].
+    pub fn address(self) -> Address {
+        let bytes = self.0.to_be_bytes();
+        let all_bytes = ["appID".as_bytes(), &bytes].concat();
+        let hash = sha2::Sha512_256::digest(all_bytes);
+        Address(hash.into())
+    }
+}
+
 impl From<u64> for AppId {
     fn from(id: u64) -> Self {
         AppId(id)
@@ -446,14 +459,6 @@ impl TransactionTypeEnum {
             ))),
         }
     }
-}
-
-/// Returns the address corresponding to an application's escrow account.
-pub fn to_app_address(app_id: u64) -> Address {
-    let bytes = app_id.to_be_bytes();
-    let all_bytes = ["appID".as_bytes(), &bytes].concat();
-    let hash = sha2::Sha512_256::digest(all_bytes);
-    Address(hash.into())
 }
 
 #[cfg(test)]

--- a/algonaut_kmd/src/kmd/v1/mod.rs
+++ b/algonaut_kmd/src/kmd/v1/mod.rs
@@ -312,7 +312,7 @@ impl Client {
         &self,
         wallet_handle: &str,
         wallet_password: &str,
-        address: &str,
+        address: &Address,
     ) -> Result<DeleteKeyResponse, ClientError> {
         let req = DeleteKeyRequest {
             wallet_handle_token: wallet_handle.to_string(),
@@ -432,7 +432,7 @@ impl Client {
     pub async fn export_multisig(
         &self,
         wallet_handle: &str,
-        address: &str,
+        address: &Address,
     ) -> Result<ExportMultisigResponse, ClientError> {
         let req = ExportMultisigRequest {
             wallet_handle_token: wallet_handle.to_string(),
@@ -457,7 +457,7 @@ impl Client {
         &self,
         wallet_handle: &str,
         wallet_password: &str,
-        address: &str,
+        address: &Address,
     ) -> Result<DeleteMultisigResponse, ClientError> {
         let req = DeleteMultisigRequest {
             wallet_handle_token: wallet_handle.to_string(),

--- a/algonaut_transaction/src/api_model.rs
+++ b/algonaut_transaction/src/api_model.rs
@@ -9,7 +9,6 @@ use crate::{
         AssetParams, AssetTransferTransaction, BoxReference, KeyRegistration, Payment, SignedLogic,
         StateProofTransaction, StateSchema, TransactionSignature, to_tx_type_enum,
     },
-    tx_group::TxGroup,
 };
 use algonaut_core::{AppId, AssetId, CompiledTeal, LogicSignature, MicroAlgos, Round, ToMsgPack};
 use algonaut_model::transaction::{
@@ -454,7 +453,6 @@ impl From<ApiStateSchema> for StateSchema {
 
 impl ToMsgPack for Transaction {}
 impl ToMsgPack for SignedTransaction {}
-impl ToMsgPack for TxGroup {}
 
 /// Convenience to serialize Transaction directly to msg pack
 impl Serialize for Transaction {

--- a/algonaut_transaction/src/transaction.rs
+++ b/algonaut_transaction/src/transaction.rs
@@ -430,6 +430,24 @@ pub struct StateSchema {
     pub number_byteslices: u64,
 }
 
+impl StateSchema {
+    /// A schema with `number_ints` integer slots and `number_byteslices`
+    /// byte-slice slots.
+    pub fn new(number_ints: u64, number_byteslices: u64) -> Self {
+        Self {
+            number_ints,
+            number_byteslices,
+        }
+    }
+
+    /// The all-zero schema — i.e. "this application has no global / local
+    /// state of this kind." Spares the four `StateSchema { number_ints: 0,
+    /// number_byteslices: 0 }` literals that the examples write.
+    pub fn empty() -> Self {
+        Self::new(0, 0)
+    }
+}
+
 /// Wraps a transaction in a signature. The encoding of this struct is suitable to be broadcast
 /// on the network
 #[derive(Clone, Debug, PartialEq)]

--- a/algonaut_transaction/src/tx_group.rs
+++ b/algonaut_transaction/src/tx_group.rs
@@ -5,72 +5,117 @@ use sha2::Digest;
 
 use crate::{Transaction, error::TransactionError};
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+/// A batch of transactions sharing a group ID.
+///
+/// The only construction path is [`TryFrom<Vec<Transaction>>`], which
+/// validates the group size, computes the group ID, and stamps it onto
+/// every transaction before returning the populated batch. Once
+/// constructed, the inner transactions are accessible via
+/// [`TxGroup::transactions`], [`TxGroup::into_transactions`], or
+/// the [`IntoIterator`] impl.
+///
+/// The previous public surface — `TxGroup::new(Vec<HashDigest>)`,
+/// `TxGroup::assign_group_id(&mut [&mut Transaction])`, and the brief
+/// rename `TxGroup::assign` — leaked an internal hashing form and forced
+/// callers into either slice-of-mut-refs ergonomics or a static method
+/// that pretended to be a constructor. Both are gone; the msgpack
+/// hashing helper now lives as a private [`TxGroupDigests`] type.
+#[derive(Debug, Clone)]
 pub struct TxGroup {
-    #[serde(rename = "txlist", default)]
-    tx_group_hashes: Vec<HashDigest>,
+    txns: Vec<Transaction>,
 }
 
 impl TxGroup {
     const MAX_TX_GROUP_SIZE: usize = 16;
 
-    /// Assign a group ID to the given transactions and return the grouped
-    /// copies. Replaces the older `assign_group_id(&mut [&mut Transaction])`
-    /// API, whose slice-of-mutable-references shape made it the odd one out
-    /// in the public surface.
-    pub fn assign(mut txns: Vec<Transaction>) -> Result<Vec<Transaction>, TransactionError> {
+    /// Borrow the grouped transactions.
+    pub fn transactions(&self) -> &[Transaction] {
+        &self.txns
+    }
+
+    /// Take the grouped transactions, consuming the batch.
+    pub fn into_transactions(self) -> Vec<Transaction> {
+        self.txns
+    }
+}
+
+impl TryFrom<Vec<Transaction>> for TxGroup {
+    type Error = TransactionError;
+
+    fn try_from(mut txns: Vec<Transaction>) -> Result<Self, Self::Error> {
         let mut refs: Vec<&mut Transaction> = txns.iter_mut().collect();
-        let gid = TxGroup::compute_group_id(refs.as_mut_slice())?;
+        let gid = compute_group_id(refs.as_mut_slice())?;
         for tx in txns.iter_mut() {
             tx.assign_group_id(gid);
         }
-        Ok(txns)
+        Ok(Self { txns })
     }
+}
 
-    /// In-place group-id assignment for callers that already hold their
-    /// transactions through mutable references — currently only the atomic
-    /// transaction composer, which stores transactions inside
-    /// `TransactionWithSigner` records and would otherwise have to
-    /// drain-and-refill on every `build_group`.
-    ///
-    /// `#[doc(hidden)]` because [`TxGroup::assign`] is the user-facing API;
-    /// this stays exposed (across-crate workspace visibility) for the
-    /// composer's internal use only.
-    #[doc(hidden)]
-    pub fn assign_in_place(txns: &mut [&mut Transaction]) -> Result<(), TransactionError> {
-        let gid = TxGroup::compute_group_id(txns)?;
-        for tx in txns {
-            tx.assign_group_id(gid);
-        }
-        Ok(())
+impl IntoIterator for TxGroup {
+    type Item = Transaction;
+    type IntoIter = std::vec::IntoIter<Transaction>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.txns.into_iter()
     }
+}
 
-    /// Internal constructor that wraps a `Vec<HashDigest>` for msgpack
-    /// hashing. Use [`TxGroup::new`] to actually group transactions.
-    pub(crate) fn from_hashes(tx_group_hashes: Vec<HashDigest>) -> TxGroup {
-        TxGroup { tx_group_hashes }
+/// Compute the group ID for a slice of transactions, leaving them
+/// untouched. Used by the in-place [`assign_in_place`] helper and by
+/// [`TxGroup::try_from`].
+pub(crate) fn compute_group_id(
+    txns: &mut [&mut Transaction],
+) -> Result<HashDigest, TransactionError> {
+    if txns.is_empty() {
+        return Err(TransactionError::EmptyTransactionListError);
     }
-
-    pub(crate) fn compute_group_id(
-        txns: &mut [&mut Transaction],
-    ) -> Result<HashDigest, TransactionError> {
-        if txns.is_empty() {
-            return Err(TransactionError::EmptyTransactionListError);
-        }
-        if txns.len() > Self::MAX_TX_GROUP_SIZE {
-            return Err(TransactionError::MaxTransactionGroupSizeError {
-                size: Self::MAX_TX_GROUP_SIZE,
-            });
-        }
-        let mut ids: Vec<HashDigest> = vec![];
-        for t in txns.iter() {
-            ids.push(t.raw_id()?);
-        }
-        let group = TxGroup::from_hashes(ids);
-        let hashed = sha2::Sha512_256::digest(group.bytes_to_sign()?);
-        Ok(HashDigest(hashed.into()))
+    if txns.len() > TxGroup::MAX_TX_GROUP_SIZE {
+        return Err(TransactionError::MaxTransactionGroupSizeError {
+            size: TxGroup::MAX_TX_GROUP_SIZE,
+        });
     }
+    let mut ids: Vec<HashDigest> = vec![];
+    for t in txns.iter() {
+        ids.push(t.raw_id()?);
+    }
+    let digests = TxGroupDigests {
+        tx_group_hashes: ids,
+    };
+    let hashed = sha2::Sha512_256::digest(digests.bytes_to_sign()?);
+    Ok(HashDigest(hashed.into()))
+}
 
+/// In-place group-id assignment for callers that already hold their
+/// transactions through mutable references — the atomic transaction
+/// composer, which stores transactions inside `TransactionWithSigner`
+/// records and cannot move them out for [`TxGroup::try_from`].
+///
+/// `#[doc(hidden)]` because [`TxGroup::try_from`] is the user-facing
+/// API; this stays exposed (workspace visibility) for the composer's
+/// internal use only.
+#[doc(hidden)]
+pub fn assign_in_place(txns: &mut [&mut Transaction]) -> Result<(), TransactionError> {
+    let gid = compute_group_id(txns)?;
+    for tx in txns {
+        tx.assign_group_id(gid);
+    }
+    Ok(())
+}
+
+/// The msgpack-hashing form of a transaction group: a list of transaction
+/// raw-IDs serialised as `txlist` and prefixed with `"TG"` before SHA-512/256
+/// hashing. Held internally so the public [`TxGroup`] type isn't
+/// contaminated by a representation no caller cares about.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+struct TxGroupDigests {
+    #[serde(rename = "txlist", default)]
+    tx_group_hashes: Vec<HashDigest>,
+}
+
+impl ToMsgPack for TxGroupDigests {}
+
+impl TxGroupDigests {
     fn bytes_to_sign(&self) -> Result<Vec<u8>, TransactionError> {
         let encoded_tx = self.to_msg_pack()?;
         let mut prefix_encoded_tx = b"TG".to_vec();
@@ -79,7 +124,7 @@ impl TxGroup {
     }
 }
 
-impl Serialize for TxGroup {
+impl Serialize for TxGroupDigests {
     fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
     where
         S: Serializer,

--- a/algonaut_transaction/src/tx_group.rs
+++ b/algonaut_transaction/src/tx_group.rs
@@ -14,10 +14,35 @@ pub struct TxGroup {
 impl TxGroup {
     const MAX_TX_GROUP_SIZE: usize = 16;
 
-    pub fn new(tx_group_hashes: Vec<HashDigest>) -> TxGroup {
-        TxGroup { tx_group_hashes }
+    /// Assign a group ID to the given transactions and return the grouped
+    /// copies. Replaces the older `assign_group_id(&mut [&mut Transaction])`
+    /// API, whose slice-of-mutable-references shape made it the odd one out
+    /// in the public surface.
+    ///
+    /// The constructor returns `Vec<Transaction>` rather than `Self` because
+    /// `TxGroup` (the msgpack-hashing helper) is not what callers want — they
+    /// want the grouped transactions back. Per the
+    /// `identifier-newtypes-at-client-boundary` ADR.
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(mut txns: Vec<Transaction>) -> Result<Vec<Transaction>, TransactionError> {
+        let mut refs: Vec<&mut Transaction> = txns.iter_mut().collect();
+        let gid = TxGroup::compute_group_id(refs.as_mut_slice())?;
+        for tx in txns.iter_mut() {
+            tx.assign_group_id(gid);
+        }
+        Ok(txns)
     }
 
+    /// In-place group-id assignment for callers that already hold their
+    /// transactions through mutable references — currently only the atomic
+    /// transaction composer, which stores transactions inside
+    /// `TransactionWithSigner` records and would otherwise have to
+    /// drain-and-refill on every `build_group`.
+    ///
+    /// `#[doc(hidden)]` because [`TxGroup::new`] is the user-facing API;
+    /// this stays exposed (across-crate workspace visibility) for the
+    /// composer's internal use only.
+    #[doc(hidden)]
     pub fn assign_group_id(txns: &mut [&mut Transaction]) -> Result<(), TransactionError> {
         let gid = TxGroup::compute_group_id(txns)?;
         for tx in txns {
@@ -26,8 +51,14 @@ impl TxGroup {
         Ok(())
     }
 
+    /// Internal constructor that wraps a `Vec<HashDigest>` for msgpack
+    /// hashing. Use [`TxGroup::new`] to actually group transactions.
+    pub(crate) fn from_hashes(tx_group_hashes: Vec<HashDigest>) -> TxGroup {
+        TxGroup { tx_group_hashes }
+    }
+
     pub(crate) fn compute_group_id(
-        txns: &[&mut Transaction],
+        txns: &mut [&mut Transaction],
     ) -> Result<HashDigest, TransactionError> {
         if txns.is_empty() {
             return Err(TransactionError::EmptyTransactionListError);
@@ -38,10 +69,10 @@ impl TxGroup {
             });
         }
         let mut ids: Vec<HashDigest> = vec![];
-        for t in txns {
+        for t in txns.iter() {
             ids.push(t.raw_id()?);
         }
-        let group = TxGroup::new(ids);
+        let group = TxGroup::from_hashes(ids);
         let hashed = sha2::Sha512_256::digest(group.bytes_to_sign()?);
         Ok(HashDigest(hashed.into()))
     }

--- a/algonaut_transaction/src/tx_group.rs
+++ b/algonaut_transaction/src/tx_group.rs
@@ -18,13 +18,7 @@ impl TxGroup {
     /// copies. Replaces the older `assign_group_id(&mut [&mut Transaction])`
     /// API, whose slice-of-mutable-references shape made it the odd one out
     /// in the public surface.
-    ///
-    /// The constructor returns `Vec<Transaction>` rather than `Self` because
-    /// `TxGroup` (the msgpack-hashing helper) is not what callers want — they
-    /// want the grouped transactions back. Per the
-    /// `identifier-newtypes-at-client-boundary` ADR.
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(mut txns: Vec<Transaction>) -> Result<Vec<Transaction>, TransactionError> {
+    pub fn assign(mut txns: Vec<Transaction>) -> Result<Vec<Transaction>, TransactionError> {
         let mut refs: Vec<&mut Transaction> = txns.iter_mut().collect();
         let gid = TxGroup::compute_group_id(refs.as_mut_slice())?;
         for tx in txns.iter_mut() {
@@ -39,11 +33,11 @@ impl TxGroup {
     /// `TransactionWithSigner` records and would otherwise have to
     /// drain-and-refill on every `build_group`.
     ///
-    /// `#[doc(hidden)]` because [`TxGroup::new`] is the user-facing API;
+    /// `#[doc(hidden)]` because [`TxGroup::assign`] is the user-facing API;
     /// this stays exposed (across-crate workspace visibility) for the
     /// composer's internal use only.
     #[doc(hidden)]
-    pub fn assign_group_id(txns: &mut [&mut Transaction]) -> Result<(), TransactionError> {
+    pub fn assign_in_place(txns: &mut [&mut Transaction]) -> Result<(), TransactionError> {
         let gid = TxGroup::compute_group_id(txns)?;
         for tx in txns {
             tx.assign_group_id(gid);

--- a/docs/adr/identifier-newtypes-at-client-boundary.md
+++ b/docs/adr/identifier-newtypes-at-client-boundary.md
@@ -82,26 +82,46 @@ conversion from callers.
 Address` replaces it. Both existing callers (`tests/step_defs/integration/abi.rs`,
 `src/util/dryrun_printer.rs`) drop the `.0` unwrap.
 
-### `TxGroup::assign` returns owned transactions
+### `TxGroup` *is* the grouped batch
 
-`TxGroup::assign_group_id(&mut [&mut t1, &mut t2])` is replaced by
+The old `TxGroup` was a passive msgpack-hashing helper holding
+`Vec<HashDigest>` — exposed publicly only so the in-place
+`assign_group_id(&mut [&mut Transaction])` API had somewhere to live as
+a static method. Two iterations during this ADR — first a public
+`TxGroup::new(Vec<Transaction>) -> Result<Vec<Transaction>>`, then a
+rename to `TxGroup::assign` — both kept that shape and both were
+unsatisfying: the type had no domain meaning, and `new` returning
+something other than `Self` is precisely the pattern
+`clippy::new_ret_no_self` exists to flag.
+
+The end state is `TxGroup` representing what callers think it does — a
+batch of transactions sharing a group ID — and a `TryFrom<Vec<Transaction>>`
+impl as the single construction path:
 
 ```rust
-TxGroup::assign(vec![t1, t2]) -> Result<Vec<Transaction>, TransactionError>
+let group: TxGroup = vec![t1, t2].try_into()?;
+// or
+let group = TxGroup::try_from(vec![t1, t2])?;
+
+for tx in group {
+    // IntoIterator over the grouped transactions
+}
 ```
 
-which consumes its inputs and returns the grouped copies. The verb-y
-name matters: the ADR index originally proposed `TxGroup::new`, but a
-`new` that returns `Vec<Transaction>` rather than a `TxGroup` is exactly
-what `clippy::new_ret_no_self` is built to catch — the caller writes
-`TxGroup::new(...)` expecting a `TxGroup` back and gets something else.
-`assign` describes the action and lets the lint stay on.
+`TxGroup::transactions(&self) -> &[Transaction]` borrows, and
+`TxGroup::into_transactions(self) -> Vec<Transaction>` consumes.
 
-The composer-internal in-place form survives as
-`TxGroup::assign_in_place(&mut [&mut Transaction])`, `#[doc(hidden)]
-pub` so the workspace can reach it without leaking it into the public
-surface. The `assign_group_id` name is also retired to avoid the clash
-with the same-named method on `Transaction` itself.
+The msgpack hashing form (the previous public struct) moves to a
+private `TxGroupDigests` inside `tx_group.rs`; the in-place mutating
+form survives as `tx_group::assign_in_place(&mut [&mut Transaction])` —
+a free function in the module, `#[doc(hidden)] pub` so the atomic
+transaction composer can reach it across the workspace boundary without
+leaking it into the public surface.
+
+The same-named `assign_group_id` method on `Transaction` (the
+per-transaction setter) is unaffected and keeps its name; the clash
+that the rename was working around no longer exists once the batch
+operation is a `TryFrom` impl on `TxGroup`.
 
 ### `StateSchema` gains constructors
 

--- a/docs/adr/identifier-newtypes-at-client-boundary.md
+++ b/docs/adr/identifier-newtypes-at-client-boundary.md
@@ -82,19 +82,26 @@ conversion from callers.
 Address` replaces it. Both existing callers (`tests/step_defs/integration/abi.rs`,
 `src/util/dryrun_printer.rs`) drop the `.0` unwrap.
 
-### `TxGroup::new` returns owned transactions
+### `TxGroup::assign` returns owned transactions
 
 `TxGroup::assign_group_id(&mut [&mut t1, &mut t2])` is replaced by
 
 ```rust
-TxGroup::new(vec![t1, t2]) -> Result<Vec<Transaction>, Error>
+TxGroup::assign(vec![t1, t2]) -> Result<Vec<Transaction>, TransactionError>
 ```
 
-which consumes its inputs and returns the grouped copies. The two
-current callers (`examples/atomic_swap.rs`,
-`src/atomic_transaction_composer/mod.rs`) update accordingly. The
-in-place mutation form is removed — no caller would prefer it now that
-the newtype-collecting form exists.
+which consumes its inputs and returns the grouped copies. The verb-y
+name matters: the ADR index originally proposed `TxGroup::new`, but a
+`new` that returns `Vec<Transaction>` rather than a `TxGroup` is exactly
+what `clippy::new_ret_no_self` is built to catch — the caller writes
+`TxGroup::new(...)` expecting a `TxGroup` back and gets something else.
+`assign` describes the action and lets the lint stay on.
+
+The composer-internal in-place form survives as
+`TxGroup::assign_in_place(&mut [&mut Transaction])`, `#[doc(hidden)]
+pub` so the workspace can reach it without leaking it into the public
+surface. The `assign_group_id` name is also retired to avoid the clash
+with the same-named method on `Transaction` itself.
 
 ### `StateSchema` gains constructors
 

--- a/docs/adr/identifier-newtypes-at-client-boundary.md
+++ b/docs/adr/identifier-newtypes-at-client-boundary.md
@@ -1,0 +1,153 @@
+---
+id: identifier-newtypes-at-client-boundary
+title: Identifier newtypes and domain types at the client boundary
+abstract: Push the AppId / AssetId / Address / TxId newtypes through the algod / indexer / kmd public method signatures, turn the to_app_address free function into AppId::address, replace the TxGroup::assign_group_id slice-of-mut-refs API with a TxGroup::new constructor, add StateSchema::empty / new, and replace teal_compile's Option<bool> with a SourceMap two-variant enum. First sub-ADR addressing items D4 and D9 of the ideal-type-safe-ergonomic-api index.
+status: proposed
+date: 2026-05-20
+deciders: []
+tags: [api, ergonomics, type-safety]
+---
+
+# Identifier newtypes and domain types at the client boundary
+
+## Status
+
+Proposed. Implements decision items **D4** and **D9** of
+[`ideal-type-safe-ergonomic-api`](ideal-type-safe-ergonomic-api.md).
+
+## Context
+
+`algonaut_core::{AppId, AssetId, TxId}` already exist as transparent
+newtypes (PR #281). The transaction builders adopted them — `Pay`,
+`CreateApplication::foreign_apps(Vec<AppId>)`, `Transaction::id` — but
+the *client* methods that consume those same values still take bare
+primitives:
+
+```rust
+algod.app(application_id: u64)         // accepts an AssetId silently
+algod.asset(asset_id: u64)
+algod.account(address: &str)           // takes a string, parses it back
+algod.pending_txn(txid: &str)
+algod.txn_proof(round: u64, txid: &str)
+indexer.lookup_application_by_id(application_id: u64)
+indexer.lookup_transaction(txid: &str)
+kmd.delete_key(_, _, address: &str)
+…
+```
+
+Twelve algod methods, sixteen indexer methods, three kmd methods. The
+type system knows the value is an `Address` or an `AppId`; the API
+throws that knowledge away at the call boundary and reconstructs it on
+the other side. Real call sites compensate with `.to_string()` /
+`.as_str()` stringification — `examples/rekey.rs` does it twice,
+`tests/step_defs/integration/assets.rs` and `general.rs` do it for every
+`account(...)` call.
+
+The companion D9 cuts are the same problem in miniature:
+
+- `to_app_address(app_id: u64)` is a free function precisely because
+  `AppId` did not exist when it was written. Both current callers
+  unwrap the newtype with `app_id.0`.
+- `TxGroup::assign_group_id(&mut [&mut t1, &mut t2])` mutates through a
+  slice of mutable references — the only API in the crate that does.
+- `StateSchema { number_ints: 0, number_byteslices: 0 }` is the empty
+  literal in `examples/app_create.rs` twice; no constructor exists.
+- `algod.teal_compile(source, None)` is `Option<bool>` for source-map
+  emission, paired with a separate `teal_compile_with_sourcemap` —
+  `None` at the call site explains nothing.
+
+## Decision
+
+### Client signatures take the newtypes
+
+For every public method on `Algod`, `Indexer`, and `Kmd` that today
+accepts an identifier as `&str` / `u64`:
+
+| Today                                              | After                                              |
+|----------------------------------------------------|----------------------------------------------------|
+| `address: &str`, `account_id: &str`                | `address: &Address`                                |
+| `application_id: u64` (and `Option<u64>`)          | `app_id: AppId` / `Option<AppId>`                  |
+| `asset_id: u64` (and `Option<u64>`)                | `asset_id: AssetId` / `Option<AssetId>`            |
+| `txid: &str` (and `Option<&str>`)                  | `txid: &TxId` / `Option<&TxId>`                    |
+
+Stringification stays at the HTTP boundary inside the client: the
+generated `algonaut_algod` / `algonaut_indexer` / `algonaut_kmd`
+operations still consume `&str` / `i32` / `u64`, and the hand-written
+wrappers convert at the edge. The public surface stops demanding the
+conversion from callers.
+
+### `to_app_address` becomes a method
+
+`algonaut_core::to_app_address(u64)` deletes; `AppId::address(self) ->
+Address` replaces it. Both existing callers (`tests/step_defs/integration/abi.rs`,
+`src/util/dryrun_printer.rs`) drop the `.0` unwrap.
+
+### `TxGroup::new` returns owned transactions
+
+`TxGroup::assign_group_id(&mut [&mut t1, &mut t2])` is replaced by
+
+```rust
+TxGroup::new(vec![t1, t2]) -> Result<Vec<Transaction>, Error>
+```
+
+which consumes its inputs and returns the grouped copies. The two
+current callers (`examples/atomic_swap.rs`,
+`src/atomic_transaction_composer/mod.rs`) update accordingly. The
+in-place mutation form is removed — no caller would prefer it now that
+the newtype-collecting form exists.
+
+### `StateSchema` gains constructors
+
+```rust
+StateSchema::empty()           // both zero
+StateSchema::new(ints, slices) // explicit counts
+```
+
+The struct keeps `pub` fields (it is a plain `(u64, u64)`) but the four
+"empty literal" sites and the two "with values" sites stop reaching for
+the field names.
+
+### `teal_compile` takes `SourceMap::{Emit, Skip}`
+
+```rust
+pub enum SourceMap {
+    Emit,
+    Skip,
+}
+
+algod.teal_compile(&source, SourceMap::Skip).await?;
+```
+
+The `algod.teal_compile_with_sourcemap` companion stays — it returns a
+parsed `SourceMap` value, a strictly different return shape — but the
+boolean `Option` on the plain `teal_compile` is gone, so the eight call
+sites that pass `None` get to say what they mean.
+
+## Consequences
+
+- **Compile-error breaking change** for every external caller of the
+  thirty-one renamed methods. Pre-1.0; the crate's `README` calls out
+  that the API still moves. Migration is mechanical: wrap a literal
+  with `AppId(..)` / `AssetId(..)`, replace `&account.address().to_string()`
+  with `&account.address()`, replace `tx_id.as_str()` with `&tx_id`.
+- **Mixed-ID mistakes become compile errors.** `algod.app(asset.id())`
+  no longer compiles; the newtypes share no `From` between each other.
+- **No serialization change.** `AppId` / `AssetId` are
+  `#[serde(transparent)]` over `u64`; `TxId` over `String`; `Address`
+  already round-trips correctly per
+  [`domain-types-serialize-for-both-json-and-msgpack`](domain-types-serialize-for-both-json-and-msgpack.md).
+  Wire bytes are identical before and after.
+- **The conversion layer is one line per method.** Each wrapper gains
+  `&address.to_string()` / `app_id.0` at the call into the generated
+  client. The cost is paid once per endpoint; user code stops paying it
+  at every call site.
+- **The examples shrink.** `examples/atomic_swap.rs` drops the
+  `&mut [&mut t1, &mut t2]` shape. `examples/app_create.rs` drops two
+  `StateSchema { number_ints: 0, number_byteslices: 0 }` literals and
+  two `teal_compile(.., None)`s. `examples/rekey.rs` drops two
+  `.to_string()` calls.
+- **Out of scope.** The remaining client-edge surface (response types —
+  D3 in the index ADR) is unchanged here. Methods continue to return
+  `*200Response` types and `pub use algonaut_algod as openapi_algod`
+  stays. D2 (finality on the client) and D3 (hide generated types) are
+  separate sub-ADRs that build on this one.

--- a/examples/app_create.rs
+++ b/examples/app_create.rs
@@ -1,9 +1,10 @@
-use algonaut::algod::v2::Algod;
+use algonaut::algod::v2::{Algod, SourceMap};
 use algonaut::transaction::CreateApplication;
 use algonaut::transaction::TxnBuilder;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::transaction::StateSchema;
 use algonaut_algod::models::PendingTransactionResponse;
+use algonaut_core::TxId;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;
@@ -42,8 +43,10 @@ int 1
     .as_bytes();
 
     info!("compiling approval and clear programs");
-    let compiled_approval_program = algod.teal_compile(approval_program, None).await?;
-    let compiled_clear_program = algod.teal_compile(clear_program, None).await?;
+    let compiled_approval_program = algod
+        .teal_compile(approval_program, SourceMap::Skip)
+        .await?;
+    let compiled_clear_program = algod.teal_compile(clear_program, SourceMap::Skip).await?;
 
     info!("retrieving suggested params");
     let params = algod.txn_params().await?;
@@ -55,14 +58,8 @@ int 1
             alice.address(),
             compiled_approval_program,
             compiled_clear_program,
-            StateSchema {
-                number_ints: 0,
-                number_byteslices: 0,
-            },
-            StateSchema {
-                number_ints: 0,
-                number_byteslices: 0,
-            },
+            StateSchema::empty(),
+            StateSchema::empty(),
         )
         .app_arguments(vec![vec![1, 0], vec![255]])
         .build(),
@@ -76,7 +73,8 @@ int 1
     let send_response = algod.send_txn(&signed_t).await?;
 
     info!("waiting for transaction finality");
-    let pending_t = wait_for_pending_transaction(&algod, &send_response.tx_id).await?;
+    let tx_id: TxId = send_response.tx_id.into();
+    let pending_t = wait_for_pending_transaction(&algod, &tx_id).await?;
 
     info!(
         "application id: {:?}",
@@ -89,7 +87,7 @@ int 1
 /// Utility function to wait on a transaction to be confirmed
 async fn wait_for_pending_transaction(
     algod: &Algod,
-    txid: &str,
+    txid: &TxId,
 ) -> Result<Option<PendingTransactionResponse>, algonaut::Error> {
     let timeout = Duration::from_secs(10);
     let start = Instant::now();

--- a/examples/app_update.rs
+++ b/examples/app_update.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::algod::v2::{Algod, SourceMap};
 use algonaut::core::AppId;
 use algonaut::transaction::TxnBuilder;
 use algonaut::transaction::account::Account;
@@ -35,10 +35,12 @@ int 1
     .as_bytes();
 
     info!("compiling approval program");
-    let compiled_approval_program = algod.teal_compile(approval_program, None).await?;
+    let compiled_approval_program = algod
+        .teal_compile(approval_program, SourceMap::Skip)
+        .await?;
 
     info!("compiling approval program");
-    let compiled_clear_program = algod.teal_compile(clear_program, None).await?;
+    let compiled_clear_program = algod.teal_compile(clear_program, SourceMap::Skip).await?;
 
     info!("retrieving suggested params");
     let params = algod.txn_params().await?;

--- a/examples/asset_create.rs
+++ b/examples/asset_create.rs
@@ -2,6 +2,7 @@ use algonaut::algod::v2::Algod;
 use algonaut::openapi_algod::models::PendingTransactionResponse;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::{CreateAsset, TxnBuilder};
+use algonaut_core::TxId;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;
@@ -51,7 +52,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     info!("transaction ID: {}", send_response.tx_id);
 
     info!("waiting for transaction finality");
-    let pending_t = wait_for_pending_transaction(&algod, &send_response.tx_id).await?;
+    let tx_id: TxId = send_response.tx_id.into();
+    let pending_t = wait_for_pending_transaction(&algod, &tx_id).await?;
     info!("asset index: {:?}", pending_t.map(|t| t.asset_index));
 
     Ok(())
@@ -60,7 +62,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 /// Utility function to wait on a transaction to be confirmed
 async fn wait_for_pending_transaction(
     algod: &Algod,
-    txid: &str,
+    txid: &TxId,
 ) -> Result<Option<PendingTransactionResponse>, algonaut::Error> {
     let timeout = Duration::from_secs(10);
     let start = Instant::now();

--- a/examples/atomic_swap.rs
+++ b/examples/atomic_swap.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     .build()?;
 
     info!("grouping transactions");
-    let grouped = TxGroup::new(vec![t1, t2])?;
+    let grouped = TxGroup::assign(vec![t1, t2])?;
     let mut grouped = grouped.into_iter();
     let t1 = grouped.next().expect("group has two transactions");
     let t2 = grouped.next().expect("group has two transactions");

--- a/examples/atomic_swap.rs
+++ b/examples/atomic_swap.rs
@@ -43,10 +43,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     .build()?;
 
     info!("grouping transactions");
-    let grouped = TxGroup::assign(vec![t1, t2])?;
-    let mut grouped = grouped.into_iter();
-    let t1 = grouped.next().expect("group has two transactions");
-    let t2 = grouped.next().expect("group has two transactions");
+    let group = TxGroup::try_from(vec![t1, t2])?;
+    let mut iter = group.into_iter();
+    let t1 = iter.next().expect("group has two transactions");
+    let t2 = iter.next().expect("group has two transactions");
 
     info!("signing transactions");
     let signed_t1 = alice.sign_transaction(t1)?;

--- a/examples/atomic_swap.rs
+++ b/examples/atomic_swap.rs
@@ -29,21 +29,24 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Normally you'll want to submit e.g. a payment and asset transfer or asset transfers for different assets.
 
     info!("building payment transaction alice -> bob");
-    let mut t1 = TxnBuilder::with(
+    let t1 = TxnBuilder::with(
         &params,
         Pay::new(alice.address(), bob.address(), MicroAlgos(1_000)).build(),
     )
     .build()?;
 
     info!("building payment transaction bob -> alice");
-    let mut t2 = TxnBuilder::with(
+    let t2 = TxnBuilder::with(
         &params,
         Pay::new(bob.address(), alice.address(), MicroAlgos(3_000)).build(),
     )
     .build()?;
 
     info!("grouping transactions");
-    TxGroup::assign_group_id(&mut [&mut t1, &mut t2])?;
+    let grouped = TxGroup::new(vec![t1, t2])?;
+    let mut grouped = grouped.into_iter();
+    let t1 = grouped.next().expect("group has two transactions");
+    let t2 = grouped.next().expect("group has two transactions");
 
     info!("signing transactions");
     let signed_t1 = alice.sign_transaction(t1)?;

--- a/examples/logic_sig_contract_account.rs
+++ b/examples/logic_sig_contract_account.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::algod::v2::{Algod, SourceMap};
 use algonaut::core::MicroAlgos;
 use algonaut::transaction::Pay;
 use algonaut::transaction::TxnBuilder;
@@ -31,7 +31,7 @@ byte 0xFF
 &&
 "#
             .as_bytes(),
-            None,
+            SourceMap::Skip,
         )
         .await?;
 

--- a/examples/logic_sig_delegated.rs
+++ b/examples/logic_sig_delegated.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::algod::v2::{Algod, SourceMap};
 use algonaut::core::{LogicSignature, MicroAlgos, TxId};
 use algonaut::transaction::transaction::TransactionSignature;
 use algonaut::transaction::{Pay, SignedTransaction};
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 int 1
 "#
             .as_bytes(),
-            None,
+            SourceMap::Skip,
         )
         .await?;
 

--- a/examples/logic_sig_delegated_multi.rs
+++ b/examples/logic_sig_delegated_multi.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::algod::v2::{Algod, SourceMap};
 use algonaut::core::{LogicSignature, MicroAlgos, MultisigAddress, TxId};
 use algonaut::transaction::transaction::TransactionSignature;
 use algonaut::transaction::{Pay, SignedTransaction};
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 int 1
 "#
             .as_bytes(),
-            None,
+            SourceMap::Skip,
         )
         .await?;
 

--- a/examples/rekey.rs
+++ b/examples/rekey.rs
@@ -1,7 +1,7 @@
 use algonaut::algod::v2::Algod;
 use algonaut::transaction::{TxnBuilder, account::Account};
 use algonaut::util::wait_for_pending_tx::wait_for_pending_transaction;
-use algonaut_core::MicroAlgos;
+use algonaut_core::{MicroAlgos, TxId};
 use algonaut_transaction::Pay;
 use dotenv::dotenv;
 use std::env;
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     info!("checking auth address");
     // double check that rekeyed account's auth address is not set
-    let account_infos = algod.account(&rekeyed_acc_address.to_string()).await?;
+    let account_infos = algod.account(&rekeyed_acc_address).await?;
     assert!(account_infos.auth_addr.is_none());
 
     info!("retrieving suggested params");
@@ -51,12 +51,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     info!("broadcasting transaction");
     let rekey_response = algod.send_txn(&rekey_signed).await?;
-    wait_for_pending_transaction(&algod, &rekey_response.tx_id).await?;
+    let tx_id: TxId = rekey_response.tx_id.into();
+    wait_for_pending_transaction(&algod, &tx_id).await?;
     info!("rekey success");
 
     info!("verifying the rekey success");
     // verify: rekey_to address is set as auth address of the rekeyed acc
-    let account_infos = algod.account(&rekeyed_acc_address.to_string()).await?;
+    let account_infos = algod.account(&rekeyed_acc_address).await?;
     assert_eq!(
         Some(rekey_to_acc_address.to_string()),
         account_infos.auth_addr

--- a/src/algod/v2/mod.rs
+++ b/src/algod/v2/mod.rs
@@ -16,9 +16,32 @@ use algonaut_algod::{
         TealDryrun200Response, TransactionParams200Response, Version,
     },
 };
-use algonaut_core::{CompiledTeal, ToMsgPack};
+use algonaut_core::{Address, AppId, AssetId, CompiledTeal, ToMsgPack, TxId};
 use algonaut_encoding::decode_base64;
 use algonaut_transaction::SignedTransaction;
+
+/// Whether `teal_compile` should ask algod to include a source-map alongside
+/// the compiled bytes. Distinct from [`algonaut_abi::sourcemap::SourceMap`],
+/// which is the *parsed* source-map type returned by
+/// [`Algod::teal_compile_with_sourcemap`].
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum SourceMap {
+    /// Request a source-map. The map travels back on the JSON response but
+    /// [`Algod::teal_compile`] still returns only the compiled bytes — call
+    /// [`Algod::teal_compile_with_sourcemap`] if you need the parsed map.
+    Emit,
+    /// Do not request a source-map.
+    Skip,
+}
+
+impl SourceMap {
+    fn as_option_bool(self) -> Option<bool> {
+        match self {
+            SourceMap::Emit => Some(true),
+            SourceMap::Skip => None,
+        }
+    }
+}
 
 /// Error class wrapping errors from algonaut_algod
 pub(crate) mod error;
@@ -52,14 +75,14 @@ impl Algod {
     /// Given a specific account public key and application ID, this call returns the account's application local state and global state (AppLocalState and AppParams, if either exists). Global state will only be returned if the provided address is the application's creator.
     pub async fn account_app(
         self,
-        address: &str,
-        application_id: u64,
+        address: &Address,
+        app_id: AppId,
     ) -> Result<AccountApplicationInformation200Response, Error> {
         Ok(
             algonaut_algod::apis::public_api::account_application_information(
                 &self.configuration,
-                address,
-                application_id,
+                &address.to_string(),
+                app_id.0,
                 None,
             )
             .await
@@ -73,7 +96,7 @@ impl Algod {
     /// `include` controls which sub-objects are returned (e.g. `["params"]`).
     pub async fn account_apps(
         &self,
-        address: &str,
+        address: &Address,
         limit: Option<u64>,
         next: Option<&str>,
         include: Option<&[String]>,
@@ -81,7 +104,7 @@ impl Algod {
         Ok(
             algonaut_algod::apis::public_api::account_applications_information(
                 &self.configuration,
-                address,
+                &address.to_string(),
                 limit,
                 next,
                 include.map(<[String]>::to_vec),
@@ -94,14 +117,14 @@ impl Algod {
     /// Lookup an account's asset holdings, paginated by asset ID.
     pub async fn account_assets(
         &self,
-        address: &str,
+        address: &Address,
         limit: Option<u64>,
         next: Option<&str>,
     ) -> Result<AccountAssetsInformation200Response, Error> {
         Ok(
             algonaut_algod::apis::public_api::account_assets_information(
                 &self.configuration,
-                address,
+                &address.to_string(),
                 limit,
                 next,
             )
@@ -111,10 +134,10 @@ impl Algod {
     }
 
     /// Given a specific account public key, this call returns the accounts status, balance and spendable amounts
-    pub async fn account(&self, address: &str) -> Result<Account, Error> {
+    pub async fn account(&self, address: &Address) -> Result<Account, Error> {
         Ok(algonaut_algod::apis::public_api::account_information(
             &self.configuration,
-            address,
+            &address.to_string(),
             None,
             None,
         )
@@ -132,11 +155,11 @@ impl Algod {
     }
 
     /// Given an application ID and box name, it returns the box name and value (each base64 encoded). Box names must be in the goal app call arg encoding form 'encoding:value'. For ints, use the form 'int:1234'. For raw bytes, use the form 'b64:A=='. For printable strings, use the form 'str:hello'. For addresses, use the form 'addr:XYZ...'.
-    pub async fn app_box(&self, application_id: u64, name: &str) -> Result<models::Box, Error> {
+    pub async fn app_box(&self, app_id: AppId, name: &str) -> Result<models::Box, Error> {
         Ok(
             algonaut_algod::apis::public_api::get_application_box_by_name(
                 &self.configuration,
-                application_id,
+                app_id.0,
                 name,
             )
             .await
@@ -147,12 +170,12 @@ impl Algod {
     /// Given an application ID, return all Box names. No particular ordering is guaranteed. Request fails when client or server-side configured limits prevent returning all Box names.
     pub async fn app_boxes(
         &self,
-        application_id: u64,
+        app_id: AppId,
         max: Option<u64>,
     ) -> Result<GetApplicationBoxes200Response, Error> {
         Ok(algonaut_algod::apis::public_api::get_application_boxes(
             &self.configuration,
-            application_id,
+            app_id.0,
             max,
         )
         .await
@@ -160,19 +183,18 @@ impl Algod {
     }
 
     /// Given a application ID, it returns application information including creator, approval and clear programs, global and local schemas, and global state.
-    pub async fn app(&self, application_id: u64) -> Result<Application, Error> {
-        Ok(algonaut_algod::apis::public_api::get_application_by_id(
-            &self.configuration,
-            application_id,
+    pub async fn app(&self, app_id: AppId) -> Result<Application, Error> {
+        Ok(
+            algonaut_algod::apis::public_api::get_application_by_id(&self.configuration, app_id.0)
+                .await
+                .map_err(Into::<AlgodError>::into)?,
         )
-        .await
-        .map_err(Into::<AlgodError>::into)?)
     }
 
     /// Given a asset ID, it returns asset information including creator, name, total supply and special addresses.
-    pub async fn asset(&self, asset_id: u64) -> Result<Asset, Error> {
+    pub async fn asset(&self, asset_id: AssetId) -> Result<Asset, Error> {
         Ok(
-            algonaut_algod::apis::public_api::get_asset_by_id(&self.configuration, asset_id)
+            algonaut_algod::apis::public_api::get_asset_by_id(&self.configuration, asset_id.0)
                 .await
                 .map_err(Into::<AlgodError>::into)?,
         )
@@ -261,11 +283,11 @@ impl Algod {
 
     /// Get a ledger delta for a given transaction group, identified by the ID
     /// of the first transaction in the group.
-    pub async fn txn_group_state_delta(&self, id: &str) -> Result<serde_json::Value, Error> {
+    pub async fn txn_group_state_delta(&self, id: &TxId) -> Result<serde_json::Value, Error> {
         Ok(
             algonaut_algod::apis::public_api::get_ledger_state_delta_for_transaction_group(
                 &self.configuration,
-                id,
+                id.as_str(),
                 None,
             )
             .await
@@ -326,14 +348,14 @@ impl Algod {
     /// `format` selects the response encoding (`"json"` or `"msgpack"`).
     pub async fn address_pending_txns(
         &self,
-        address: &str,
+        address: &Address,
         max: Option<u64>,
         format: Option<&str>,
     ) -> Result<GetPendingTransactionsByAddress200Response, Error> {
         Ok(
             algonaut_algod::apis::public_api::get_pending_transactions_by_address(
                 &self.configuration,
-                address,
+                &address.to_string(),
                 max,
                 format,
             )
@@ -391,12 +413,12 @@ impl Algod {
     pub async fn txn_proof(
         &self,
         round: u64,
-        txid: &str,
+        txid: &TxId,
     ) -> Result<GetTransactionProof200Response, Error> {
         Ok(algonaut_algod::apis::public_api::get_transaction_proof(
             &self.configuration,
             round,
-            txid,
+            txid.as_str(),
             None,
             None,
         )
@@ -432,11 +454,11 @@ impl Algod {
     }
 
     /// Given a transaction ID of a recently submitted transaction, it returns information about it.  There are several cases when this might succeed: - transaction committed (committed round > 0) - transaction still in the pool (committed round = 0, pool error = \"\") - transaction removed from pool due to error (committed round = 0, pool error != \"\") Or the transaction may have happened sufficiently long ago that the node no longer remembers it, and this will return an error.
-    pub async fn pending_txn(&self, txid: &str) -> Result<PendingTransactionResponse, Error> {
+    pub async fn pending_txn(&self, txid: &TxId) -> Result<PendingTransactionResponse, Error> {
         Ok(
             algonaut_algod::apis::public_api::pending_transaction_information(
                 &self.configuration,
-                txid,
+                txid.as_str(),
                 None,
             )
             .await
@@ -538,12 +560,15 @@ impl Algod {
     pub async fn teal_compile(
         &self,
         source: &[u8],
-        sourcemap: Option<bool>,
+        sourcemap: SourceMap,
     ) -> Result<CompiledTeal, Error> {
-        let api_compiled_teal =
-            algonaut_algod::apis::public_api::teal_compile(&self.configuration, source, sourcemap)
-                .await
-                .map_err(Into::<AlgodError>::into)?;
+        let api_compiled_teal = algonaut_algod::apis::public_api::teal_compile(
+            &self.configuration,
+            source,
+            sourcemap.as_option_bool(),
+        )
+        .await
+        .map_err(Into::<AlgodError>::into)?;
         // The api result (program + hash) is mapped to the domain program struct, which computes the hash on demand.
         // The hash here is redundant and we want to allow to generate it with the SDK too (e.g. for when loading programs from a DB).
         // At the moment it seems not warranted to add a cache (so it's initialized with the API hash or lazily), but this can be re-evaluated.
@@ -628,7 +653,7 @@ impl Algod {
     /// `first` through `last`. Returns the participation ID of the new keys.
     pub async fn generate_participation_keys(
         &self,
-        address: &str,
+        address: &Address,
         first: u64,
         last: u64,
         dilution: Option<u64>,
@@ -636,7 +661,7 @@ impl Algod {
         Ok(
             algonaut_algod::apis::private_api::generate_participation_keys(
                 &self.configuration,
-                address,
+                &address.to_string(),
                 first,
                 last,
                 dilution,

--- a/src/atomic_transaction_composer/mod.rs
+++ b/src/atomic_transaction_composer/mod.rs
@@ -396,7 +396,7 @@ impl AtomicTransactionComposer {
             for tx in self.txs.iter_mut() {
                 group_txs.push(&mut tx.tx);
             }
-            TxGroup::assign_group_id(&mut group_txs)?;
+            TxGroup::assign_in_place(&mut group_txs)?;
         }
 
         self.status = AtomicTransactionComposerStatus::Built;

--- a/src/atomic_transaction_composer/mod.rs
+++ b/src/atomic_transaction_composer/mod.rs
@@ -21,7 +21,7 @@ use algonaut_transaction::{
         ApplicationCallOnComplete, ApplicationCallTransaction, BoxReference, StateSchema,
         to_tx_type_enum,
     },
-    tx_group::TxGroup,
+    tx_group,
 };
 use data_encoding::BASE64;
 use num_bigint::BigUint;
@@ -396,7 +396,7 @@ impl AtomicTransactionComposer {
             for tx in self.txs.iter_mut() {
                 group_txs.push(&mut tx.tx);
             }
-            TxGroup::assign_in_place(&mut group_txs)?;
+            tx_group::assign_in_place(&mut group_txs)?;
         }
 
         self.status = AtomicTransactionComposerStatus::Built;

--- a/src/atomic_transaction_composer/mod.rs
+++ b/src/atomic_transaction_composer/mod.rs
@@ -488,7 +488,7 @@ impl AtomicTransactionComposer {
         }
 
         let tx_id = self.signed_txs[index_to_wait].transaction_id.clone();
-        let pending_tx = wait_for_pending_transaction(algod, tx_id.as_str()).await?;
+        let pending_tx = wait_for_pending_transaction(algod, &tx_id).await?;
 
         let mut return_list: Vec<AbiMethodResult> = vec![];
 
@@ -505,7 +505,7 @@ impl AtomicTransactionComposer {
             if i != index_to_wait {
                 let tx_id = self.signed_txs[i].transaction_id.clone();
 
-                match algod.pending_txn(tx_id.as_str()).await {
+                match algod.pending_txn(&tx_id).await {
                     Ok(p) => {
                         current_tx_id = tx_id;
                         current_pending_tx = p;

--- a/src/indexer/v2/mod.rs
+++ b/src/indexer/v2/mod.rs
@@ -1,5 +1,6 @@
 use self::error::IndexerError;
 use crate::Error;
+use algonaut_core::{Address, AppId, AssetId, TxId};
 use algonaut_indexer::{
     apis::configuration::{ApiKey, Configuration},
     models::{
@@ -54,8 +55,8 @@ impl Indexer {
     /// Lookup an account's asset holdings, optionally for a specific ID.
     pub async fn lookup_account_app_local_states(
         &self,
-        account_id: &str,
-        application_id: Option<u64>,
+        address: &Address,
+        app_id: Option<AppId>,
         include_all: Option<bool>,
         limit: Option<u64>,
         next: Option<&str>,
@@ -63,8 +64,8 @@ impl Indexer {
         Ok(
             algonaut_indexer::apis::lookup_api::lookup_account_app_local_states(
                 &self.configuration,
-                account_id,
-                application_id,
+                &address.to_string(),
+                app_id.map(|a| a.0),
                 include_all,
                 limit,
                 next,
@@ -77,16 +78,16 @@ impl Indexer {
     /// Lookup an account's asset holdings, optionally for a specific ID.
     pub async fn lookup_account_assets(
         &self,
-        account_id: &str,
-        asset_id: Option<u64>,
+        address: &Address,
+        asset_id: Option<AssetId>,
         include_all: Option<bool>,
         limit: Option<u64>,
         next: Option<&str>,
     ) -> Result<LookupAccountAssets200Response, Error> {
         Ok(algonaut_indexer::apis::lookup_api::lookup_account_assets(
             &self.configuration,
-            account_id,
-            asset_id,
+            &address.to_string(),
+            asset_id.map(|a| a.0),
             include_all,
             limit,
             next,
@@ -98,14 +99,14 @@ impl Indexer {
     /// Lookup account information.
     pub async fn lookup_account_by_id(
         &self,
-        account_id: &str,
+        address: &Address,
         round: Option<u64>,
         include_all: Option<bool>,
         exclude: Option<Vec<String>>,
     ) -> Result<LookupAccountById200Response, Error> {
         Ok(algonaut_indexer::apis::lookup_api::lookup_account_by_id(
             &self.configuration,
-            account_id,
+            &address.to_string(),
             round,
             include_all,
             exclude,
@@ -117,8 +118,8 @@ impl Indexer {
     /// Lookup an account's created application parameters, optionally for a specific ID.
     pub async fn lookup_account_created_applications(
         &self,
-        account_id: &str,
-        application_id: Option<u64>,
+        address: &Address,
+        app_id: Option<AppId>,
         include_all: Option<bool>,
         limit: Option<u64>,
         next: Option<&str>,
@@ -126,8 +127,8 @@ impl Indexer {
         Ok(
             algonaut_indexer::apis::lookup_api::lookup_account_created_applications(
                 &self.configuration,
-                account_id,
-                application_id,
+                &address.to_string(),
+                app_id.map(|a| a.0),
                 include_all,
                 limit,
                 next,
@@ -140,8 +141,8 @@ impl Indexer {
     /// Lookup an account's created asset parameters, optionally for a specific ID.
     pub async fn lookup_account_created_assets(
         &self,
-        account_id: &str,
-        asset_id: Option<u64>,
+        address: &Address,
+        asset_id: Option<AssetId>,
         include_all: Option<bool>,
         limit: Option<u64>,
         next: Option<&str>,
@@ -149,8 +150,8 @@ impl Indexer {
         Ok(
             algonaut_indexer::apis::lookup_api::lookup_account_created_assets(
                 &self.configuration,
-                account_id,
-                asset_id,
+                &address.to_string(),
+                asset_id.map(|a| a.0),
                 include_all,
                 limit,
                 next,
@@ -164,17 +165,17 @@ impl Indexer {
     #[allow(clippy::too_many_arguments)]
     pub async fn lookup_account_transactions(
         &self,
-        account_id: &str,
+        address: &Address,
         limit: Option<u64>,
         next: Option<&str>,
         note_prefix: Option<&str>,
         tx_type: Option<&str>,
         sig_type: Option<&str>,
-        txid: Option<&str>,
+        txid: Option<&TxId>,
         round: Option<u64>,
         min_round: Option<u64>,
         max_round: Option<u64>,
-        asset_id: Option<u64>,
+        asset_id: Option<AssetId>,
         before_time: Option<String>,
         after_time: Option<String>,
         currency_greater_than: Option<u64>,
@@ -184,17 +185,17 @@ impl Indexer {
         Ok(
             algonaut_indexer::apis::lookup_api::lookup_account_transactions(
                 &self.configuration,
-                account_id,
+                &address.to_string(),
                 limit,
                 next,
                 note_prefix,
                 tx_type,
                 sig_type,
-                txid,
+                txid.map(TxId::as_str),
                 round,
                 min_round,
                 max_round,
-                asset_id,
+                asset_id.map(|a| a.0),
                 before_time,
                 after_time,
                 currency_greater_than,
@@ -209,13 +210,13 @@ impl Indexer {
     /// Given an application ID and box name, returns base64 encoded box name and value. Box names must be in the goal app call arg form 'encoding:value'. For ints, use the form 'int:1234'. For raw bytes, encode base 64 and use 'b64' prefix as in 'b64:A=='. For printable strings, use the form 'str:hello'. For addresses, use the form 'addr:XYZ...'.
     pub async fn lookup_application_box_by_id_and_name(
         &self,
-        application_id: u64,
+        app_id: AppId,
         name: &str,
     ) -> Result<algonaut_indexer::models::Box, Error> {
         Ok(
             algonaut_indexer::apis::lookup_api::lookup_application_box_by_id_and_name(
                 &self.configuration,
-                application_id,
+                app_id.0,
                 name,
             )
             .await
@@ -226,13 +227,13 @@ impl Indexer {
     /// Lookup application.
     pub async fn lookup_application_by_id(
         &self,
-        application_id: u64,
+        app_id: AppId,
         include_all: Option<bool>,
     ) -> Result<LookupApplicationById200Response, Error> {
         Ok(
             algonaut_indexer::apis::lookup_api::lookup_application_by_id(
                 &self.configuration,
-                application_id,
+                app_id.0,
                 include_all,
             )
             .await
@@ -244,10 +245,10 @@ impl Indexer {
     #[allow(clippy::too_many_arguments)]
     pub async fn lookup_application_logs_by_id(
         &self,
-        application_id: u64,
+        app_id: AppId,
         limit: Option<u64>,
         next: Option<&str>,
-        txid: Option<&str>,
+        txid: Option<&TxId>,
         min_round: Option<u64>,
         max_round: Option<u64>,
         sender_address: Option<&str>,
@@ -255,10 +256,10 @@ impl Indexer {
         Ok(
             algonaut_indexer::apis::lookup_api::lookup_application_logs_by_id(
                 &self.configuration,
-                application_id,
+                app_id.0,
                 limit,
                 next,
-                txid,
+                txid.map(TxId::as_str),
                 min_round,
                 max_round,
                 sender_address,
@@ -271,7 +272,7 @@ impl Indexer {
     /// Lookup the list of accounts who hold this asset
     pub async fn lookup_asset_balances(
         &self,
-        asset_id: u64,
+        asset_id: AssetId,
         include_all: Option<bool>,
         limit: Option<u64>,
         next: Option<&str>,
@@ -280,7 +281,7 @@ impl Indexer {
     ) -> Result<LookupAssetBalances200Response, Error> {
         Ok(algonaut_indexer::apis::lookup_api::lookup_asset_balances(
             &self.configuration,
-            asset_id,
+            asset_id.0,
             include_all,
             limit,
             next,
@@ -294,12 +295,12 @@ impl Indexer {
     /// Lookup asset information.
     pub async fn lookup_asset_by_id(
         &self,
-        asset_id: u64,
+        asset_id: AssetId,
         include_all: Option<bool>,
     ) -> Result<LookupAssetById200Response, Error> {
         Ok(algonaut_indexer::apis::lookup_api::lookup_asset_by_id(
             &self.configuration,
-            asset_id,
+            asset_id.0,
             include_all,
         )
         .await
@@ -310,13 +311,13 @@ impl Indexer {
     #[allow(clippy::too_many_arguments)]
     pub async fn lookup_asset_transactions(
         &self,
-        asset_id: u64,
+        asset_id: AssetId,
         limit: Option<u64>,
         next: Option<&str>,
         note_prefix: Option<&str>,
         tx_type: Option<&str>,
         sig_type: Option<&str>,
-        txid: Option<&str>,
+        txid: Option<&TxId>,
         round: Option<u64>,
         min_round: Option<u64>,
         max_round: Option<u64>,
@@ -324,21 +325,22 @@ impl Indexer {
         after_time: Option<String>,
         currency_greater_than: Option<u64>,
         currency_less_than: Option<u64>,
-        address: Option<&str>,
+        address: Option<&Address>,
         address_role: Option<&str>,
         exclude_close_to: Option<bool>,
         rekey_to: Option<bool>,
     ) -> Result<LookupAccountTransactions200Response, Error> {
+        let address = address.map(Address::to_string);
         Ok(
             algonaut_indexer::apis::lookup_api::lookup_asset_transactions(
                 &self.configuration,
-                asset_id,
+                asset_id.0,
                 limit,
                 next,
                 note_prefix,
                 tx_type,
                 sig_type,
-                txid,
+                txid.map(TxId::as_str),
                 round,
                 min_round,
                 max_round,
@@ -346,7 +348,7 @@ impl Indexer {
                 after_time,
                 currency_greater_than,
                 currency_less_than,
-                address,
+                address.as_deref(),
                 address_role,
                 exclude_close_to,
                 rekey_to,
@@ -374,42 +376,44 @@ impl Indexer {
     /// Lookup a single transaction.
     pub async fn lookup_transaction(
         &self,
-        txid: &str,
+        txid: &TxId,
     ) -> Result<LookupTransaction200Response, Error> {
-        Ok(
-            algonaut_indexer::apis::lookup_api::lookup_transaction(&self.configuration, txid)
-                .await
-                .map_err(Into::<IndexerError>::into)?,
+        Ok(algonaut_indexer::apis::lookup_api::lookup_transaction(
+            &self.configuration,
+            txid.as_str(),
         )
+        .await
+        .map_err(Into::<IndexerError>::into)?)
     }
 
     /// Search for accounts.
     #[allow(clippy::too_many_arguments)]
     pub async fn search_for_accounts(
         &self,
-        asset_id: Option<u64>,
+        asset_id: Option<AssetId>,
         limit: Option<u64>,
         next: Option<&str>,
         currency_greater_than: Option<u64>,
         include_all: Option<bool>,
         exclude: Option<Vec<String>>,
         currency_less_than: Option<u64>,
-        auth_addr: Option<&str>,
+        auth_addr: Option<&Address>,
         round: Option<u64>,
-        application_id: Option<u64>,
+        app_id: Option<AppId>,
     ) -> Result<SearchForAccounts200Response, Error> {
+        let auth_addr = auth_addr.map(Address::to_string);
         Ok(algonaut_indexer::apis::search_api::search_for_accounts(
             &self.configuration,
-            asset_id,
+            asset_id.map(|a| a.0),
             limit,
             next,
             currency_greater_than,
             include_all,
             exclude,
             currency_less_than,
-            auth_addr,
+            auth_addr.as_deref(),
             round,
-            application_id,
+            app_id.map(|a| a.0),
         )
         .await
         .map_err(Into::<IndexerError>::into)?)
@@ -418,14 +422,14 @@ impl Indexer {
     /// Given an application ID, returns the box names of that application sorted lexicographically.
     pub async fn search_for_application_boxes(
         &self,
-        application_id: u64,
+        app_id: AppId,
         limit: Option<u64>,
         next: Option<&str>,
     ) -> Result<SearchForApplicationBoxes200Response, Error> {
         Ok(
             algonaut_indexer::apis::search_api::search_for_application_boxes(
                 &self.configuration,
-                application_id,
+                app_id.0,
                 limit,
                 next,
             )
@@ -437,16 +441,17 @@ impl Indexer {
     /// Search for applications
     pub async fn search_for_applications(
         &self,
-        application_id: Option<u64>,
-        creator: Option<&str>,
+        app_id: Option<AppId>,
+        creator: Option<&Address>,
         include_all: Option<bool>,
         limit: Option<u64>,
         next: Option<&str>,
     ) -> Result<LookupAccountCreatedApplications200Response, Error> {
+        let creator = creator.map(Address::to_string);
         Ok(algonaut_indexer::apis::search_api::search_for_applications(
             &self.configuration,
-            application_id,
-            creator,
+            app_id.map(|a| a.0),
+            creator.as_deref(),
             include_all,
             limit,
             next,
@@ -462,20 +467,21 @@ impl Indexer {
         include_all: Option<bool>,
         limit: Option<u64>,
         next: Option<&str>,
-        creator: Option<&str>,
+        creator: Option<&Address>,
         name: Option<&str>,
         unit: Option<&str>,
-        asset_id: Option<u64>,
+        asset_id: Option<AssetId>,
     ) -> Result<LookupAccountCreatedAssets200Response, Error> {
+        let creator = creator.map(Address::to_string);
         Ok(algonaut_indexer::apis::search_api::search_for_assets(
             &self.configuration,
             include_all,
             limit,
             next,
-            creator,
+            creator.as_deref(),
             name,
             unit,
-            asset_id,
+            asset_id.map(|a| a.0),
         )
         .await
         .map_err(Into::<IndexerError>::into)?)
@@ -522,21 +528,22 @@ impl Indexer {
         note_prefix: Option<&str>,
         tx_type: Option<&str>,
         sig_type: Option<&str>,
-        txid: Option<&str>,
+        txid: Option<&TxId>,
         round: Option<u64>,
         min_round: Option<u64>,
         max_round: Option<u64>,
-        asset_id: Option<u64>,
+        asset_id: Option<AssetId>,
         before_time: Option<String>,
         after_time: Option<String>,
         currency_greater_than: Option<u64>,
         currency_less_than: Option<u64>,
-        address: Option<&str>,
+        address: Option<&Address>,
         address_role: Option<&str>,
         exclude_close_to: Option<bool>,
         rekey_to: Option<bool>,
-        application_id: Option<u64>,
+        app_id: Option<AppId>,
     ) -> Result<LookupAccountTransactions200Response, Error> {
+        let address = address.map(Address::to_string);
         Ok(algonaut_indexer::apis::search_api::search_for_transactions(
             &self.configuration,
             limit,
@@ -544,20 +551,20 @@ impl Indexer {
             note_prefix,
             tx_type,
             sig_type,
-            txid,
+            txid.map(TxId::as_str),
             round,
             min_round,
             max_round,
-            asset_id,
+            asset_id.map(|a| a.0),
             before_time,
             after_time,
             currency_greater_than,
             currency_less_than,
-            address,
+            address.as_deref(),
             address_role,
             exclude_close_to,
             rekey_to,
-            application_id,
+            app_id.map(|a| a.0),
         )
         .await
         .map_err(Into::<IndexerError>::into)?)

--- a/src/kmd/v1/mod.rs
+++ b/src/kmd/v1/mod.rs
@@ -170,7 +170,7 @@ impl Kmd {
         &self,
         wallet_handle: &str,
         wallet_password: &str,
-        address: &str,
+        address: &Address,
     ) -> Result<DeleteKeyResponse, Error> {
         Ok(self
             .client
@@ -219,7 +219,7 @@ impl Kmd {
     pub async fn export_multisig(
         &self,
         wallet_handle: &str,
-        address: &str,
+        address: &Address,
     ) -> Result<ExportMultisigResponse, Error> {
         Ok(self.client.export_multisig(wallet_handle, address).await?)
     }
@@ -229,7 +229,7 @@ impl Kmd {
         &self,
         wallet_handle: &str,
         wallet_password: &str,
-        address: &str,
+        address: &Address,
     ) -> Result<DeleteMultisigResponse, Error> {
         Ok(self
             .client

--- a/src/util/dryrun_printer.rs
+++ b/src/util/dryrun_printer.rs
@@ -3,7 +3,7 @@ use algonaut_algod::models::{
     Application, ApplicationParams, ApplicationStateSchema, DryrunRequest, DryrunState,
     DryrunTxnResult, TealValue,
 };
-use algonaut_core::{Address, AppId, AssetId, to_app_address};
+use algonaut_core::{Address, AppId, AssetId};
 use algonaut_encoding::Bytes;
 use algonaut_transaction::{
     SignedTransaction, TransactionType,
@@ -48,7 +48,7 @@ pub async fn create_dryrun_with_settings(
         if let TransactionType::ApplicationCallTransaction(app_call) = &tx.txn_type {
             if let Some(app_id) = app_call.app_id {
                 apps.insert(app_id);
-                accts.insert(to_app_address(app_id.0));
+                accts.insert(app_id.address());
             } else {
                 // Prepare and set param fields for Application being created
                 app_infos.push(to_application(app_call, &tx.sender()))
@@ -68,18 +68,18 @@ pub async fn create_dryrun_with_settings(
     }
 
     for asset_id in assets {
-        let asset = algod.asset(asset_id.0).await?;
+        let asset = algod.asset(asset_id).await?;
         accts.insert(asset.params.creator.parse().unwrap());
     }
 
     for app_id in apps {
-        let app = algod.app(app_id.0).await?;
+        let app = algod.app(app_id).await?;
         accts.insert(app.params.creator.parse().unwrap());
         app_infos.push(app);
     }
 
     for address in accts {
-        let acc = algod.account(address.to_string().as_str()).await?;
+        let acc = algod.account(&address).await?;
         acct_infos.push(acc);
     }
 

--- a/src/util/wait_for_pending_tx.rs
+++ b/src/util/wait_for_pending_tx.rs
@@ -1,13 +1,14 @@
 use super::sleep;
 use crate::{Error, algod::v2::Algod};
 use algonaut_algod::models::PendingTransactionResponse;
+use algonaut_core::TxId;
 use instant::Instant;
 use std::time::Duration;
 
 /// Utility to wait for a transaction to be confirmed
 pub async fn wait_for_pending_transaction(
     algod: &Algod,
-    tx_id: &str,
+    tx_id: &TxId,
 ) -> Result<PendingTransactionResponse, Error> {
     let timeout = Duration::from_secs(60);
     let start = Instant::now();

--- a/tests/step_defs/integration/abi.rs
+++ b/tests/step_defs/integration/abi.rs
@@ -12,7 +12,7 @@ use algonaut_abi::{
     abi_type::{AbiType, AbiValue},
 };
 use algonaut_algod::models::PendingTransactionResponse;
-use algonaut_core::{Address, AppId, MicroAlgos, to_app_address};
+use algonaut_core::{Address, AppId, MicroAlgos, TxId};
 use algonaut_transaction::{
     Pay, TxnBuilder,
     transaction::{ApplicationCallOnComplete, BoxReference, StateSchema},
@@ -411,18 +411,12 @@ async fn add_method_call(
     let extra_pages = extra_pages.unwrap_or(0);
 
     let global_schema = match (global_ints, global_bytes) {
-        (Some(ints), Some(bytes)) => Some(StateSchema {
-            number_ints: ints,
-            number_byteslices: bytes,
-        }),
+        (Some(ints), Some(bytes)) => Some(StateSchema::new(ints, bytes)),
         _ => None,
     };
 
     let local_schema = match (local_ints, local_bytes) {
-        (Some(ints), Some(bytes)) => Some(StateSchema {
-            number_ints: ints,
-            number_byteslices: bytes,
-        }),
+        (Some(ints), Some(bytes)) => Some(StateSchema::new(ints, bytes)),
         _ => None,
     };
 
@@ -872,7 +866,7 @@ async fn i_fund_the_current_applications_address(w: &mut World, micro_algos: u64
 
     let first_account = accounts[0];
 
-    let app_address = to_app_address(app_id.0);
+    let app_address = app_id.address();
 
     let tx_params = algod.txn_params().await.expect("couldn't get params");
 
@@ -893,7 +887,8 @@ async fn i_fund_the_current_applications_address(w: &mut World, micro_algos: u64
         .await
         .expect("couldn't send tx");
 
-    let _ = wait_for_pending_transaction(algod, &res.tx_id);
+    let tx_id: TxId = res.tx_id.into();
+    let _ = wait_for_pending_transaction(algod, &tx_id);
 }
 
 #[given(regex = r#"^I reset the array of application IDs to remember\.$"#)]

--- a/tests/step_defs/integration/applications.rs
+++ b/tests/step_defs/integration/applications.rs
@@ -59,15 +59,9 @@ async fn i_build_an_application_transaction(
             let approval_program = read_teal(algod, &approval_program_file).await;
             let clear_program = read_teal(algod, &clear_program_file).await;
 
-            let global_schema = StateSchema {
-                number_ints: global_ints,
-                number_byteslices: global_bytes,
-            };
+            let global_schema = StateSchema::new(global_ints, global_bytes);
 
-            let local_schema = StateSchema {
-                number_ints: local_ints,
-                number_byteslices: local_bytes,
-            };
+            let local_schema = StateSchema::new(local_ints, local_bytes);
 
             CreateApplication::new(
                 transient_account.address(),
@@ -163,7 +157,7 @@ async fn i_remember_the_new_application_id(w: &mut World) {
     let tx_id = w.tx_id.as_ref().unwrap();
     let app_ids: &mut Vec<AppId> = w.app_ids.as_mut();
 
-    let p_tx = algod.pending_txn(tx_id.as_str()).await.unwrap();
+    let p_tx = algod.pending_txn(tx_id).await.unwrap();
     assert!(p_tx.application_index.is_some());
     let app_id = AppId(p_tx.application_index.unwrap());
 
@@ -187,10 +181,7 @@ async fn the_transient_account_should_have(
     let transient_account = w.transient_account.as_ref().unwrap();
     let app_id = w.app_id.unwrap();
 
-    let account_infos = algod
-        .account(&transient_account.address().to_string())
-        .await
-        .unwrap();
+    let account_infos = algod.account(&transient_account.address()).await.unwrap();
 
     assert!(account_infos.clone().apps_total_schema.is_some());
     let total_schema = account_infos.clone().apps_total_schema.unwrap();

--- a/tests/step_defs/integration/assets.rs
+++ b/tests/step_defs/integration/assets.rs
@@ -29,7 +29,7 @@ async fn choose_creator_and_second(w: &World) -> Result<(Address, Address), Erro
     let accounts = w.accounts.as_ref().expect("accounts not set");
     let mut balances: Vec<(Address, u64)> = Vec::with_capacity(accounts.len());
     for addr in accounts {
-        let info = algod.account(&addr.to_string()).await?;
+        let info = algod.account(addr).await?;
         balances.push((*addr, info.amount));
     }
     balances.sort_by(|a, b| b.1.cmp(&a.1));
@@ -138,7 +138,7 @@ async fn i_send_the_bogus_kmd_signed_transaction(w: &mut World) -> Result<(), Er
 async fn i_update_the_asset_index(w: &mut World) -> Result<(), Error> {
     let algod = w.algod.as_ref().expect("algod not set");
     let tx_id = w.tx_id.as_ref().expect("no last tx id");
-    let pending = algod.pending_txn(tx_id.as_str()).await?;
+    let pending = algod.pending_txn(tx_id).await?;
     if let Some(asset_index) = pending.asset_index {
         w.asset_id = Some(AssetId(asset_index));
     }
@@ -150,7 +150,7 @@ async fn i_update_the_asset_index(w: &mut World) -> Result<(), Error> {
 async fn i_get_the_asset_info(w: &mut World) -> Result<(), Error> {
     let algod = w.algod.as_ref().expect("algod not set");
     let asset_id = w.asset_id.expect("asset id not set");
-    let asset = algod.asset(asset_id.0).await?;
+    let asset = algod.asset(asset_id).await?;
     w.asset_info = Some(*asset.params);
     Ok(())
 }
@@ -211,7 +211,7 @@ async fn i_should_be_unable_to_get_the_asset_info(w: &mut World) {
     let algod = w.algod.as_ref().expect("algod not set");
     let asset_id = w.asset_id.expect("asset id not set");
     assert!(
-        algod.asset(asset_id.0).await.is_err(),
+        algod.asset(asset_id).await.is_err(),
         "expected asset info to be missing after destroy"
     );
 }
@@ -301,7 +301,7 @@ async fn the_creator_should_have_assets_remaining(
     let algod = w.algod.as_ref().expect("algod not set");
     let creator = w.asset_creator.expect("asset creator not set");
     let asset_id = w.asset_id.expect("asset id not set");
-    let info = algod.account(&creator.to_string()).await?;
+    let info = algod.account(&creator).await?;
     let holding = info
         .assets
         .as_deref()

--- a/tests/step_defs/integration/compile.rs
+++ b/tests/step_defs/integration/compile.rs
@@ -1,4 +1,5 @@
 use crate::step_defs::integration::world::World;
+use algonaut::algod::v2::SourceMap;
 use algonaut_core::Address;
 use cucumber::{then, when};
 use data_encoding::BASE64;
@@ -23,7 +24,7 @@ async fn i_compile_a_teal_program(w: &mut World, program: String) {
     let algod = w.algod.as_ref().expect("algod not set");
     let source = read_resource(&program);
 
-    match algod.teal_compile(&source, None).await {
+    match algod.teal_compile(&source, SourceMap::Skip).await {
         Ok(compiled) => {
             let hash: Address = compiled.hash().into();
             w.compile_status = Some(200);

--- a/tests/step_defs/integration/general.rs
+++ b/tests/step_defs/integration/general.rs
@@ -19,7 +19,7 @@ pub async fn pick_funded_account(
 ) -> Result<Address, Box<dyn Error>> {
     let mut best: Option<(Address, u64)> = None;
     for addr in accounts {
-        let info = algod.account(&addr.to_string()).await?;
+        let info = algod.account(addr).await?;
         if best.is_none_or(|(_, bal)| info.amount > bal) {
             best = Some((*addr, info.amount));
         }
@@ -146,7 +146,8 @@ async fn i_create_a_new_transient_account_and_fund_it_with_microalgos(
     let s_tx = sender_account.sign_transaction(tx)?;
 
     let send_response = algod.send_txn(&s_tx).await?;
-    wait_for_pending_transaction(algod, &send_response.tx_id).await?;
+    let tx_id: TxId = send_response.tx_id.into();
+    wait_for_pending_transaction(algod, &tx_id).await?;
 
     w.transient_account = Some(sender_account);
 
@@ -189,7 +190,7 @@ async fn i_wait_for_the_transaction_to_be_confirmed(w: &mut World) {
     let algod = w.algod.as_ref().expect("algod not set");
     let tx_id = w.tx_id.as_ref().expect("tx id not set");
 
-    wait_for_pending_transaction(&algod, tx_id.as_str())
+    wait_for_pending_transaction(&algod, tx_id)
         .await
         .expect("couldn't get pending tx");
 }

--- a/tests/step_defs/integration/kmd.rs
+++ b/tests/step_defs/integration/kmd.rs
@@ -179,9 +179,8 @@ async fn i_delete_the_key(w: &mut World) -> Result<(), Error> {
     let addr = w
         .generated_kmd_address
         .as_ref()
-        .expect("generated kmd address not set")
-        .to_string();
-    kmd.delete_key(handle, password, &addr).await?;
+        .expect("generated kmd address not set");
+    kmd.delete_key(handle, password, addr).await?;
     Ok(())
 }
 
@@ -208,9 +207,8 @@ async fn i_can_get_account_information(w: &mut World) -> Result<(), Error> {
     let addr = w
         .generated_kmd_address
         .as_ref()
-        .expect("generated kmd address not set")
-        .to_string();
-    algod.account(&addr).await?;
+        .expect("generated kmd address not set");
+    algod.account(addr).await?;
     Ok(())
 }
 
@@ -250,7 +248,7 @@ async fn the_private_key_should_be_equal_to_the_exported_private_key(
         "exported seed differs from generated seed"
     );
     // Clean up so the wallet doesn't accumulate keys across runs.
-    kmd.delete_key(handle, password, &account.address().to_string())
+    kmd.delete_key(handle, password, &account.address())
         .await
         .ok();
     Ok(())
@@ -321,9 +319,7 @@ async fn i_export_the_multisig(w: &mut World) -> Result<(), Error> {
     let kmd = w.kmd.as_ref().expect("kmd not set");
     let handle = w.handle.as_ref().expect("wallet handle not set");
     let msig = w.multisig.as_ref().expect("multisig not set");
-    let resp = kmd
-        .export_multisig(handle, &msig.address().to_string())
-        .await?;
+    let resp = kmd.export_multisig(handle, &msig.address()).await?;
     w.exported_multisig_pks = Some(resp.pks);
     Ok(())
 }
@@ -347,7 +343,7 @@ async fn i_delete_the_multisig(w: &mut World) -> Result<(), Error> {
     let handle = w.handle.as_ref().expect("wallet handle not set");
     let password = w.password.as_ref().expect("wallet password not set");
     let msig = w.multisig.as_ref().expect("multisig not set");
-    kmd.delete_multisig(handle, password, &msig.address().to_string())
+    kmd.delete_multisig(handle, password, &msig.address())
         .await?;
     Ok(())
 }

--- a/tests/step_defs/integration/rekey.rs
+++ b/tests/step_defs/integration/rekey.rs
@@ -1,5 +1,5 @@
 use crate::step_defs::{integration::world::World, util::wait_for_pending_transaction};
-use algonaut_core::{Address, MicroAlgos};
+use algonaut_core::{Address, MicroAlgos, TxId};
 use algonaut_transaction::{Pay, TxnBuilder, account::Account};
 use cucumber::{given, when};
 use std::error::Error;
@@ -30,7 +30,8 @@ async fn i_generate_a_key_using_kmd_for_rekeying_and_fund_it(
     .build()?;
     let signed = funder_account.sign_transaction(tx)?;
     let resp = algod.send_txn(&signed).await?;
-    wait_for_pending_transaction(algod, &resp.tx_id).await?;
+    let tx_id: TxId = resp.tx_id.into();
+    wait_for_pending_transaction(algod, &tx_id).await?;
 
     w.rekey_target = Some(new_addr);
     Ok(())

--- a/tests/step_defs/unit/v2_client_paths.rs
+++ b/tests/step_defs/unit/v2_client_paths.rs
@@ -11,6 +11,7 @@ use crate::step_defs::unit::mock_server::MockServer;
 use crate::step_defs::unit::world::UnitWorld;
 use algonaut::algod::v2::Algod;
 use algonaut::indexer::v2::Indexer;
+use algonaut_core::{Address, AppId, AssetId, TxId};
 use cucumber::{given, then, when};
 
 /// A token (the `Configuration` requires one; its value is irrelevant to the
@@ -35,6 +36,44 @@ fn opt_csv(s: &str) -> Option<Vec<String>> {
         None
     } else {
         Some(s.split(',').map(|p| p.to_string()).collect())
+    }
+}
+
+/// Parse a feature-table cell into an [`Address`]. The cells are populated
+/// with well-formed Algorand addresses; treat parse failure as a test-data
+/// bug rather than a fall-through.
+fn parse_address(s: &str) -> Address {
+    s.parse()
+        .unwrap_or_else(|e| panic!("invalid address `{s}`: {e}"))
+}
+
+/// Treat empty cells as "argument omitted"; otherwise parse the cell as an
+/// [`Address`].
+fn opt_address(s: &str) -> Option<Address> {
+    if s.is_empty() {
+        None
+    } else {
+        Some(parse_address(s))
+    }
+}
+
+/// Treat `0` (and empty) as "argument omitted" for application IDs.
+fn opt_app_id(n: u64) -> Option<AppId> {
+    if n == 0 { None } else { Some(AppId(n)) }
+}
+
+/// Treat `0` (and empty) as "argument omitted" for asset IDs.
+fn opt_asset_id(n: u64) -> Option<AssetId> {
+    if n == 0 { None } else { Some(AssetId(n)) }
+}
+
+/// Treat empty cells as "argument omitted"; otherwise wrap the cell as a
+/// [`TxId`].
+fn opt_tx_id(s: &str) -> Option<TxId> {
+    if s.is_empty() {
+        None
+    } else {
+        Some(TxId(s.to_string()))
     }
 }
 
@@ -182,7 +221,7 @@ async fn algod_pending_txns_by_address(
     format: String,
 ) {
     let _ = algod(w)
-        .address_pending_txns(&account, opt_u64(max), opt_str(&format))
+        .address_pending_txns(&parse_address(&account), opt_u64(max), opt_str(&format))
         .await;
 }
 
@@ -193,7 +232,7 @@ async fn algod_status_after_block(w: &mut UnitWorld, round: u64) {
 
 #[when(regex = r#"^we make an Account Information call against account "([^"]*)"$"#)]
 async fn algod_account_information(w: &mut UnitWorld, account: String) {
-    let _ = algod(w).account(&account).await;
+    let _ = algod(w).account(&parse_address(&account)).await;
 }
 
 #[when(regex = r#"^we make a Get Block call against block number (\d+) with format "([^"]*)"$"#)]
@@ -207,24 +246,26 @@ async fn algod_get_block(w: &mut UnitWorld, round: u64, format: String) {
 
 #[when(regex = r#"^we make a GetAssetByID call for assetID (\d+)$"#)]
 async fn algod_get_asset_by_id(w: &mut UnitWorld, asset_id: u64) {
-    let _ = algod(w).asset(asset_id).await;
+    let _ = algod(w).asset(AssetId(asset_id)).await;
 }
 
 #[when(regex = r#"^we make a GetApplicationByID call for applicationID (\d+)$"#)]
 async fn algod_get_application_by_id(w: &mut UnitWorld, application_id: u64) {
-    let _ = algod(w).app(application_id).await;
+    let _ = algod(w).app(AppId(application_id)).await;
 }
 
 #[when(
     regex = r#"^we make a GetApplicationBoxByName call for applicationID (\d+) with encoded box name "([^"]*)"$"#
 )]
 async fn algod_get_application_box_by_name(w: &mut UnitWorld, application_id: u64, name: String) {
-    let _ = algod(w).app_box(application_id, &name).await;
+    let _ = algod(w).app_box(AppId(application_id), &name).await;
 }
 
 #[when(regex = r#"^we make a GetApplicationBoxes call for applicationID (\d+) with max (\d+)$"#)]
 async fn algod_get_application_boxes(w: &mut UnitWorld, application_id: u64, max: u64) {
-    let _ = algod(w).app_boxes(application_id, opt_u64(max)).await;
+    let _ = algod(w)
+        .app_boxes(AppId(application_id), opt_u64(max))
+        .await;
 }
 
 #[when(
@@ -262,7 +303,9 @@ async fn algod_account_application_information(
     account: String,
     application_id: u64,
 ) {
-    let _ = algod(w).account_app(&account, application_id).await;
+    let _ = algod(w)
+        .account_app(&parse_address(&account), AppId(application_id))
+        .await;
 }
 
 #[when(
@@ -378,7 +421,7 @@ async fn algod_account_assets_information(
     next: String,
 ) {
     let _ = algod(w)
-        .account_assets(&account, opt_u64(limit), opt_str(&next))
+        .account_assets(&parse_address(&account), opt_u64(limit), opt_str(&next))
         .await;
 }
 
@@ -394,7 +437,7 @@ async fn algod_account_applications_information(
 ) {
     let _ = algod(w)
         .account_apps(
-            &account,
+            &parse_address(&account),
             opt_u64(limit),
             opt_str(&next),
             opt_csv(&include).as_deref(),
@@ -422,7 +465,7 @@ async fn indexer_lookup_asset_balances(
 ) {
     let _ = indexer(w)
         .lookup_asset_balances(
-            index,
+            AssetId(index),
             None,
             opt_u64(limit),
             opt_str(&next),
@@ -457,13 +500,13 @@ async fn indexer_lookup_asset_transactions(
 ) {
     let _ = indexer(w)
         .lookup_asset_transactions(
-            index,
+            AssetId(index),
             opt_u64(limit),
             None,
             opt_str(&note_prefix),
             opt_str(&tx_type),
             opt_str(&sig_type),
-            opt_str(&txid),
+            opt_tx_id(&txid).as_ref(),
             opt_u64(round),
             opt_u64(min_round),
             opt_u64(max_round),
@@ -471,7 +514,7 @@ async fn indexer_lookup_asset_transactions(
             opt_str(&after_time).map(str::to_string),
             Some(cgt),
             opt_u64(clt),
-            opt_str(&address),
+            opt_address(&address).as_ref(),
             opt_str(&address_role),
             opt_bool(&exclude_close_to),
             None,
@@ -505,13 +548,13 @@ async fn indexer_lookup_asset_transactions_rekey(
 ) {
     let _ = indexer(w)
         .lookup_asset_transactions(
-            index,
+            AssetId(index),
             opt_u64(limit),
             None,
             opt_str(&note_prefix),
             opt_str(&tx_type),
             opt_str(&sig_type),
-            opt_str(&txid),
+            opt_tx_id(&txid).as_ref(),
             opt_u64(round),
             opt_u64(min_round),
             opt_u64(max_round),
@@ -519,7 +562,7 @@ async fn indexer_lookup_asset_transactions_rekey(
             opt_str(&after_time).map(str::to_string),
             Some(cgt),
             opt_u64(clt),
-            opt_str(&address),
+            opt_address(&address).as_ref(),
             opt_str(&address_role),
             opt_bool(&exclude_close_to),
             opt_bool(&rekey_to),
@@ -550,17 +593,17 @@ async fn indexer_lookup_account_transactions(
 ) {
     let _ = indexer(w)
         .lookup_account_transactions(
-            &account,
+            &parse_address(&account),
             opt_u64(limit),
             None,
             opt_str(&note_prefix),
             opt_str(&tx_type),
             opt_str(&sig_type),
-            opt_str(&txid),
+            opt_tx_id(&txid).as_ref(),
             opt_u64(round),
             opt_u64(min_round),
             opt_u64(max_round),
-            opt_u64(index),
+            opt_asset_id(index),
             opt_str(&before_time).map(str::to_string),
             opt_str(&after_time).map(str::to_string),
             Some(cgt),
@@ -594,17 +637,17 @@ async fn indexer_lookup_account_transactions_rekey(
 ) {
     let _ = indexer(w)
         .lookup_account_transactions(
-            &account,
+            &parse_address(&account),
             opt_u64(limit),
             None,
             opt_str(&note_prefix),
             opt_str(&tx_type),
             opt_str(&sig_type),
-            opt_str(&txid),
+            opt_tx_id(&txid).as_ref(),
             opt_u64(round),
             opt_u64(min_round),
             opt_u64(max_round),
-            opt_u64(index),
+            opt_asset_id(index),
             opt_str(&before_time).map(str::to_string),
             opt_str(&after_time).map(str::to_string),
             Some(cgt),
@@ -629,7 +672,7 @@ async fn indexer_lookup_block_header(w: &mut UnitWorld, round: u64, header: Stri
 )]
 async fn indexer_lookup_account_by_id(w: &mut UnitWorld, account: String, round: u64) {
     let _ = indexer(w)
-        .lookup_account_by_id(&account, opt_u64(round), None, None)
+        .lookup_account_by_id(&parse_address(&account), opt_u64(round), None, None)
         .await;
 }
 
@@ -638,13 +681,13 @@ async fn indexer_lookup_account_by_id(w: &mut UnitWorld, account: String, round:
 )]
 async fn indexer_lookup_account_by_id_exclude(w: &mut UnitWorld, account: String, exclude: String) {
     let _ = indexer(w)
-        .lookup_account_by_id(&account, None, None, opt_csv(&exclude))
+        .lookup_account_by_id(&parse_address(&account), None, None, opt_csv(&exclude))
         .await;
 }
 
 #[when(regex = r"^we make a Lookup Asset by ID call against asset index (\d+)$")]
 async fn indexer_lookup_asset_by_id(w: &mut UnitWorld, index: u64) {
-    let _ = indexer(w).lookup_asset_by_id(index, None).await;
+    let _ = indexer(w).lookup_asset_by_id(AssetId(index), None).await;
 }
 
 #[when(
@@ -660,7 +703,7 @@ async fn indexer_search_accounts(
 ) {
     let _ = indexer(w)
         .search_for_accounts(
-            opt_u64(index),
+            opt_asset_id(index),
             opt_u64(limit),
             None,
             Some(cgt),
@@ -714,16 +757,16 @@ async fn indexer_search_for_transactions(
             opt_str(&note_prefix),
             opt_str(&tx_type),
             opt_str(&sig_type),
-            opt_str(&txid),
+            opt_tx_id(&txid).as_ref(),
             opt_u64(round),
             opt_u64(min_round),
             opt_u64(max_round),
-            opt_u64(index),
+            opt_asset_id(index),
             opt_str(&before_time).map(str::to_string),
             opt_str(&after_time).map(str::to_string),
             Some(cgt),
             opt_u64(clt),
-            opt_str(&account),
+            opt_address(&account).as_ref(),
             opt_str(&address_role),
             opt_bool(&exclude_close_to),
             None,
@@ -764,16 +807,16 @@ async fn indexer_search_for_transactions_rekey(
             opt_str(&note_prefix),
             opt_str(&tx_type),
             opt_str(&sig_type),
-            opt_str(&txid),
+            opt_tx_id(&txid).as_ref(),
             opt_u64(round),
             opt_u64(min_round),
             opt_u64(max_round),
-            opt_u64(index),
+            opt_asset_id(index),
             opt_str(&before_time).map(str::to_string),
             opt_str(&after_time).map(str::to_string),
             Some(cgt),
             opt_u64(clt),
-            opt_str(&account),
+            opt_address(&account).as_ref(),
             opt_str(&address_role),
             opt_bool(&exclude_close_to),
             opt_bool(&rekey_to),
@@ -829,10 +872,10 @@ async fn indexer_search_for_assets(
             None,
             opt_u64(limit),
             None,
-            opt_str(&creator),
+            opt_address(&creator).as_ref(),
             opt_str(&name),
             opt_str(&unit),
-            opt_u64(index),
+            opt_asset_id(index),
         )
         .await;
 }
@@ -851,14 +894,14 @@ async fn indexer_search_accounts_auth(
 ) {
     let _ = indexer(w)
         .search_for_accounts(
-            opt_u64(index),
+            opt_asset_id(index),
             opt_u64(limit),
             None,
             Some(cgt),
             None,
             None,
             opt_u64(clt),
-            opt_str(&auth_addr),
+            opt_address(&auth_addr).as_ref(),
             opt_u64(round),
             None,
         )
@@ -886,21 +929,21 @@ async fn indexer_search_accounts_exclude(w: &mut UnitWorld, exclude: String) {
 #[when(regex = r"^we make a SearchForApplications call with applicationID (\d+)$")]
 async fn indexer_search_for_applications(w: &mut UnitWorld, application_id: u64) {
     let _ = indexer(w)
-        .search_for_applications(opt_u64(application_id), None, None, None, None)
+        .search_for_applications(opt_app_id(application_id), None, None, None, None)
         .await;
 }
 
 #[when(regex = r#"^we make a SearchForApplications call with creator "([^"]*)"$"#)]
 async fn indexer_search_for_applications_creator(w: &mut UnitWorld, creator: String) {
     let _ = indexer(w)
-        .search_for_applications(None, opt_str(&creator), None, None, None)
+        .search_for_applications(None, opt_address(&creator).as_ref(), None, None, None)
         .await;
 }
 
 #[when(regex = r"^we make a LookupApplications call with applicationID (\d+)$")]
 async fn indexer_lookup_applications(w: &mut UnitWorld, application_id: u64) {
     let _ = indexer(w)
-        .lookup_application_by_id(application_id, None)
+        .lookup_application_by_id(AppId(application_id), None)
         .await;
 }
 
@@ -909,7 +952,7 @@ async fn indexer_lookup_applications(w: &mut UnitWorld, application_id: u64) {
 )]
 async fn indexer_lookup_application_box(w: &mut UnitWorld, application_id: u64, name: String) {
     let _ = indexer(w)
-        .lookup_application_box_by_id_and_name(application_id, &name)
+        .lookup_application_box_by_id_and_name(AppId(application_id), &name)
         .await;
 }
 
@@ -923,7 +966,7 @@ async fn indexer_search_for_application_boxes(
     next: String,
 ) {
     let _ = indexer(w)
-        .search_for_application_boxes(application_id, opt_u64(max), opt_str(&next))
+        .search_for_application_boxes(AppId(application_id), opt_u64(max), opt_str(&next))
         .await;
 }
 
@@ -943,10 +986,10 @@ async fn indexer_lookup_application_logs(
 ) {
     let _ = indexer(w)
         .lookup_application_logs_by_id(
-            application_id,
+            AppId(application_id),
             opt_u64(limit),
             opt_str(&next),
-            opt_str(&txid),
+            opt_tx_id(&txid).as_ref(),
             opt_u64(min_round),
             opt_u64(max_round),
             opt_str(&sender),
@@ -967,8 +1010,8 @@ async fn indexer_lookup_account_assets(
 ) {
     let _ = indexer(w)
         .lookup_account_assets(
-            &account_id,
-            opt_u64(asset_id),
+            &parse_address(&account_id),
+            opt_asset_id(asset_id),
             opt_bool(&include_all),
             opt_u64(limit),
             opt_str(&next),
@@ -989,8 +1032,8 @@ async fn indexer_lookup_account_created_assets(
 ) {
     let _ = indexer(w)
         .lookup_account_created_assets(
-            &account_id,
-            opt_u64(asset_id),
+            &parse_address(&account_id),
+            opt_asset_id(asset_id),
             opt_bool(&include_all),
             opt_u64(limit),
             opt_str(&next),
@@ -1011,8 +1054,8 @@ async fn indexer_lookup_account_app_local_states(
 ) {
     let _ = indexer(w)
         .lookup_account_app_local_states(
-            &account_id,
-            opt_u64(application_id),
+            &parse_address(&account_id),
+            opt_app_id(application_id),
             opt_bool(&include_all),
             opt_u64(limit),
             opt_str(&next),
@@ -1033,8 +1076,8 @@ async fn indexer_lookup_account_created_applications(
 ) {
     let _ = indexer(w)
         .lookup_account_created_applications(
-            &account_id,
-            opt_u64(application_id),
+            &parse_address(&account_id),
+            opt_app_id(application_id),
             opt_bool(&include_all),
             opt_u64(limit),
             opt_str(&next),

--- a/tests/step_defs/unit/v2_client_responses.rs
+++ b/tests/step_defs/unit/v2_client_responses.rs
@@ -14,6 +14,7 @@ use crate::step_defs::unit::mock_server::ResponseMockServer;
 use crate::step_defs::unit::world::{UnitResponse, UnitWorld};
 use algonaut::algod::v2::Algod;
 use algonaut::indexer::v2::Indexer;
+use algonaut_core::{Address, AssetId, TxId};
 use algonaut_encoding::decode_base64;
 use cucumber::{given, then, when};
 use std::fs;
@@ -22,6 +23,21 @@ use std::path::Path;
 /// A token (the `Configuration` requires one; its value is irrelevant to a
 /// canned-response server).
 const TOKEN: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+/// Placeholder Algorand address: the mock server answers every request with
+/// the same canned body regardless of the path, so the address value is
+/// irrelevant; this just needs to be well-formed.
+fn placeholder_address() -> Address {
+    "7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q"
+        .parse()
+        .expect("placeholder address is well-formed")
+}
+
+/// Placeholder transaction ID: see `placeholder_address` — value is
+/// irrelevant to the response-mock test, only the shape matters.
+fn placeholder_txid() -> TxId {
+    TxId("placeholder-txid".to_string())
+}
 
 /// Load a fixture's bytes as the raw HTTP response body.
 ///
@@ -112,7 +128,7 @@ async fn mock_http_responses(w: &mut UnitWorld, jsonfiles: String, directory: St
 
 #[when(regex = r"^we make any Pending Transaction Information call$")]
 async fn algod_pending_txn(w: &mut UnitWorld) {
-    let r = algod(w).pending_txn("placeholder-txid").await;
+    let r = algod(w).pending_txn(&placeholder_txid()).await;
     record(w, r, UnitResponse::PendingTransaction);
 }
 
@@ -131,7 +147,7 @@ async fn algod_send_raw_txn(w: &mut UnitWorld) {
 #[when(regex = r"^we make any Pending Transactions By Address call$")]
 async fn algod_pending_txns_by_address(w: &mut UnitWorld) {
     let r = algod(w)
-        .address_pending_txns("placeholder-address", None, None)
+        .address_pending_txns(&placeholder_address(), None, None)
         .await;
     record(w, r, UnitResponse::PendingTransactions);
 }
@@ -156,7 +172,7 @@ async fn algod_status_after_block(w: &mut UnitWorld) {
 
 #[when(regex = r"^we make any Account Information call$")]
 async fn algod_account_information(w: &mut UnitWorld) {
-    let r = algod(w).account("placeholder-address").await;
+    let r = algod(w).account(&placeholder_address()).await;
     record(w, r, UnitResponse::Account);
 }
 
@@ -183,7 +199,7 @@ async fn algod_dryrun(w: &mut UnitWorld) {
 #[when(regex = r"^we make any LookupAssetBalances call$")]
 async fn indexer_lookup_asset_balances(w: &mut UnitWorld) {
     let r = indexer(w)
-        .lookup_asset_balances(0, None, None, None, None, None)
+        .lookup_asset_balances(AssetId(0), None, None, None, None, None)
         .await;
     record(w, r, UnitResponse::AssetBalances);
 }
@@ -192,8 +208,24 @@ async fn indexer_lookup_asset_balances(w: &mut UnitWorld) {
 async fn indexer_lookup_asset_transactions(w: &mut UnitWorld) {
     let r = indexer(w)
         .lookup_asset_transactions(
-            0, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-            None, None, None,
+            AssetId(0),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
         )
         .await;
     record(w, r, UnitResponse::Transactions);
@@ -203,7 +235,7 @@ async fn indexer_lookup_asset_transactions(w: &mut UnitWorld) {
 async fn indexer_lookup_account_transactions(w: &mut UnitWorld) {
     let r = indexer(w)
         .lookup_account_transactions(
-            "placeholder-account",
+            &placeholder_address(),
             None,
             None,
             None,
@@ -233,14 +265,14 @@ async fn indexer_lookup_block(w: &mut UnitWorld) {
 #[when(regex = r"^we make any LookupAccountByID call$")]
 async fn indexer_lookup_account_by_id(w: &mut UnitWorld) {
     let r = indexer(w)
-        .lookup_account_by_id("placeholder-account", None, None, None)
+        .lookup_account_by_id(&placeholder_address(), None, None, None)
         .await;
     record(w, r, UnitResponse::IndexerAccount);
 }
 
 #[when(regex = r"^we make any LookupAssetByID call$")]
 async fn indexer_lookup_asset_by_id(w: &mut UnitWorld) {
-    let r = indexer(w).lookup_asset_by_id(0, None).await;
+    let r = indexer(w).lookup_asset_by_id(AssetId(0), None).await;
     record(w, r, UnitResponse::IndexerAsset);
 }
 

--- a/tests/step_defs/util.rs
+++ b/tests/step_defs/util.rs
@@ -6,16 +6,16 @@ use std::{
     time::{Duration, Instant},
 };
 
-use algonaut::algod::v2::Algod;
+use algonaut::algod::v2::{Algod, SourceMap};
 use algonaut_algod::models::PendingTransactionResponse;
-use algonaut_core::{Address, CompiledTeal};
+use algonaut_core::{Address, CompiledTeal, TxId};
 use algonaut_model::kmd::v1::ExportKeyResponse;
 use algonaut_transaction::account::Account;
 
 /// Utility function to wait on a transaction to be confirmed
 pub async fn wait_for_pending_transaction(
     algod: &Algod,
-    txid: &str,
+    txid: &TxId,
 ) -> Result<Option<PendingTransactionResponse>, algonaut::Error> {
     let timeout = Duration::from_secs(10);
     let start = Instant::now();
@@ -80,7 +80,10 @@ pub async fn read_teal(algod: &Algod, file_name: &str) -> CompiledTeal {
     let file_bytes = fs::read(&format!("tests/features/resources/{file_name}")).unwrap();
 
     if file_name.ends_with(".teal") {
-        algod.teal_compile(&file_bytes, None).await.unwrap()
+        algod
+            .teal_compile(&file_bytes, SourceMap::Skip)
+            .await
+            .unwrap()
     } else {
         CompiledTeal(file_bytes)
     }


### PR DESCRIPTION
## Summary

First sub-ADR of the `ideal-type-safe-ergonomic-api` roadmap (PR #284), addressing decision items **D4** (newtype identifier family) and **D9** (accept what you mean).

`AppId` / `AssetId` / `Address` / `TxId` already existed (PR #281) but only flowed through the transaction-builder side. This pushes them through every `Algod`, `Indexer`, and `Kmd` public method signature so the type system stops being lied to at the call boundary.

### Breaking API changes

**Client signatures take newtypes.** Thirty-one public methods across the three clients:

- `algod.account(&Address)`, `algod.app(AppId)`, `algod.asset(AssetId)`, `algod.pending_txn(&TxId)`, `algod.txn_proof(round, &TxId)`, `algod.account_app(&Address, AppId)`, `algod.app_box(AppId, &str)`, etc.
- `indexer.lookup_account_by_id(&Address, ...)`, `indexer.lookup_application_by_id(AppId, ...)`, `indexer.lookup_asset_by_id(AssetId, ...)`, `indexer.lookup_transaction(&TxId)`, `indexer.search_for_*` etc. — including their `Option<AppId>` / `Option<AssetId>` / `Option<&TxId>` / `Option<&Address>` shaped parameters.
- `kmd.delete_key(_, _, &Address)`, `kmd.export_multisig(_, &Address)`, `kmd.delete_multisig(_, _, &Address)`.

Stringification stays at the HTTP edge inside the wrappers (`&address.to_string()` once per method); user code stops doing it at every call site.

### D9 smaller cuts

- `algonaut_core::to_app_address(u64) -> Address` retires. `AppId::address(self) -> Address` replaces it. Both former callers (`tests/step_defs/integration/abi.rs`, `src/util/dryrun_printer.rs`) drop their `.0` unwrap.
- `TxGroup::new(Vec<Transaction>) -> Result<Vec<Transaction>>` becomes the user-facing group constructor — returns owned grouped copies. The previous `TxGroup::assign_group_id(&mut [&mut Transaction])` is `#[doc(hidden)] pub` for the composer's internal use only.
- `StateSchema::empty()` / `StateSchema::new(ints, slices)` replace the six bare-literal sites in examples and step-defs.
- `Algod::teal_compile`'s `Option<bool>` parameter becomes a `SourceMap` enum with `Emit` / `Skip` variants. `algonaut_abi::sourcemap::SourceMap` (parsed source-map) is unchanged.

### Migration

Mechanical, no migration shim — pre-1.0, README still flags the API as moving. Wrap literals with `AppId(..)` / `AssetId(..)`, replace `&account.address().to_string()` with `&account.address()`, replace `tx_id.as_str()` with `&tx_id`, `StateSchema { number_ints: 0, number_byteslices: 0 }` with `StateSchema::empty()`, `algod.teal_compile(..., None)` with `algod.teal_compile(..., SourceMap::Skip)`.

## What's intentionally out of scope

D2 (finality on the client / `PendingSubmission`) and D3 (hide generated `*200Response` types behind hand-named domain types) are separate sub-ADRs that build on this one — methods here still return `*200Response` shapes and `pub use algonaut_algod as openapi_algod` stays.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets` (with `RUSTFLAGS=-D warnings`)
- [x] `cargo check --target wasm32-unknown-unknown`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --examples --tests`
- [ ] Cucumber integration features pass on CI (requires the live algod harness; covered by the `cargo-test-integration` job)

## Refs

- Index ADR: #284 (`docs/adr/ideal-type-safe-ergonomic-api.md`)
- Sub-ADR added in this PR: `docs/adr/identifier-newtypes-at-client-boundary.md`
- Prior id-newtype work: #281