### PR TITLE
feat(transaction): one build per transaction (D1)

### DIFF
--- a/algonaut_transaction/src/builder.rs
+++ b/algonaut_transaction/src/builder.rs
@@ -140,6 +140,18 @@ impl Pay {
         }
     }
 
+    /// A zero-amount self-payment that rekeys `from`'s account to a new
+    /// authorising address.
+    ///
+    /// Algorand has no dedicated rekey transaction type; rekey is a
+    /// header field that any transaction can carry, and a zero-amount
+    /// self-payment is the canonical minimal carrier. The full
+    /// [`Pay::new`] + [`Pay::rekey_to`] form stays available for the
+    /// "rekey *and* actually pay someone" case.
+    pub fn rekey(from: Address, new_auth: Address) -> Self {
+        Self::new(from, from, MicroAlgos(0)).rekey_to(new_auth)
+    }
+
     pub fn close_remainder_to(mut self, close_remainder_to: Address) -> Self {
         self.close_remainder_to = Some(close_remainder_to);
         self

--- a/algonaut_transaction/src/builder.rs
+++ b/algonaut_transaction/src/builder.rs
@@ -19,110 +19,100 @@ pub trait TransactionParams {
     fn genesis_id(&self) -> &String;
 }
 
-/// A builder for [Transaction].
-pub struct TxnBuilder {
-    fee: MicroAlgos,
-    first_valid: Round,
-    genesis_hash: HashDigest,
-    last_valid: Round,
-    txn_type: TransactionType,
-    genesis_id: Option<String>,
-    group: Option<HashDigest>,
-    lease: Option<HashDigest>,
-    note: Option<Vec<u8>>,
-    rekey_to: Option<Address>,
+/// Shared header fields every transaction can carry. Embedded inside each
+/// per-type builder ([`Pay`], [`CreateAsset`], [`CallApplication`], …), so
+/// every builder has a single terminal `build(&params)` that finalises both
+/// the header and the type-specific fields.
+#[derive(Debug, Default, Clone)]
+pub struct TxnHeader {
+    pub(crate) fee: Option<MicroAlgos>,
+    pub(crate) note: Option<Vec<u8>>,
+    pub(crate) lease: Option<HashDigest>,
+    pub(crate) rekey_to: Option<Address>,
+    pub(crate) group: Option<HashDigest>,
+    pub(crate) genesis_id: Option<String>,
 }
 
-impl TxnBuilder {
-    /// Convenience to initialize builder with suggested transaction params
-    ///
-    /// The txn fee is estimated, based on params. To set the fee manually, use [with_fee](Self::with_fee) or [new](Self::new).
-    pub fn with(params: &impl TransactionParams, txn_type: TransactionType) -> Self {
-        Self::with_fee(params, MicroAlgos(params.min_fee()), txn_type)
-    }
-
-    /// Convenience to initialize builder with suggested transaction params, and set the fee manually (ignoring the fee fields in params).
-    ///
-    /// Useful e.g. in txns groups where one txn pays the fee for others.
-    pub fn with_fee(
+impl TxnHeader {
+    /// Combine this header with the suggested params and a type-specific
+    /// `txn_type` to produce a finished [`Transaction`]. Used by every
+    /// per-type builder's terminal `build(&params)`.
+    pub(crate) fn into_transaction(
+        self,
         params: &impl TransactionParams,
-        fee: MicroAlgos,
         txn_type: TransactionType,
-    ) -> Self {
-        Self::new(
-            fee,
-            Round(params.last_round()),
-            Round(params.last_round() + 1000),
-            params.genesis_hash(),
-            txn_type,
-        )
-        .genesis_id(params.genesis_id().clone())
-    }
-
-    pub fn new(
-        fee: MicroAlgos,
-        first_valid: Round,
-        last_valid: Round,
-        genesis_hash: HashDigest,
-        txn_type: TransactionType,
-    ) -> Self {
-        TxnBuilder {
+    ) -> Result<Transaction, TransactionError> {
+        let fee = self.fee.unwrap_or(MicroAlgos(params.min_fee()));
+        let first_valid = Round(params.last_round());
+        let last_valid = Round(params.last_round() + 1000);
+        Ok(Transaction {
             fee,
             first_valid,
-            genesis_hash,
+            genesis_hash: params.genesis_hash(),
             last_valid,
             txn_type,
-            genesis_id: None,
-            group: None,
-            lease: None,
-            note: None,
-            rekey_to: None,
-        }
-    }
-
-    pub fn genesis_id(mut self, id: String) -> Self {
-        self.genesis_id = Some(id);
-        self
-    }
-
-    pub fn group(mut self, group: HashDigest) -> Self {
-        self.group = Some(group);
-        self
-    }
-
-    pub fn lease(mut self, lease: HashDigest) -> Self {
-        self.lease = Some(lease);
-        self
-    }
-
-    pub fn note(mut self, note: Vec<u8>) -> Self {
-        self.note = Some(note);
-        self
-    }
-
-    pub fn rekey_to(mut self, rekey_to: Address) -> Self {
-        self.rekey_to = Some(rekey_to);
-        self
-    }
-
-    pub fn build(self) -> Result<Transaction, TransactionError> {
-        Ok(self.build_tx(self.fee))
-    }
-
-    fn build_tx(&self, fee: MicroAlgos) -> Transaction {
-        Transaction {
-            fee,
-            first_valid: self.first_valid,
-            genesis_hash: self.genesis_hash,
-            last_valid: self.last_valid,
-            txn_type: self.txn_type.clone(),
-            genesis_id: self.genesis_id.clone(),
+            genesis_id: Some(
+                self.genesis_id
+                    .unwrap_or_else(|| params.genesis_id().clone()),
+            ),
             group: self.group,
             lease: self.lease,
-            note: self.note.clone(),
+            note: self.note,
             rekey_to: self.rekey_to,
-        }
+        })
     }
+}
+
+/// Mint the six fluent header setters (`fee`, `note`, `lease`, `rekey_to`,
+/// `group`, `genesis_id`) on a per-type builder that has a `header:
+/// TxnHeader` field. Used at the bottom of every builder's `impl` block.
+macro_rules! impl_txn_header_setters {
+    ($t:ty) => {
+        impl $t {
+            /// Override the per-byte-estimated fee from
+            /// [`TransactionParams::min_fee`] with an explicit value. Useful
+            /// in transaction groups where one txn pays the fee for others.
+            pub fn fee(mut self, fee: MicroAlgos) -> Self {
+                self.header.fee = Some(fee);
+                self
+            }
+
+            /// Attach an opaque note to the transaction.
+            pub fn note(mut self, note: Vec<u8>) -> Self {
+                self.header.note = Some(note);
+                self
+            }
+
+            /// Attach a lease — prevents a second transaction with the same
+            /// lease + sender from being committed within the validity
+            /// window.
+            pub fn lease(mut self, lease: HashDigest) -> Self {
+                self.header.lease = Some(lease);
+                self
+            }
+
+            /// Rekey the sender's account to a new auth address as part of
+            /// this transaction.
+            pub fn rekey_to(mut self, rekey_to: Address) -> Self {
+                self.header.rekey_to = Some(rekey_to);
+                self
+            }
+
+            /// Stamp a precomputed group ID on this transaction. Normally
+            /// you don't call this directly; [`crate::tx_group::TxGroup`]
+            /// does it via its `TryFrom<Vec<Transaction>>` impl.
+            pub fn group(mut self, group: HashDigest) -> Self {
+                self.header.group = Some(group);
+                self
+            }
+
+            /// Override the suggested-params genesis ID. Rarely needed.
+            pub fn genesis_id(mut self, id: String) -> Self {
+                self.header.genesis_id = Some(id);
+                self
+            }
+        }
+    };
 }
 
 /// A builder for [Payment].
@@ -131,6 +121,7 @@ pub struct Pay {
     receiver: Address,
     amount: MicroAlgos,
     close_remainder_to: Option<Address>,
+    header: TxnHeader,
 }
 
 impl Pay {
@@ -140,6 +131,7 @@ impl Pay {
             receiver,
             amount,
             close_remainder_to: None,
+            header: TxnHeader::default(),
         }
     }
 
@@ -148,15 +140,18 @@ impl Pay {
         self
     }
 
-    pub fn build(self) -> TransactionType {
-        TransactionType::Payment(Payment {
+    pub fn build(self, params: &impl TransactionParams) -> Result<Transaction, TransactionError> {
+        let txn_type = TransactionType::Payment(Payment {
             sender: self.sender,
             receiver: self.receiver,
             amount: self.amount,
             close_remainder_to: self.close_remainder_to,
-        })
+        });
+        self.header.into_transaction(params, txn_type)
     }
 }
+
+impl_txn_header_setters!(Pay);
 
 /// A builder for [KeyRegistration].
 pub struct RegisterKey {
@@ -168,6 +163,7 @@ pub struct RegisterKey {
     vote_key_dilution: Option<u64>,
     state_proof_key: Option<StateProofPk>,
     nonparticipating: Option<bool>,
+    header: TxnHeader,
 }
 
 impl RegisterKey {
@@ -193,6 +189,7 @@ impl RegisterKey {
             vote_key_dilution: Some(vote_key_dilution),
             state_proof_key: Some(state_proof_key),
             nonparticipating: None,
+            header: TxnHeader::default(),
         }
     }
 
@@ -206,6 +203,7 @@ impl RegisterKey {
             vote_key_dilution: None,
             state_proof_key: None,
             nonparticipating: None,
+            header: TxnHeader::default(),
         }
     }
 
@@ -219,11 +217,12 @@ impl RegisterKey {
             vote_key_dilution: None,
             state_proof_key: None,
             nonparticipating: Some(nonparticipating),
+            header: TxnHeader::default(),
         }
     }
 
-    pub fn build(self) -> TransactionType {
-        TransactionType::KeyRegistration(KeyRegistration {
+    pub fn build(self, params: &impl TransactionParams) -> Result<Transaction, TransactionError> {
+        let txn_type = TransactionType::KeyRegistration(KeyRegistration {
             sender: self.sender,
             vote_pk: self.vote_pk,
             selection_pk: self.selection_pk,
@@ -232,9 +231,12 @@ impl RegisterKey {
             vote_key_dilution: self.vote_key_dilution,
             state_proof_key: self.state_proof_key,
             nonparticipating: self.nonparticipating,
-        })
+        });
+        self.header.into_transaction(params, txn_type)
     }
 }
+
+impl_txn_header_setters!(RegisterKey);
 
 /// A builder for [AssetConfigurationTransaction].
 pub struct CreateAsset {
@@ -250,6 +252,7 @@ pub struct CreateAsset {
     reserve: Option<Address>,
     freeze: Option<Address>,
     clawback: Option<Address>,
+    header: TxnHeader,
 }
 
 impl CreateAsset {
@@ -267,6 +270,7 @@ impl CreateAsset {
             reserve: None,
             freeze: None,
             clawback: None,
+            header: TxnHeader::default(),
         }
     }
 
@@ -310,26 +314,30 @@ impl CreateAsset {
         self
     }
 
-    pub fn build(self) -> TransactionType {
-        TransactionType::AssetConfigurationTransaction(AssetConfigurationTransaction {
-            sender: self.sender,
-            config_asset: None,
-            params: Some(AssetParams {
-                total: self.total,
-                decimals: self.decimals,
-                default_frozen: self.default_frozen,
-                unit_name: self.unit_name,
-                asset_name: self.asset_name,
-                url: self.url,
-                meta_data_hash: self.meta_data_hash,
-                manager: self.manager,
-                reserve: self.reserve,
-                freeze: self.freeze,
-                clawback: self.clawback,
-            }),
-        })
+    pub fn build(self, params: &impl TransactionParams) -> Result<Transaction, TransactionError> {
+        let txn_type =
+            TransactionType::AssetConfigurationTransaction(AssetConfigurationTransaction {
+                sender: self.sender,
+                config_asset: None,
+                params: Some(AssetParams {
+                    total: self.total,
+                    decimals: self.decimals,
+                    default_frozen: self.default_frozen,
+                    unit_name: self.unit_name,
+                    asset_name: self.asset_name,
+                    url: self.url,
+                    meta_data_hash: self.meta_data_hash,
+                    manager: self.manager,
+                    reserve: self.reserve,
+                    freeze: self.freeze,
+                    clawback: self.clawback,
+                }),
+            });
+        self.header.into_transaction(params, txn_type)
     }
 }
+
+impl_txn_header_setters!(CreateAsset);
 
 /// A builder for [AssetConfigurationTransaction].
 pub struct UpdateAsset {
@@ -346,6 +354,7 @@ pub struct UpdateAsset {
     reserve: Option<Address>,
     freeze: Option<Address>,
     clawback: Option<Address>,
+    header: TxnHeader,
 }
 
 impl UpdateAsset {
@@ -364,6 +373,7 @@ impl UpdateAsset {
             reserve: None,
             freeze: None,
             clawback: None,
+            header: TxnHeader::default(),
         }
     }
 
@@ -422,46 +432,59 @@ impl UpdateAsset {
         self
     }
 
-    pub fn build(self) -> TransactionType {
-        TransactionType::AssetConfigurationTransaction(AssetConfigurationTransaction {
-            sender: self.sender,
-            config_asset: Some(self.asset_id),
-            params: Some(AssetParams {
-                total: self.total,
-                decimals: self.decimals,
-                default_frozen: self.default_frozen,
-                unit_name: self.unit_name,
-                asset_name: self.asset_name,
-                url: self.url,
-                meta_data_hash: self.meta_data_hash,
-                manager: self.manager,
-                reserve: self.reserve,
-                freeze: self.freeze,
-                clawback: self.clawback,
-            }),
-        })
+    pub fn build(self, params: &impl TransactionParams) -> Result<Transaction, TransactionError> {
+        let txn_type =
+            TransactionType::AssetConfigurationTransaction(AssetConfigurationTransaction {
+                sender: self.sender,
+                config_asset: Some(self.asset_id),
+                params: Some(AssetParams {
+                    total: self.total,
+                    decimals: self.decimals,
+                    default_frozen: self.default_frozen,
+                    unit_name: self.unit_name,
+                    asset_name: self.asset_name,
+                    url: self.url,
+                    meta_data_hash: self.meta_data_hash,
+                    manager: self.manager,
+                    reserve: self.reserve,
+                    freeze: self.freeze,
+                    clawback: self.clawback,
+                }),
+            });
+        self.header.into_transaction(params, txn_type)
     }
 }
+
+impl_txn_header_setters!(UpdateAsset);
 
 /// A builder for [AssetConfigurationTransaction].
 pub struct DestroyAsset {
     sender: Address,
     asset_id: AssetId,
+    header: TxnHeader,
 }
 
 impl DestroyAsset {
     pub fn new(sender: Address, asset_id: AssetId) -> Self {
-        DestroyAsset { sender, asset_id }
+        DestroyAsset {
+            sender,
+            asset_id,
+            header: TxnHeader::default(),
+        }
     }
 
-    pub fn build(self) -> TransactionType {
-        TransactionType::AssetConfigurationTransaction(AssetConfigurationTransaction {
-            sender: self.sender,
-            config_asset: Some(self.asset_id),
-            params: None,
-        })
+    pub fn build(self, params: &impl TransactionParams) -> Result<Transaction, TransactionError> {
+        let txn_type =
+            TransactionType::AssetConfigurationTransaction(AssetConfigurationTransaction {
+                sender: self.sender,
+                config_asset: Some(self.asset_id),
+                params: None,
+            });
+        self.header.into_transaction(params, txn_type)
     }
 }
+
+impl_txn_header_setters!(DestroyAsset);
 
 /// A builder for [AssetTransferTransaction].
 pub struct TransferAsset {
@@ -470,6 +493,7 @@ pub struct TransferAsset {
     amount: u64,
     receiver: Address,
     close_to: Option<Address>,
+    header: TxnHeader,
 }
 
 impl TransferAsset {
@@ -480,6 +504,7 @@ impl TransferAsset {
             amount,
             receiver,
             close_to: None,
+            header: TxnHeader::default(),
         }
     }
 
@@ -488,35 +513,46 @@ impl TransferAsset {
         self
     }
 
-    pub fn build(self) -> TransactionType {
-        TransactionType::AssetTransferTransaction(AssetTransferTransaction {
+    pub fn build(self, params: &impl TransactionParams) -> Result<Transaction, TransactionError> {
+        let txn_type = TransactionType::AssetTransferTransaction(AssetTransferTransaction {
             sender: self.sender,
             xfer: self.xfer,
             amount: self.amount,
             receiver: self.receiver,
             close_to: self.close_to,
-        })
+        });
+        self.header.into_transaction(params, txn_type)
     }
 }
+
+impl_txn_header_setters!(TransferAsset);
 
 /// A builder for [AssetAcceptTransaction].
 pub struct AcceptAsset {
     sender: Address,
     asset_id: AssetId,
+    header: TxnHeader,
 }
 
 impl AcceptAsset {
     pub fn new(sender: Address, asset_id: AssetId) -> Self {
-        AcceptAsset { sender, asset_id }
+        AcceptAsset {
+            sender,
+            asset_id,
+            header: TxnHeader::default(),
+        }
     }
 
-    pub fn build(self) -> TransactionType {
-        TransactionType::AssetAcceptTransaction(AssetAcceptTransaction {
+    pub fn build(self, params: &impl TransactionParams) -> Result<Transaction, TransactionError> {
+        let txn_type = TransactionType::AssetAcceptTransaction(AssetAcceptTransaction {
             sender: self.sender,
             xfer: self.asset_id,
-        })
+        });
+        self.header.into_transaction(params, txn_type)
     }
 }
+
+impl_txn_header_setters!(AcceptAsset);
 
 /// A builder for [AssetClawbackTransaction].
 pub struct ClawbackAsset {
@@ -526,6 +562,7 @@ pub struct ClawbackAsset {
     asset_sender: Address,
     asset_receiver: Address,
     asset_close_to: Option<Address>,
+    header: TxnHeader,
 }
 
 impl ClawbackAsset {
@@ -543,6 +580,7 @@ impl ClawbackAsset {
             asset_sender,
             asset_receiver,
             asset_close_to: None,
+            header: TxnHeader::default(),
         }
     }
 
@@ -551,17 +589,20 @@ impl ClawbackAsset {
         self
     }
 
-    pub fn build(self) -> TransactionType {
-        TransactionType::AssetClawbackTransaction(AssetClawbackTransaction {
+    pub fn build(self, params: &impl TransactionParams) -> Result<Transaction, TransactionError> {
+        let txn_type = TransactionType::AssetClawbackTransaction(AssetClawbackTransaction {
             sender: self.sender,
             xfer: self.asset_id,
             asset_amount: self.asset_amount,
             asset_sender: self.asset_sender,
             asset_receiver: self.asset_receiver,
             asset_close_to: self.asset_close_to,
-        })
+        });
+        self.header.into_transaction(params, txn_type)
     }
 }
+
+impl_txn_header_setters!(ClawbackAsset);
 
 /// A builder for [AssetFreezeTransaction].
 pub struct FreezeAsset {
@@ -569,6 +610,7 @@ pub struct FreezeAsset {
     freeze_account: Address,
     asset_id: AssetId,
     frozen: bool,
+    header: TxnHeader,
 }
 
 impl FreezeAsset {
@@ -578,18 +620,22 @@ impl FreezeAsset {
             freeze_account,
             asset_id,
             frozen,
+            header: TxnHeader::default(),
         }
     }
 
-    pub fn build(self) -> TransactionType {
-        TransactionType::AssetFreezeTransaction(AssetFreezeTransaction {
+    pub fn build(self, params: &impl TransactionParams) -> Result<Transaction, TransactionError> {
+        let txn_type = TransactionType::AssetFreezeTransaction(AssetFreezeTransaction {
             sender: self.sender,
             freeze_account: self.freeze_account,
             asset_id: self.asset_id,
             frozen: self.frozen,
-        })
+        });
+        self.header.into_transaction(params, txn_type)
     }
 }
+
+impl_txn_header_setters!(FreezeAsset);
 
 /// A builder for [ApplicationCallTransaction].
 pub struct CreateApplication {
@@ -604,6 +650,7 @@ pub struct CreateApplication {
     local_state_schema: Option<StateSchema>,
     extra_pages: u32,
     boxes: Option<Vec<BoxReference>>,
+    header: TxnHeader,
 }
 
 impl CreateApplication {
@@ -626,6 +673,7 @@ impl CreateApplication {
             local_state_schema: Some(local_state_schema),
             extra_pages: 0,
             boxes: None,
+            header: TxnHeader::default(),
         }
     }
 
@@ -659,8 +707,8 @@ impl CreateApplication {
         self
     }
 
-    pub fn build(self) -> TransactionType {
-        TransactionType::ApplicationCallTransaction(ApplicationCallTransaction {
+    pub fn build(self, params: &impl TransactionParams) -> Result<Transaction, TransactionError> {
+        let txn_type = TransactionType::ApplicationCallTransaction(ApplicationCallTransaction {
             sender: self.sender,
             app_id: None,
             on_complete: ApplicationCallOnComplete::NoOp,
@@ -674,9 +722,12 @@ impl CreateApplication {
             local_state_schema: self.local_state_schema,
             extra_pages: self.extra_pages,
             boxes: self.boxes,
-        })
+        });
+        self.header.into_transaction(params, txn_type)
     }
 }
+
+impl_txn_header_setters!(CreateApplication);
 
 /// A builder for [ApplicationCallTransaction].
 pub struct UpdateApplication {
@@ -689,6 +740,7 @@ pub struct UpdateApplication {
     foreign_apps: Option<Vec<AppId>>,
     foreign_assets: Option<Vec<AssetId>>,
     boxes: Option<Vec<BoxReference>>,
+    header: TxnHeader,
 }
 
 impl UpdateApplication {
@@ -708,6 +760,7 @@ impl UpdateApplication {
             foreign_apps: None,
             foreign_assets: None,
             boxes: None,
+            header: TxnHeader::default(),
         }
     }
 
@@ -736,8 +789,8 @@ impl UpdateApplication {
         self
     }
 
-    pub fn build(self) -> TransactionType {
-        TransactionType::ApplicationCallTransaction(ApplicationCallTransaction {
+    pub fn build(self, params: &impl TransactionParams) -> Result<Transaction, TransactionError> {
+        let txn_type = TransactionType::ApplicationCallTransaction(ApplicationCallTransaction {
             sender: self.sender,
             app_id: Some(self.app_id),
             on_complete: ApplicationCallOnComplete::UpdateApplication,
@@ -751,9 +804,12 @@ impl UpdateApplication {
             local_state_schema: None,
             extra_pages: 0,
             boxes: self.boxes,
-        })
+        });
+        self.header.into_transaction(params, txn_type)
     }
 }
+
+impl_txn_header_setters!(UpdateApplication);
 
 /// A builder for [ApplicationCallTransaction].
 pub struct CallApplication {
@@ -764,6 +820,7 @@ pub struct CallApplication {
     foreign_apps: Option<Vec<AppId>>,
     foreign_assets: Option<Vec<AssetId>>,
     boxes: Option<Vec<BoxReference>>,
+    header: TxnHeader,
 }
 
 impl CallApplication {
@@ -776,6 +833,7 @@ impl CallApplication {
             foreign_apps: None,
             foreign_assets: None,
             boxes: None,
+            header: TxnHeader::default(),
         }
     }
 
@@ -804,8 +862,8 @@ impl CallApplication {
         self
     }
 
-    pub fn build(self) -> TransactionType {
-        TransactionType::ApplicationCallTransaction(ApplicationCallTransaction {
+    pub fn build(self, params: &impl TransactionParams) -> Result<Transaction, TransactionError> {
+        let txn_type = TransactionType::ApplicationCallTransaction(ApplicationCallTransaction {
             sender: self.sender,
             app_id: Some(self.app_id),
             on_complete: ApplicationCallOnComplete::NoOp,
@@ -819,9 +877,12 @@ impl CallApplication {
             local_state_schema: None,
             extra_pages: 0,
             boxes: self.boxes,
-        })
+        });
+        self.header.into_transaction(params, txn_type)
     }
 }
+
+impl_txn_header_setters!(CallApplication);
 
 /// A builder for [ApplicationCallTransaction].
 pub struct ClearApplication {
@@ -832,6 +893,7 @@ pub struct ClearApplication {
     foreign_apps: Option<Vec<AppId>>,
     foreign_assets: Option<Vec<AssetId>>,
     boxes: Option<Vec<BoxReference>>,
+    header: TxnHeader,
 }
 
 impl ClearApplication {
@@ -844,6 +906,7 @@ impl ClearApplication {
             foreign_apps: None,
             foreign_assets: None,
             boxes: None,
+            header: TxnHeader::default(),
         }
     }
 
@@ -872,8 +935,8 @@ impl ClearApplication {
         self
     }
 
-    pub fn build(self) -> TransactionType {
-        TransactionType::ApplicationCallTransaction(ApplicationCallTransaction {
+    pub fn build(self, params: &impl TransactionParams) -> Result<Transaction, TransactionError> {
+        let txn_type = TransactionType::ApplicationCallTransaction(ApplicationCallTransaction {
             sender: self.sender,
             app_id: Some(self.app_id),
             on_complete: ApplicationCallOnComplete::ClearState,
@@ -887,9 +950,12 @@ impl ClearApplication {
             local_state_schema: None,
             extra_pages: 0,
             boxes: self.boxes,
-        })
+        });
+        self.header.into_transaction(params, txn_type)
     }
 }
+
+impl_txn_header_setters!(ClearApplication);
 
 /// A builder for [ApplicationCallTransaction].
 pub struct CloseApplication {
@@ -900,6 +966,7 @@ pub struct CloseApplication {
     foreign_apps: Option<Vec<AppId>>,
     foreign_assets: Option<Vec<AssetId>>,
     boxes: Option<Vec<BoxReference>>,
+    header: TxnHeader,
 }
 
 impl CloseApplication {
@@ -912,6 +979,7 @@ impl CloseApplication {
             foreign_apps: None,
             foreign_assets: None,
             boxes: None,
+            header: TxnHeader::default(),
         }
     }
 
@@ -940,8 +1008,8 @@ impl CloseApplication {
         self
     }
 
-    pub fn build(self) -> TransactionType {
-        TransactionType::ApplicationCallTransaction(ApplicationCallTransaction {
+    pub fn build(self, params: &impl TransactionParams) -> Result<Transaction, TransactionError> {
+        let txn_type = TransactionType::ApplicationCallTransaction(ApplicationCallTransaction {
             sender: self.sender,
             app_id: Some(self.app_id),
             on_complete: ApplicationCallOnComplete::CloseOut,
@@ -955,9 +1023,12 @@ impl CloseApplication {
             local_state_schema: None,
             extra_pages: 0,
             boxes: self.boxes,
-        })
+        });
+        self.header.into_transaction(params, txn_type)
     }
 }
+
+impl_txn_header_setters!(CloseApplication);
 
 /// A builder for [ApplicationCallTransaction].
 pub struct DeleteApplication {
@@ -968,6 +1039,7 @@ pub struct DeleteApplication {
     foreign_apps: Option<Vec<AppId>>,
     foreign_assets: Option<Vec<AssetId>>,
     boxes: Option<Vec<BoxReference>>,
+    header: TxnHeader,
 }
 
 impl DeleteApplication {
@@ -980,6 +1052,7 @@ impl DeleteApplication {
             foreign_apps: None,
             foreign_assets: None,
             boxes: None,
+            header: TxnHeader::default(),
         }
     }
 
@@ -1008,8 +1081,8 @@ impl DeleteApplication {
         self
     }
 
-    pub fn build(self) -> TransactionType {
-        TransactionType::ApplicationCallTransaction(ApplicationCallTransaction {
+    pub fn build(self, params: &impl TransactionParams) -> Result<Transaction, TransactionError> {
+        let txn_type = TransactionType::ApplicationCallTransaction(ApplicationCallTransaction {
             sender: self.sender,
             app_id: Some(self.app_id),
             on_complete: ApplicationCallOnComplete::DeleteApplication,
@@ -1023,9 +1096,12 @@ impl DeleteApplication {
             local_state_schema: None,
             extra_pages: 0,
             boxes: self.boxes,
-        })
+        });
+        self.header.into_transaction(params, txn_type)
     }
 }
+
+impl_txn_header_setters!(DeleteApplication);
 
 /// A builder for [ApplicationCallTransaction].
 pub struct OptInApplication {
@@ -1036,6 +1112,7 @@ pub struct OptInApplication {
     foreign_apps: Option<Vec<AppId>>,
     foreign_assets: Option<Vec<AssetId>>,
     boxes: Option<Vec<BoxReference>>,
+    header: TxnHeader,
 }
 
 impl OptInApplication {
@@ -1048,6 +1125,7 @@ impl OptInApplication {
             foreign_apps: None,
             foreign_assets: None,
             boxes: None,
+            header: TxnHeader::default(),
         }
     }
 
@@ -1076,8 +1154,8 @@ impl OptInApplication {
         self
     }
 
-    pub fn build(self) -> TransactionType {
-        TransactionType::ApplicationCallTransaction(ApplicationCallTransaction {
+    pub fn build(self, params: &impl TransactionParams) -> Result<Transaction, TransactionError> {
+        let txn_type = TransactionType::ApplicationCallTransaction(ApplicationCallTransaction {
             sender: self.sender,
             app_id: Some(self.app_id),
             on_complete: ApplicationCallOnComplete::OptIn,
@@ -1091,6 +1169,9 @@ impl OptInApplication {
             local_state_schema: None,
             extra_pages: 0,
             boxes: self.boxes,
-        })
+        });
+        self.header.into_transaction(params, txn_type)
     }
 }
+
+impl_txn_header_setters!(OptInApplication);

--- a/algonaut_transaction/src/builder.rs
+++ b/algonaut_transaction/src/builder.rs
@@ -37,7 +37,12 @@ impl TxnHeader {
     /// Combine this header with the suggested params and a type-specific
     /// `txn_type` to produce a finished [`Transaction`]. Used by every
     /// per-type builder's terminal `build(&params)`.
-    pub(crate) fn into_transaction(
+    ///
+    /// Named `apply` rather than `into_transaction` because the latter
+    /// reads like an `Into`-trait method (`fn into_X(self) -> X`), which
+    /// this is not — it takes two extra arguments and can never be that
+    /// trait.
+    pub(crate) fn apply(
         self,
         params: &impl TransactionParams,
         txn_type: TransactionType,
@@ -147,7 +152,7 @@ impl Pay {
             amount: self.amount,
             close_remainder_to: self.close_remainder_to,
         });
-        self.header.into_transaction(params, txn_type)
+        self.header.apply(params, txn_type)
     }
 }
 
@@ -232,7 +237,7 @@ impl RegisterKey {
             state_proof_key: self.state_proof_key,
             nonparticipating: self.nonparticipating,
         });
-        self.header.into_transaction(params, txn_type)
+        self.header.apply(params, txn_type)
     }
 }
 
@@ -333,7 +338,7 @@ impl CreateAsset {
                     clawback: self.clawback,
                 }),
             });
-        self.header.into_transaction(params, txn_type)
+        self.header.apply(params, txn_type)
     }
 }
 
@@ -451,7 +456,7 @@ impl UpdateAsset {
                     clawback: self.clawback,
                 }),
             });
-        self.header.into_transaction(params, txn_type)
+        self.header.apply(params, txn_type)
     }
 }
 
@@ -480,7 +485,7 @@ impl DestroyAsset {
                 config_asset: Some(self.asset_id),
                 params: None,
             });
-        self.header.into_transaction(params, txn_type)
+        self.header.apply(params, txn_type)
     }
 }
 
@@ -521,7 +526,7 @@ impl TransferAsset {
             receiver: self.receiver,
             close_to: self.close_to,
         });
-        self.header.into_transaction(params, txn_type)
+        self.header.apply(params, txn_type)
     }
 }
 
@@ -548,7 +553,7 @@ impl AcceptAsset {
             sender: self.sender,
             xfer: self.asset_id,
         });
-        self.header.into_transaction(params, txn_type)
+        self.header.apply(params, txn_type)
     }
 }
 
@@ -598,7 +603,7 @@ impl ClawbackAsset {
             asset_receiver: self.asset_receiver,
             asset_close_to: self.asset_close_to,
         });
-        self.header.into_transaction(params, txn_type)
+        self.header.apply(params, txn_type)
     }
 }
 
@@ -631,7 +636,7 @@ impl FreezeAsset {
             asset_id: self.asset_id,
             frozen: self.frozen,
         });
-        self.header.into_transaction(params, txn_type)
+        self.header.apply(params, txn_type)
     }
 }
 
@@ -723,7 +728,7 @@ impl CreateApplication {
             extra_pages: self.extra_pages,
             boxes: self.boxes,
         });
-        self.header.into_transaction(params, txn_type)
+        self.header.apply(params, txn_type)
     }
 }
 
@@ -805,7 +810,7 @@ impl UpdateApplication {
             extra_pages: 0,
             boxes: self.boxes,
         });
-        self.header.into_transaction(params, txn_type)
+        self.header.apply(params, txn_type)
     }
 }
 
@@ -878,7 +883,7 @@ impl CallApplication {
             extra_pages: 0,
             boxes: self.boxes,
         });
-        self.header.into_transaction(params, txn_type)
+        self.header.apply(params, txn_type)
     }
 }
 
@@ -951,7 +956,7 @@ impl ClearApplication {
             extra_pages: 0,
             boxes: self.boxes,
         });
-        self.header.into_transaction(params, txn_type)
+        self.header.apply(params, txn_type)
     }
 }
 
@@ -1024,7 +1029,7 @@ impl CloseApplication {
             extra_pages: 0,
             boxes: self.boxes,
         });
-        self.header.into_transaction(params, txn_type)
+        self.header.apply(params, txn_type)
     }
 }
 
@@ -1097,7 +1102,7 @@ impl DeleteApplication {
             extra_pages: 0,
             boxes: self.boxes,
         });
-        self.header.into_transaction(params, txn_type)
+        self.header.apply(params, txn_type)
     }
 }
 
@@ -1170,7 +1175,7 @@ impl OptInApplication {
             extra_pages: 0,
             boxes: self.boxes,
         });
-        self.header.into_transaction(params, txn_type)
+        self.header.apply(params, txn_type)
     }
 }
 

--- a/algonaut_transaction/src/builder.rs
+++ b/algonaut_transaction/src/builder.rs
@@ -687,6 +687,15 @@ impl CreateApplication {
         self
     }
 
+    /// Raw byte-string arguments passed to the contract's TEAL program
+    /// (the on-wire `apaa` field). The protocol imposes no type system
+    /// here — each `Vec<u8>` lands on the AVM stack as a `bytes` value,
+    /// and the TEAL program decides how to interpret it.
+    ///
+    /// **For ARC-4 (ABI-typed) calls, use `MethodCall` instead** — it
+    /// encodes the method selector and arguments for you and decodes
+    /// the return value. This setter is the lower-level escape hatch
+    /// for calling contracts that don't follow ARC-4.
     pub fn app_arguments(mut self, app_arguments: Vec<Vec<u8>>) -> Self {
         self.app_arguments = Some(app_arguments);
         self
@@ -774,6 +783,15 @@ impl UpdateApplication {
         self
     }
 
+    /// Raw byte-string arguments passed to the contract's TEAL program
+    /// (the on-wire `apaa` field). The protocol imposes no type system
+    /// here — each `Vec<u8>` lands on the AVM stack as a `bytes` value,
+    /// and the TEAL program decides how to interpret it.
+    ///
+    /// **For ARC-4 (ABI-typed) calls, use `MethodCall` instead** — it
+    /// encodes the method selector and arguments for you and decodes
+    /// the return value. This setter is the lower-level escape hatch
+    /// for calling contracts that don't follow ARC-4.
     pub fn app_arguments(mut self, app_arguments: Vec<Vec<u8>>) -> Self {
         self.app_arguments = Some(app_arguments);
         self
@@ -847,6 +865,15 @@ impl CallApplication {
         self
     }
 
+    /// Raw byte-string arguments passed to the contract's TEAL program
+    /// (the on-wire `apaa` field). The protocol imposes no type system
+    /// here — each `Vec<u8>` lands on the AVM stack as a `bytes` value,
+    /// and the TEAL program decides how to interpret it.
+    ///
+    /// **For ARC-4 (ABI-typed) calls, use `MethodCall` instead** — it
+    /// encodes the method selector and arguments for you and decodes
+    /// the return value. This setter is the lower-level escape hatch
+    /// for calling contracts that don't follow ARC-4.
     pub fn app_arguments(mut self, app_arguments: Vec<Vec<u8>>) -> Self {
         self.app_arguments = Some(app_arguments);
         self
@@ -920,6 +947,15 @@ impl ClearApplication {
         self
     }
 
+    /// Raw byte-string arguments passed to the contract's TEAL program
+    /// (the on-wire `apaa` field). The protocol imposes no type system
+    /// here — each `Vec<u8>` lands on the AVM stack as a `bytes` value,
+    /// and the TEAL program decides how to interpret it.
+    ///
+    /// **For ARC-4 (ABI-typed) calls, use `MethodCall` instead** — it
+    /// encodes the method selector and arguments for you and decodes
+    /// the return value. This setter is the lower-level escape hatch
+    /// for calling contracts that don't follow ARC-4.
     pub fn app_arguments(mut self, app_arguments: Vec<Vec<u8>>) -> Self {
         self.app_arguments = Some(app_arguments);
         self
@@ -993,6 +1029,15 @@ impl CloseApplication {
         self
     }
 
+    /// Raw byte-string arguments passed to the contract's TEAL program
+    /// (the on-wire `apaa` field). The protocol imposes no type system
+    /// here — each `Vec<u8>` lands on the AVM stack as a `bytes` value,
+    /// and the TEAL program decides how to interpret it.
+    ///
+    /// **For ARC-4 (ABI-typed) calls, use `MethodCall` instead** — it
+    /// encodes the method selector and arguments for you and decodes
+    /// the return value. This setter is the lower-level escape hatch
+    /// for calling contracts that don't follow ARC-4.
     pub fn app_arguments(mut self, app_arguments: Vec<Vec<u8>>) -> Self {
         self.app_arguments = Some(app_arguments);
         self
@@ -1066,6 +1111,15 @@ impl DeleteApplication {
         self
     }
 
+    /// Raw byte-string arguments passed to the contract's TEAL program
+    /// (the on-wire `apaa` field). The protocol imposes no type system
+    /// here — each `Vec<u8>` lands on the AVM stack as a `bytes` value,
+    /// and the TEAL program decides how to interpret it.
+    ///
+    /// **For ARC-4 (ABI-typed) calls, use `MethodCall` instead** — it
+    /// encodes the method selector and arguments for you and decodes
+    /// the return value. This setter is the lower-level escape hatch
+    /// for calling contracts that don't follow ARC-4.
     pub fn app_arguments(mut self, app_arguments: Vec<Vec<u8>>) -> Self {
         self.app_arguments = Some(app_arguments);
         self
@@ -1139,6 +1193,15 @@ impl OptInApplication {
         self
     }
 
+    /// Raw byte-string arguments passed to the contract's TEAL program
+    /// (the on-wire `apaa` field). The protocol imposes no type system
+    /// here — each `Vec<u8>` lands on the AVM stack as a `bytes` value,
+    /// and the TEAL program decides how to interpret it.
+    ///
+    /// **For ARC-4 (ABI-typed) calls, use `MethodCall` instead** — it
+    /// encodes the method selector and arguments for you and decodes
+    /// the return value. This setter is the lower-level escape hatch
+    /// for calling contracts that don't follow ARC-4.
     pub fn app_arguments(mut self, app_arguments: Vec<Vec<u8>>) -> Self {
         self.app_arguments = Some(app_arguments);
         self

--- a/algonaut_transaction/src/lib.rs
+++ b/algonaut_transaction/src/lib.rs
@@ -9,7 +9,8 @@ pub mod tx_group;
 pub mod url;
 
 pub use builder::{
-    AcceptAsset, ClawbackAsset, CreateApplication, CreateAsset, FreezeAsset, Pay, RegisterKey,
-    TransferAsset, TxnBuilder,
+    AcceptAsset, CallApplication, ClawbackAsset, ClearApplication, CloseApplication,
+    CreateApplication, CreateAsset, DeleteApplication, DestroyAsset, FreezeAsset, OptInApplication,
+    Pay, RegisterKey, TransferAsset, UpdateApplication, UpdateAsset,
 };
 pub use transaction::{SignedTransaction, Transaction, TransactionType};

--- a/docs/adr/one-build-per-transaction.md
+++ b/docs/adr/one-build-per-transaction.md
@@ -86,15 +86,21 @@ reader looking for `Pay::note` finds it via `rustdoc`, IDE
 auto-complete, and `rg '\.note\('` without needing to know the trait
 exists.
 
-### `TxnHeader::into_transaction`
+### `TxnHeader::apply`
 
 Each builder's new `build(&params)` finishes by calling
-`self.header.into_transaction(params, txn_type)`, the helper that
-formerly lived inside `TxnBuilder::build_tx`. It applies the suggested
-params (`first_valid` = `last_round`, `last_valid` = `last_round +
-1000`, `fee` defaults to `min_fee`, `genesis_id` falls back to params)
-and returns the `Transaction`. `pub(crate)` — only the per-type
-builders and the atomic-transaction-composer need it.
+`self.header.apply(params, txn_type)`, the helper that formerly lived
+inside `TxnBuilder::build_tx`. It applies the suggested params
+(`first_valid` = `last_round`, `last_valid` = `last_round + 1000`,
+`fee` defaults to `min_fee`, `genesis_id` falls back to params) and
+returns the `Transaction`. `pub(crate)` — only the per-type builders
+and the atomic-transaction-composer need it.
+
+The name matters: an `into_transaction(self, ...) -> Transaction`
+reads like a Rust `Into`-trait method (`fn into_X(self) -> X`), but
+this signature takes two extra arguments and can never be that trait.
+`apply` describes the operation — "apply this header against params +
+txn_type" — without making a promise the type signature won't keep.
 
 ### The composer
 
@@ -103,10 +109,10 @@ builders and the atomic-transaction-composer need it.
 `TxnBuilder::with_fee(&params, fee, app_call).rekey_to(...)...build()?`.
 After this change, the same construction happens inline (the
 `Transaction` struct's fields are `pub`), using the same `last_round +
-1000` shape `TxnHeader::into_transaction` uses. The composer does not
-go through any per-type builder because its `AddMethodCallParams` is
-the union of every application-call variant — the `MethodCall`
-fluent builder (D6) is the eventual replacement for that path.
+1000` shape `TxnHeader::apply` uses. The composer does not go through
+any per-type builder because its `AddMethodCallParams` is the union of
+every application-call variant — the `MethodCall` fluent builder (D6)
+is the eventual replacement for that path.
 
 ## Consequences
 

--- a/docs/adr/one-build-per-transaction.md
+++ b/docs/adr/one-build-per-transaction.md
@@ -1,0 +1,129 @@
+---
+id: one-build-per-transaction
+title: One build per transaction
+abstract: Fold the outer `TxnBuilder` into each per-type builder (`Pay`, `CreateAsset`, `CallApplication`, …). Each builder grows the six header setters (`fee`, `note`, `lease`, `rekey_to`, `group`, `genesis_id`) and a single terminal `build(&params) -> Result<Transaction, TransactionError>` — replacing today's two-stage `TxnBuilder::with(&params, Inner::new(...).build()).build()?` pattern. Second sub-ADR addressing decision item D1 of the ideal-type-safe-ergonomic-api index.
+status: proposed
+date: 2026-05-20
+deciders: []
+tags: [api, ergonomics, type-safety]
+---
+
+# One build per transaction
+
+## Status
+
+Proposed. Implements decision item **D1** of
+[`ideal-type-safe-ergonomic-api`](ideal-type-safe-ergonomic-api.md).
+
+## Context
+
+The canonical transaction-construction line, repeated in every example
+and most step-defs:
+
+```rust
+let t = TxnBuilder::with(
+    &params,
+    Pay::new(alice.address(), bob.address(), MicroAlgos(123_456)).build(),
+)
+.build()?;
+```
+
+Two `build()` calls. The inner one (`Pay::build`) turns a `Pay` into a
+`TransactionType` enum; the outer one (`TxnBuilder::build`) turns header
+fields plus that enum into a `Transaction`. The inner builder is
+infallible, the outer one returns `Result` — so the same word means two
+different things, one nesting level apart. A reader cannot tell from the
+call site why one `build` can fail and the other cannot.
+
+The outer header setters (`note`, `lease`, `rekey_to`, …) live on
+`TxnBuilder`, separated from the type-specific setters on `Pay` /
+`CreateAsset` / … . Setting a note and a close-remainder requires
+threading both through the two-stage call chain.
+
+## Decision
+
+Every per-type builder (`Pay`, `RegisterKey`, `CreateAsset`,
+`UpdateAsset`, `DestroyAsset`, `TransferAsset`, `AcceptAsset`,
+`ClawbackAsset`, `FreezeAsset`, `CreateApplication`,
+`UpdateApplication`, `CallApplication`, `ClearApplication`,
+`CloseApplication`, `DeleteApplication`, `OptInApplication`) embeds a
+shared `TxnHeader` and exposes the six header setters directly. The
+terminal `build(self) -> TransactionType` is replaced by
+`build(self, params: &impl TransactionParams) -> Result<Transaction,
+TransactionError>`, which finalises both the header and the
+type-specific fields in one shot.
+
+```rust
+let t = Pay::new(alice.address(), bob.address(), MicroAlgos(123_456))
+    .note(b"hello".to_vec())
+    .build(&params)?;
+```
+
+The outer `TxnBuilder` retires.
+
+### `TxnHeader` and `impl_txn_header_setters!`
+
+A new `TxnHeader { fee, note, lease, rekey_to, group, genesis_id }`
+struct lives in `algonaut_transaction::builder` and stores the six
+optional header fields. Every per-type builder gains a
+`header: TxnHeader` field, defaulted in its constructor(s).
+
+A `macro_rules! impl_txn_header_setters!` at the top of the same module
+mints the six fluent setters (`fee`, `note`, `lease`, `rekey_to`,
+`group`, `genesis_id`) on a target builder. The macro is applied once
+per builder — at the bottom of its `impl` block — so the setters are
+inherent methods, callable without a trait import:
+
+```rust
+impl_txn_header_setters!(Pay);
+impl_txn_header_setters!(CreateAsset);
+// ...
+```
+
+A trait + blanket-impl alternative was considered (`HasTxnHeader` plus
+`TxnHeaderSetters` default methods). The macro wins on grep-ability: a
+reader looking for `Pay::note` finds it via `rustdoc`, IDE
+auto-complete, and `rg '\.note\('` without needing to know the trait
+exists.
+
+### `TxnHeader::into_transaction`
+
+Each builder's new `build(&params)` finishes by calling
+`self.header.into_transaction(params, txn_type)`, the helper that
+formerly lived inside `TxnBuilder::build_tx`. It applies the suggested
+params (`first_valid` = `last_round`, `last_valid` = `last_round +
+1000`, `fee` defaults to `min_fee`, `genesis_id` falls back to params)
+and returns the `Transaction`. `pub(crate)` — only the per-type
+builders and the atomic-transaction-composer need it.
+
+### The composer
+
+`AtomicTransactionComposer::add_method_call` used to build its
+`ApplicationCallTransaction` enum variant by hand and wrap it in
+`TxnBuilder::with_fee(&params, fee, app_call).rekey_to(...)...build()?`.
+After this change, the same construction happens inline (the
+`Transaction` struct's fields are `pub`), using the same `last_round +
+1000` shape `TxnHeader::into_transaction` uses. The composer does not
+go through any per-type builder because its `AddMethodCallParams` is
+the union of every application-call variant — the `MethodCall`
+fluent builder (D6) is the eventual replacement for that path.
+
+## Consequences
+
+- **Compile-error breaking change** for every caller writing
+  `TxnBuilder::with(...)` or `TxnBuilder::with_fee(...)`. Pre-1.0;
+  mechanical migration: drop `TxnBuilder`, append `.build(&params)?` to
+  the inner builder, move any header setters onto the inner builder.
+  ~40 call sites across `examples/` and `tests/step_defs/` migrated in
+  this PR.
+- **The same word stops meaning two things.** There is one `build` per
+  transaction now, and it is the one that can fail. Type-specific
+  setters and header setters share a namespace; the call site reads in
+  natural order.
+- **Out of scope.** D6 — the `MethodCall` fluent builder replacing
+  `AddMethodCallParams` / `add_method_call(&mut params)` — is a
+  separate sub-ADR. The composer's current internal construction path
+  is preserved as-is, just inlined now that `TxnBuilder` is gone.
+- **No serialization or wire-format change.** `Transaction` is byte-
+  identical before and after; only the path to constructing it
+  changes.

--- a/examples/app_call.rs
+++ b/examples/app_call.rs
@@ -24,9 +24,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     info!("building transaction");
     // TODO set a correct app-id here
-    let t = CallApplication::new(alice.address(), AppId(5))
-        .app_arguments(vec![vec![1, 0], vec![255]])
-        .build(&params)?;
+    let t = CallApplication::new(alice.address(), AppId(5)).build(&params)?;
 
     info!("signing transaction");
     let signed_t = alice.sign_transaction(t)?;

--- a/examples/app_call.rs
+++ b/examples/app_call.rs
@@ -1,6 +1,5 @@
 use algonaut::algod::v2::Algod;
 use algonaut::core::AppId;
-use algonaut::transaction::TxnBuilder;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::builder::CallApplication;
 use dotenv::dotenv;
@@ -24,14 +23,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.txn_params().await?;
 
     info!("building transaction");
-    let t = TxnBuilder::with(
-        &params,
-        // TODO set a correct app-id here
-        CallApplication::new(alice.address(), AppId(5))
-            .app_arguments(vec![vec![1, 0], vec![255]])
-            .build(),
-    )
-    .build()?;
+    // TODO set a correct app-id here
+    let t = CallApplication::new(alice.address(), AppId(5))
+        .app_arguments(vec![vec![1, 0], vec![255]])
+        .build(&params)?;
 
     info!("signing transaction");
     let signed_t = alice.sign_transaction(t)?;

--- a/examples/app_clear_state.rs
+++ b/examples/app_clear_state.rs
@@ -1,6 +1,5 @@
 use algonaut::algod::v2::Algod;
 use algonaut::core::AppId;
-use algonaut::transaction::TxnBuilder;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::builder::ClearApplication;
 use dotenv::dotenv;
@@ -26,11 +25,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     info!("building CreateApplication transaction");
     // to test this, create an application that sets local state and opt-in, for/with the account sending this transaction.
     // TODO set a correct app-id here
-    let t = TxnBuilder::with(
-        &params,
-        ClearApplication::new(alice.address(), AppId(11)).build(),
-    )
-    .build()?;
+    let t = ClearApplication::new(alice.address(), AppId(11)).build(&params)?;
 
     info!("signing transaction");
     let signed_t = alice.sign_transaction(t)?;

--- a/examples/app_close_out.rs
+++ b/examples/app_close_out.rs
@@ -1,6 +1,5 @@
 use algonaut::algod::v2::Algod;
 use algonaut::core::AppId;
-use algonaut::transaction::TxnBuilder;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::builder::CloseApplication;
 use dotenv::dotenv;
@@ -27,11 +26,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // to test this, create an application that sets local state and opt-in, for/with the account sending this transaction.
     // the approval program has to return success for the local state to be cleared.
     // TODO set a correct app-id here
-    let t = TxnBuilder::with(
-        &params,
-        CloseApplication::new(alice.address(), AppId(0)).build(),
-    )
-    .build()?;
+    let t = CloseApplication::new(alice.address(), AppId(0)).build(&params)?;
 
     info!("signing transaction");
     let signed_t = alice.sign_transaction(t)?;

--- a/examples/app_create.rs
+++ b/examples/app_create.rs
@@ -1,6 +1,5 @@
 use algonaut::algod::v2::{Algod, SourceMap};
 use algonaut::transaction::CreateApplication;
-use algonaut::transaction::TxnBuilder;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::transaction::StateSchema;
 use algonaut_algod::models::PendingTransactionResponse;
@@ -52,19 +51,15 @@ int 1
     let params = algod.txn_params().await?;
 
     info!("building CreateApplication transaction");
-    let t = TxnBuilder::with(
-        &params,
-        CreateApplication::new(
-            alice.address(),
-            compiled_approval_program,
-            compiled_clear_program,
-            StateSchema::empty(),
-            StateSchema::empty(),
-        )
-        .app_arguments(vec![vec![1, 0], vec![255]])
-        .build(),
+    let t = CreateApplication::new(
+        alice.address(),
+        compiled_approval_program,
+        compiled_clear_program,
+        StateSchema::empty(),
+        StateSchema::empty(),
     )
-    .build()?;
+    .app_arguments(vec![vec![1, 0], vec![255]])
+    .build(&params)?;
 
     info!("signing transaction");
     let signed_t = alice.sign_transaction(t)?;

--- a/examples/app_create.rs
+++ b/examples/app_create.rs
@@ -58,7 +58,6 @@ int 1
         StateSchema::empty(),
         StateSchema::empty(),
     )
-    .app_arguments(vec![vec![1, 0], vec![255]])
     .build(&params)?;
 
     info!("signing transaction");

--- a/examples/app_delete.rs
+++ b/examples/app_delete.rs
@@ -23,9 +23,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.txn_params().await?;
 
     info!("building DeleteApplication transaction");
-    let t = DeleteApplication::new(alice.address(), AppId(3))
-        .app_arguments(vec![vec![1, 0], vec![255]])
-        .build(&params)?;
+    let t = DeleteApplication::new(alice.address(), AppId(3)).build(&params)?;
 
     info!("signing transaction");
     let signed_t = alice.sign_transaction(t)?;

--- a/examples/app_delete.rs
+++ b/examples/app_delete.rs
@@ -1,6 +1,5 @@
 use algonaut::algod::v2::Algod;
 use algonaut::core::AppId;
-use algonaut::transaction::TxnBuilder;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::builder::DeleteApplication;
 use dotenv::dotenv;
@@ -24,13 +23,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.txn_params().await?;
 
     info!("building DeleteApplication transaction");
-    let t = TxnBuilder::with(
-        &params,
-        DeleteApplication::new(alice.address(), AppId(3))
-            .app_arguments(vec![vec![1, 0], vec![255]])
-            .build(),
-    )
-    .build()?;
+    let t = DeleteApplication::new(alice.address(), AppId(3))
+        .app_arguments(vec![vec![1, 0], vec![255]])
+        .build(&params)?;
 
     info!("signing transaction");
     let signed_t = alice.sign_transaction(t)?;

--- a/examples/app_optin.rs
+++ b/examples/app_optin.rs
@@ -24,9 +24,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     info!("building OptInApplication transaction");
     // TODO set a correct app-id here
-    let t = OptInApplication::new(alice.address(), AppId(11))
-        .app_arguments(vec![vec![1, 0], vec![255]])
-        .build(&params)?;
+    let t = OptInApplication::new(alice.address(), AppId(11)).build(&params)?;
 
     info!("signing transaction");
     let signed_t = alice.sign_transaction(t)?;

--- a/examples/app_optin.rs
+++ b/examples/app_optin.rs
@@ -1,6 +1,5 @@
 use algonaut::algod::v2::Algod;
 use algonaut::core::AppId;
-use algonaut::transaction::TxnBuilder;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::builder::OptInApplication;
 use dotenv::dotenv;
@@ -24,14 +23,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.txn_params().await?;
 
     info!("building OptInApplication transaction");
-    let t = TxnBuilder::with(
-        &params,
-        // TODO set a correct app-id here
-        OptInApplication::new(alice.address(), AppId(11))
-            .app_arguments(vec![vec![1, 0], vec![255]])
-            .build(),
-    )
-    .build()?;
+    // TODO set a correct app-id here
+    let t = OptInApplication::new(alice.address(), AppId(11))
+        .app_arguments(vec![vec![1, 0], vec![255]])
+        .build(&params)?;
 
     info!("signing transaction");
     let signed_t = alice.sign_transaction(t)?;

--- a/examples/app_update.rs
+++ b/examples/app_update.rs
@@ -1,6 +1,5 @@
 use algonaut::algod::v2::{Algod, SourceMap};
 use algonaut::core::AppId;
-use algonaut::transaction::TxnBuilder;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::builder::UpdateApplication;
 use dotenv::dotenv;
@@ -46,18 +45,14 @@ int 1
     let params = algod.txn_params().await?;
 
     info!("building UpdateApplication transaction");
-    let t = TxnBuilder::with(
-        &params,
-        UpdateApplication::new(
-            alice.address(),
-            AppId(5),
-            compiled_approval_program,
-            compiled_clear_program,
-        )
-        .app_arguments(vec![vec![1, 0], vec![255]]) // for the program being upgraded
-        .build(),
+    let t = UpdateApplication::new(
+        alice.address(),
+        AppId(5),
+        compiled_approval_program,
+        compiled_clear_program,
     )
-    .build()?;
+    .app_arguments(vec![vec![1, 0], vec![255]]) // for the program being upgraded
+    .build(&params)?;
 
     info!("signing transaction");
     let signed_t = alice.sign_transaction(t)?;

--- a/examples/app_update.rs
+++ b/examples/app_update.rs
@@ -51,7 +51,6 @@ int 1
         compiled_approval_program,
         compiled_clear_program,
     )
-    .app_arguments(vec![vec![1, 0], vec![255]]) // for the program being upgraded
     .build(&params)?;
 
     info!("signing transaction");

--- a/examples/asset_clawback.rs
+++ b/examples/asset_clawback.rs
@@ -1,7 +1,7 @@
 use algonaut::algod::v2::Algod;
 use algonaut::core::AssetId;
 use algonaut::transaction::ClawbackAsset;
-use algonaut::transaction::{TxnBuilder, account::Account};
+use algonaut::transaction::account::Account;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;
@@ -28,18 +28,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.txn_params().await?;
 
     info!("building ClawbackAsset transaction");
-    let t = TxnBuilder::with(
-        &params,
-        ClawbackAsset::new(
-            alice.address(),
-            AssetId(21),
-            1,
-            bob.address(),
-            alice.address(),
-        )
-        .build(),
+    let t = ClawbackAsset::new(
+        alice.address(),
+        AssetId(21),
+        1,
+        bob.address(),
+        alice.address(),
     )
-    .build()?;
+    .build(&params)?;
 
     info!("signing transaction");
     let signed_t = alice.sign_transaction(t)?;

--- a/examples/asset_create.rs
+++ b/examples/asset_create.rs
@@ -1,7 +1,7 @@
 use algonaut::algod::v2::Algod;
 use algonaut::openapi_algod::models::PendingTransactionResponse;
+use algonaut::transaction::CreateAsset;
 use algonaut::transaction::account::Account;
-use algonaut::transaction::{CreateAsset, TxnBuilder};
 use algonaut_core::TxId;
 use dotenv::dotenv;
 use std::env;
@@ -28,19 +28,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.txn_params().await?;
 
     info!("building CreateAsset transaction");
-    let t = TxnBuilder::with(
-        &params,
-        CreateAsset::new(alice.address(), 100, 2, false)
-            .unit_name("EIRI".to_owned())
-            .asset_name("Naki".to_owned())
-            .manager(alice.address())
-            .reserve(alice.address())
-            .freeze(alice.address())
-            .clawback(alice.address())
-            .url("example.com".to_owned())
-            .build(),
-    )
-    .build()?;
+    let t = CreateAsset::new(alice.address(), 100, 2, false)
+        .unit_name("EIRI".to_owned())
+        .asset_name("Naki".to_owned())
+        .manager(alice.address())
+        .reserve(alice.address())
+        .freeze(alice.address())
+        .clawback(alice.address())
+        .url("example.com".to_owned())
+        .build(&params)?;
 
     info!("signing transaction");
     // we need to sign the transaction to prove that we own the sender address

--- a/examples/asset_optin.rs
+++ b/examples/asset_optin.rs
@@ -1,7 +1,7 @@
 use algonaut::algod::v2::Algod;
 use algonaut::core::AssetId;
 use algonaut::transaction::AcceptAsset;
-use algonaut::transaction::{TxnBuilder, account::Account};
+use algonaut::transaction::account::Account;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;
@@ -24,11 +24,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.txn_params().await?;
 
     info!("building AcceptAsset transaction");
-    let t = TxnBuilder::with(
-        &params,
-        AcceptAsset::new(bob.address(), AssetId(16)).build(),
-    )
-    .build()?;
+    let t = AcceptAsset::new(bob.address(), AssetId(16)).build(&params)?;
 
     info!("signing transaction");
     let sign_response = bob.sign_transaction(t)?;

--- a/examples/asset_transfer.rs
+++ b/examples/asset_transfer.rs
@@ -1,7 +1,7 @@
 use algonaut::algod::v2::Algod;
 use algonaut::core::AssetId;
 use algonaut::transaction::TransferAsset;
-use algonaut::transaction::{TxnBuilder, account::Account};
+use algonaut::transaction::account::Account;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;
@@ -24,11 +24,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.txn_params().await?;
 
     info!("building TransferAsset transaction");
-    let t = TxnBuilder::with(
-        &params,
-        TransferAsset::new(alice.address(), AssetId(16), 1, bob.address()).build(),
-    )
-    .build()?;
+    let t = TransferAsset::new(alice.address(), AssetId(16), 1, bob.address()).build(&params)?;
 
     info!("signing transaction");
     let sign_response = alice.sign_transaction(t)?;

--- a/examples/atomic_swap.rs
+++ b/examples/atomic_swap.rs
@@ -1,7 +1,6 @@
 use algonaut::algod::v2::Algod;
 use algonaut::core::MicroAlgos;
 use algonaut::transaction::Pay;
-use algonaut::transaction::TxnBuilder;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::tx_group::TxGroup;
 use dotenv::dotenv;
@@ -29,18 +28,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Normally you'll want to submit e.g. a payment and asset transfer or asset transfers for different assets.
 
     info!("building payment transaction alice -> bob");
-    let t1 = TxnBuilder::with(
-        &params,
-        Pay::new(alice.address(), bob.address(), MicroAlgos(1_000)).build(),
-    )
-    .build()?;
+    let t1 = Pay::new(alice.address(), bob.address(), MicroAlgos(1_000)).build(&params)?;
 
     info!("building payment transaction bob -> alice");
-    let t2 = TxnBuilder::with(
-        &params,
-        Pay::new(bob.address(), alice.address(), MicroAlgos(3_000)).build(),
-    )
-    .build()?;
+    let t2 = Pay::new(bob.address(), alice.address(), MicroAlgos(3_000)).build(&params)?;
 
     info!("grouping transactions");
     let group = TxGroup::try_from(vec![t1, t2])?;

--- a/examples/key_reg.rs
+++ b/examples/key_reg.rs
@@ -1,7 +1,7 @@
 use algonaut::algod::v2::Algod;
 use algonaut::core::{Round, StateProofPk, VotePk, VrfPk};
 use algonaut::transaction::RegisterKey;
-use algonaut::transaction::{TxnBuilder, account::Account};
+use algonaut::transaction::account::Account;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;
@@ -29,20 +29,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.txn_params().await?;
 
     info!("building RegisterKey transaction");
-    let t = TxnBuilder::with(
-        &params,
-        RegisterKey::online(
-            alice.address(),
-            VotePk::from_base64_str(vote_pk_str)?,
-            VrfPk::from_base64_str(selection_pk_str)?,
-            StateProofPk::from_base64_str(state_proof_key_str)?,
-            Round(params.last_round),
-            Round(params.last_round + 3_000_000),
-            10_000,
-        )
-        .build(),
+    let t = RegisterKey::online(
+        alice.address(),
+        VotePk::from_base64_str(vote_pk_str)?,
+        VrfPk::from_base64_str(selection_pk_str)?,
+        StateProofPk::from_base64_str(state_proof_key_str)?,
+        Round(params.last_round),
+        Round(params.last_round + 3_000_000),
+        10_000,
     )
-    .build()?;
+    .build(&params)?;
 
     info!("signing transaction");
     let sign_response = alice.sign_transaction(t)?;

--- a/examples/kmd_sign_submit_transaction.rs
+++ b/examples/kmd_sign_submit_transaction.rs
@@ -1,7 +1,7 @@
 use algonaut::algod::v2::Algod;
 use algonaut::core::MicroAlgos;
 use algonaut::kmd::v1::Kmd;
-use algonaut::transaction::{Pay, TxnBuilder};
+use algonaut::transaction::Pay;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;
@@ -53,8 +53,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.txn_params().await?;
 
     info!("building Pay transaction");
-    let t =
-        TxnBuilder::with(&params, Pay::new(sender, bob, MicroAlgos(123_456)).build()).build()?;
+    let t = Pay::new(sender, bob, MicroAlgos(123_456)).build(&params)?;
 
     info!("signing transaction");
     // we need to sign the transaction to prove that we own the sender address

--- a/examples/logic_sig_contract_account.rs
+++ b/examples/logic_sig_contract_account.rs
@@ -1,7 +1,6 @@
 use algonaut::algod::v2::{Algod, SourceMap};
 use algonaut::core::MicroAlgos;
 use algonaut::transaction::Pay;
-use algonaut::transaction::TxnBuilder;
 use algonaut::transaction::contract_account::ContractAccount;
 use dotenv::dotenv;
 use std::env;
@@ -45,11 +44,7 @@ byte 0xFF
     let params = algod.txn_params().await?;
 
     info!("building Pay transaction");
-    let t = TxnBuilder::with(
-        &params,
-        Pay::new(*contract_account.address(), receiver, MicroAlgos(123_456)).build(),
-    )
-    .build()?;
+    let t = Pay::new(*contract_account.address(), receiver, MicroAlgos(123_456)).build(&params)?;
 
     info!("signing transaction with contract account");
     let signed_t = contract_account.sign(t, vec![vec![1, 0], vec![255]])?;

--- a/examples/logic_sig_delegated.rs
+++ b/examples/logic_sig_delegated.rs
@@ -1,8 +1,8 @@
 use algonaut::algod::v2::{Algod, SourceMap};
 use algonaut::core::{LogicSignature, MicroAlgos, TxId};
+use algonaut::transaction::account::Account;
 use algonaut::transaction::transaction::TransactionSignature;
 use algonaut::transaction::{Pay, SignedTransaction};
-use algonaut::transaction::{TxnBuilder, account::Account};
 use algonaut_transaction::transaction::SignedLogic;
 use dotenv::dotenv;
 use std::env;
@@ -40,11 +40,7 @@ int 1
     let params = algod.txn_params().await?;
 
     info!("building Pay transaction");
-    let t = TxnBuilder::with(
-        &params,
-        Pay::new(alice.address(), bob.address(), MicroAlgos(123_456)).build(),
-    )
-    .build()?;
+    let t = Pay::new(alice.address(), bob.address(), MicroAlgos(123_456)).build(&params)?;
 
     info!("generating program signature");
     let signature = alice.generate_program_sig(&program);

--- a/examples/logic_sig_delegated_multi.rs
+++ b/examples/logic_sig_delegated_multi.rs
@@ -1,8 +1,8 @@
 use algonaut::algod::v2::{Algod, SourceMap};
 use algonaut::core::{LogicSignature, MicroAlgos, MultisigAddress, TxId};
+use algonaut::transaction::account::Account;
 use algonaut::transaction::transaction::TransactionSignature;
 use algonaut::transaction::{Pay, SignedTransaction};
-use algonaut::transaction::{TxnBuilder, account::Account};
 use algonaut_transaction::transaction::SignedLogic;
 use dotenv::dotenv;
 use std::env;
@@ -46,11 +46,7 @@ int 1
     let params = algod.txn_params().await?;
 
     info!("building Pay transaction");
-    let t = TxnBuilder::with(
-        &params,
-        Pay::new(multisig_address.address(), casey, MicroAlgos(123_456)).build(),
-    )
-    .build()?;
+    let t = Pay::new(multisig_address.address(), casey, MicroAlgos(123_456)).build(&params)?;
 
     info!("alice is initializing multi-signature");
     let msig = alice.init_logic_msig(&program, &multisig_address)?;

--- a/examples/multi_sig.rs
+++ b/examples/multi_sig.rs
@@ -1,8 +1,8 @@
 use algonaut::algod::v2::Algod;
 use algonaut::core::{MicroAlgos, MultisigAddress, TxId};
+use algonaut::transaction::account::Account;
 use algonaut::transaction::transaction::TransactionSignature;
 use algonaut::transaction::{Pay, SignedTransaction};
-use algonaut::transaction::{TxnBuilder, account::Account};
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;
@@ -31,16 +31,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.txn_params().await?;
 
     info!("building Pay transaction");
-    let t = TxnBuilder::with(
-        &params,
-        Pay::new(
-            multisig_address.address(),
-            bob.address(),
-            MicroAlgos(123_456),
-        )
-        .build(),
+    let t = Pay::new(
+        multisig_address.address(),
+        bob.address(),
+        MicroAlgos(123_456),
     )
-    .build()?;
+    .build(&params)?;
 
     info!("initializing multisig");
     let msig = alice.init_transaction_msig(&t, &multisig_address)?;

--- a/examples/payment.rs
+++ b/examples/payment.rs
@@ -1,7 +1,7 @@
 use algonaut::algod::v2::Algod;
 use algonaut::core::MicroAlgos;
 use algonaut::transaction::Pay;
-use algonaut::transaction::{TxnBuilder, account::Account};
+use algonaut::transaction::account::Account;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;
@@ -26,11 +26,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.txn_params().await?;
 
     info!("building Pay transaction");
-    let t = TxnBuilder::with(
-        &params,
-        Pay::new(alice.address(), bob.address(), MicroAlgos(123_456)).build(),
-    )
-    .build()?;
+    let t = Pay::new(alice.address(), bob.address(), MicroAlgos(123_456)).build(&params)?;
 
     info!("signing transaction");
     let sign_response = alice.sign_transaction(t)?;

--- a/examples/rekey.rs
+++ b/examples/rekey.rs
@@ -38,10 +38,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.txn_params().await?;
 
     info!("creating rekey-ing transaction");
-    // rekey
-    let rekey_tx = Pay::new(rekeyed_acc_address, rekeyed_acc_address, MicroAlgos(0))
-        .rekey_to(rekey_to_acc_address)
-        .build(&params)?;
+    let rekey_tx = Pay::rekey(rekeyed_acc_address, rekey_to_acc_address).build(&params)?;
 
     info!("signing transaction");
     let rekey_signed = rekeyed_acc.sign_transaction(rekey_tx)?;

--- a/examples/rekey.rs
+++ b/examples/rekey.rs
@@ -1,5 +1,5 @@
 use algonaut::algod::v2::Algod;
-use algonaut::transaction::{TxnBuilder, account::Account};
+use algonaut::transaction::account::Account;
 use algonaut::util::wait_for_pending_tx::wait_for_pending_transaction;
 use algonaut_core::{MicroAlgos, TxId};
 use algonaut_transaction::Pay;
@@ -39,12 +39,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     info!("creating rekey-ing transaction");
     // rekey
-    let rekey_tx = TxnBuilder::with(
-        &params,
-        Pay::new(rekeyed_acc_address, rekeyed_acc_address, MicroAlgos(0)).build(),
-    )
-    .rekey_to(rekey_to_acc_address)
-    .build()?;
+    let rekey_tx = Pay::new(rekeyed_acc_address, rekeyed_acc_address, MicroAlgos(0))
+        .rekey_to(rekey_to_acc_address)
+        .build(&params)?;
 
     info!("signing transaction");
     let rekey_signed = rekeyed_acc.sign_transaction(rekey_tx)?;
@@ -66,11 +63,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     info!("testing the rekey success");
     // verify: send a tx with the rekeyed address as sender, signing with rekey_to account
     let receiver = "PGCS3D5JL4AIFGTBPDGGMMCT3ODKUUFEFG336MJO25CGBG7ORKVOE3AHSU".parse()?;
-    let payment_tx = TxnBuilder::with(
-        &params,
-        Pay::new(rekeyed_acc_address, receiver, MicroAlgos(10_000)).build(),
-    )
-    .build()?;
+    let payment_tx = Pay::new(rekeyed_acc_address, receiver, MicroAlgos(10_000)).build(&params)?;
 
     info!("signing transaction");
     let payment_signed = rekey_to_acc.sign_transaction(payment_tx)?;

--- a/examples/sign_offline.rs
+++ b/examples/sign_offline.rs
@@ -1,7 +1,7 @@
 use algonaut::algod::v2::Algod;
 use algonaut::core::{MicroAlgos, ToMsgPack};
+use algonaut::transaction::Pay;
 use algonaut::transaction::account::Account;
-use algonaut::transaction::{Pay, TxnBuilder};
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;
@@ -25,16 +25,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params = algod.txn_params().await?;
 
     info!("building Pay transaction");
-    let t = TxnBuilder::with(
-        &params,
-        Pay::new(
-            alice.address(),
-            env::var("BOB_ADDRESS")?.parse()?,
-            MicroAlgos(123_456),
-        )
-        .build(),
+    let t = Pay::new(
+        alice.address(),
+        env::var("BOB_ADDRESS")?.parse()?,
+        MicroAlgos(123_456),
     )
-    .build()?;
+    .build(&params)?;
 
     info!("signing transaction");
     let signed_transaction = alice.sign_transaction(t)?;

--- a/src/atomic_transaction_composer/mod.rs
+++ b/src/atomic_transaction_composer/mod.rs
@@ -12,10 +12,11 @@ use algonaut_algod::models::{
     PendingTransactionResponse, SimulateRequest, SimulateRequestTransactionGroup,
     SimulateTransaction200Response, TransactionParams200Response,
 };
-use algonaut_core::{Address, AppId, AssetId, CompiledTeal, MicroAlgos, TxId};
+use algonaut_core::{Address, AppId, AssetId, CompiledTeal, MicroAlgos, Round, TxId};
 use algonaut_crypto::HashDigest;
 use algonaut_transaction::{
-    SignedTransaction, Transaction, TransactionType, TxnBuilder,
+    SignedTransaction, Transaction, TransactionType,
+    builder::TransactionParams,
     error::TransactionError,
     transaction::{
         ApplicationCallOnComplete, ApplicationCallTransaction, BoxReference, StateSchema,
@@ -356,18 +357,19 @@ impl AtomicTransactionComposer {
             boxes: params.boxes.clone(),
         });
 
-        let mut tx_builder = TxnBuilder::with_fee(&params.suggested_params, params.fee, app_call);
-        if let Some(rekey_to) = params.rekey_to {
-            tx_builder = tx_builder.rekey_to(rekey_to);
-        }
-        if let Some(lease) = params.lease {
-            tx_builder = tx_builder.lease(lease);
-        }
-        if let Some(note) = params.note.clone() {
-            tx_builder = tx_builder.note(note);
-        }
-
-        let tx = tx_builder.build()?;
+        let sp = &params.suggested_params;
+        let tx = Transaction {
+            fee: params.fee,
+            first_valid: Round(sp.last_round()),
+            genesis_hash: sp.genesis_hash(),
+            last_valid: Round(sp.last_round() + 1000),
+            txn_type: app_call,
+            genesis_id: Some(sp.genesis_id().clone()),
+            group: None,
+            lease: params.lease,
+            note: params.note.clone(),
+            rekey_to: params.rekey_to,
+        };
 
         self.txs.append(&mut txs_with_signer);
         self.txs.push(TransactionWithSigner {

--- a/tests/step_defs/integration/abi.rs
+++ b/tests/step_defs/integration/abi.rs
@@ -14,7 +14,7 @@ use algonaut_abi::{
 use algonaut_algod::models::PendingTransactionResponse;
 use algonaut_core::{Address, AppId, MicroAlgos, TxId};
 use algonaut_transaction::{
-    Pay, TxnBuilder,
+    Pay,
     transaction::{ApplicationCallOnComplete, BoxReference, StateSchema},
 };
 use cucumber::{codegen::Regex, given, then, when};
@@ -80,9 +80,7 @@ async fn i_build_a_payment_transaction_with_sender_receiver_amount_close_remaind
         payment = payment.close_remainder_to(close_to);
     }
 
-    let tx = TxnBuilder::with(tx_params, payment.build())
-        .build()
-        .unwrap();
+    let tx = payment.build(tx_params).unwrap();
 
     w.tx = Some(tx);
 }
@@ -870,12 +868,9 @@ async fn i_fund_the_current_applications_address(w: &mut World, micro_algos: u64
 
     let tx_params = algod.txn_params().await.expect("couldn't get params");
 
-    let tx = TxnBuilder::with(
-        &tx_params,
-        Pay::new(first_account, app_address, MicroAlgos(micro_algos)).build(),
-    )
-    .build()
-    .unwrap();
+    let tx = Pay::new(first_account, app_address, MicroAlgos(micro_algos))
+        .build(&tx_params)
+        .unwrap();
 
     let signed_tx = kmd
         .sign_transaction(kmd_handle, kmd_pw, &tx)

--- a/tests/step_defs/integration/applications.rs
+++ b/tests/step_defs/integration/applications.rs
@@ -2,12 +2,12 @@ use crate::step_defs::integration::world::World;
 use crate::step_defs::util::{parse_app_args, read_teal, split_addresses, split_uint64};
 use algonaut_algod::models::{Application, ApplicationLocalState};
 use algonaut_core::{AppId, AssetId};
+use algonaut_transaction::CreateApplication;
 use algonaut_transaction::builder::{
     CallApplication, ClearApplication, CloseApplication, DeleteApplication, OptInApplication,
     UpdateApplication,
 };
 use algonaut_transaction::transaction::StateSchema;
-use algonaut_transaction::{CreateApplication, TxnBuilder};
 use cucumber::{given, then, when};
 use data_encoding::BASE64;
 use std::error::Error;
@@ -54,7 +54,7 @@ async fn i_build_an_application_transaction(
 
     let params = algod.txn_params().await?;
 
-    let tx_type = match operation.as_str() {
+    let tx = match operation.as_str() {
         "create" => {
             let approval_program = read_teal(algod, &approval_program_file).await;
             let clear_program = read_teal(algod, &clear_program_file).await;
@@ -75,7 +75,7 @@ async fn i_build_an_application_transaction(
             .accounts(accounts)
             .app_arguments(args)
             .extra_pages(extra_pages)
-            .build()
+            .build(&params)?
         }
         "update" => {
             let app_id = w.app_id.unwrap();
@@ -93,7 +93,7 @@ async fn i_build_an_application_transaction(
             .foreign_apps(foreign_apps)
             .accounts(accounts)
             .app_arguments(args)
-            .build()
+            .build(&params)?
         }
         "call" => {
             let app_id = w.app_id.unwrap();
@@ -102,7 +102,7 @@ async fn i_build_an_application_transaction(
                 .foreign_apps(foreign_apps)
                 .accounts(accounts)
                 .app_arguments(args)
-                .build()
+                .build(&params)?
         }
         "optin" => {
             let app_id = w.app_id.unwrap();
@@ -112,7 +112,7 @@ async fn i_build_an_application_transaction(
                 .foreign_apps(foreign_apps)
                 .accounts(accounts)
                 .app_arguments(args)
-                .build()
+                .build(&params)?
         }
         "clear" => {
             let app_id = w.app_id.unwrap();
@@ -121,7 +121,7 @@ async fn i_build_an_application_transaction(
                 .foreign_apps(foreign_apps)
                 .accounts(accounts)
                 .app_arguments(args)
-                .build()
+                .build(&params)?
         }
         "closeout" => {
             let app_id = w.app_id.unwrap();
@@ -130,7 +130,7 @@ async fn i_build_an_application_transaction(
                 .foreign_apps(foreign_apps)
                 .accounts(accounts)
                 .app_arguments(args)
-                .build()
+                .build(&params)?
         }
         "delete" => {
             let app_id = w.app_id.unwrap();
@@ -139,13 +139,13 @@ async fn i_build_an_application_transaction(
                 .foreign_apps(foreign_apps)
                 .accounts(accounts)
                 .app_arguments(args)
-                .build()
+                .build(&params)?
         }
 
         _ => Err(format!("Invalid str: {}", operation))?,
     };
 
-    w.tx = Some(TxnBuilder::with(&params, tx_type).build()?);
+    w.tx = Some(tx);
 
     Ok(())
 }

--- a/tests/step_defs/integration/assets.rs
+++ b/tests/step_defs/integration/assets.rs
@@ -3,7 +3,7 @@ use algonaut::error::Error;
 use algonaut_algod::models::AssetParams;
 use algonaut_core::{Address, AssetId, TxId};
 use algonaut_transaction::{
-    AcceptAsset, ClawbackAsset, CreateAsset, FreezeAsset, TransferAsset, TxnBuilder,
+    AcceptAsset, ClawbackAsset, CreateAsset, FreezeAsset, TransferAsset,
     builder::{DestroyAsset, UpdateAsset},
 };
 use cucumber::{given, then, when};
@@ -54,7 +54,7 @@ async fn build_creation(w: &mut World, total: u64, default_frozen: bool) -> Resu
     w.asset_second = Some(second);
 
     let params = algod.txn_params().await?;
-    let create = CreateAsset::new(creator, total, 0, default_frozen)
+    let tx = CreateAsset::new(creator, total, 0, default_frozen)
         .unit_name(UNIT_NAME.to_string())
         .asset_name(ASSET_NAME.to_string())
         .url(ASSET_URL.to_string())
@@ -63,9 +63,9 @@ async fn build_creation(w: &mut World, total: u64, default_frozen: bool) -> Resu
         .reserve(creator)
         .freeze(creator)
         .clawback(creator)
-        .build();
+        .build(&params)?;
 
-    w.tx = Some(TxnBuilder::with(&params, create).build()?);
+    w.tx = Some(tx);
 
     w.expected_asset_params = Some(AssetParams {
         creator: creator.to_string(),
@@ -184,8 +184,7 @@ async fn i_create_a_no_managers_asset_reconfigure_transaction(w: &mut World) -> 
     let creator = w.asset_creator.expect("asset creator not set");
     let asset_id = w.asset_id.expect("asset id not set");
     let params = algod.txn_params().await?;
-    let update = UpdateAsset::new(creator, asset_id).build();
-    w.tx = Some(TxnBuilder::with(&params, update).build()?);
+    w.tx = Some(UpdateAsset::new(creator, asset_id).build(&params)?);
     if let Some(exp) = w.expected_asset_params.as_mut() {
         exp.manager = None;
         exp.reserve = None;
@@ -201,8 +200,7 @@ async fn i_create_an_asset_destroy_transaction(w: &mut World) -> Result<(), Erro
     let creator = w.asset_creator.expect("asset creator not set");
     let asset_id = w.asset_id.expect("asset id not set");
     let params = algod.txn_params().await?;
-    let destroy = DestroyAsset::new(creator, asset_id).build();
-    w.tx = Some(TxnBuilder::with(&params, destroy).build()?);
+    w.tx = Some(DestroyAsset::new(creator, asset_id).build(&params)?);
     Ok(())
 }
 
@@ -224,8 +222,7 @@ async fn i_create_a_transaction_for_a_second_account_signalling_asset_acceptance
     let second = w.asset_second.expect("asset second account not set");
     let asset_id = w.asset_id.expect("asset id not set");
     let params = algod.txn_params().await?;
-    let optin = AcceptAsset::new(second, asset_id).build();
-    w.tx = Some(TxnBuilder::with(&params, optin).build()?);
+    w.tx = Some(AcceptAsset::new(second, asset_id).build(&params)?);
     Ok(())
 }
 
@@ -238,8 +235,7 @@ async fn i_create_transfer_creator_to_second(w: &mut World, amount: u64) -> Resu
     let second = w.asset_second.expect("asset second account not set");
     let asset_id = w.asset_id.expect("asset id not set");
     let params = algod.txn_params().await?;
-    let xfer = TransferAsset::new(creator, asset_id, amount, second).build();
-    w.tx = Some(TxnBuilder::with(&params, xfer).build()?);
+    w.tx = Some(TransferAsset::new(creator, asset_id, amount, second).build(&params)?);
     Ok(())
 }
 
@@ -252,8 +248,7 @@ async fn i_create_transfer_second_to_creator(w: &mut World, amount: u64) -> Resu
     let second = w.asset_second.expect("asset second account not set");
     let asset_id = w.asset_id.expect("asset id not set");
     let params = algod.txn_params().await?;
-    let xfer = TransferAsset::new(second, asset_id, amount, creator).build();
-    w.tx = Some(TxnBuilder::with(&params, xfer).build()?);
+    w.tx = Some(TransferAsset::new(second, asset_id, amount, creator).build(&params)?);
     Ok(())
 }
 
@@ -264,8 +259,7 @@ async fn i_create_revocation(w: &mut World, amount: u64) -> Result<(), Error> {
     let second = w.asset_second.expect("asset second account not set");
     let asset_id = w.asset_id.expect("asset id not set");
     let params = algod.txn_params().await?;
-    let clawback = ClawbackAsset::new(creator, asset_id, amount, second, creator).build();
-    w.tx = Some(TxnBuilder::with(&params, clawback).build()?);
+    w.tx = Some(ClawbackAsset::new(creator, asset_id, amount, second, creator).build(&params)?);
     Ok(())
 }
 
@@ -276,8 +270,7 @@ async fn i_create_a_freeze_transaction(w: &mut World) -> Result<(), Error> {
     let second = w.asset_second.expect("asset second account not set");
     let asset_id = w.asset_id.expect("asset id not set");
     let params = algod.txn_params().await?;
-    let freeze = FreezeAsset::new(creator, second, asset_id, true).build();
-    w.tx = Some(TxnBuilder::with(&params, freeze).build()?);
+    w.tx = Some(FreezeAsset::new(creator, second, asset_id, true).build(&params)?);
     Ok(())
 }
 
@@ -288,8 +281,7 @@ async fn i_create_an_unfreeze_transaction(w: &mut World) -> Result<(), Error> {
     let second = w.asset_second.expect("asset second account not set");
     let asset_id = w.asset_id.expect("asset id not set");
     let params = algod.txn_params().await?;
-    let unfreeze = FreezeAsset::new(creator, second, asset_id, false).build();
-    w.tx = Some(TxnBuilder::with(&params, unfreeze).build()?);
+    w.tx = Some(FreezeAsset::new(creator, second, asset_id, false).build(&params)?);
     Ok(())
 }
 

--- a/tests/step_defs/integration/dryrun.rs
+++ b/tests/step_defs/integration/dryrun.rs
@@ -3,9 +3,7 @@ use algonaut::dryrun::{DryrunRequestBuilder, field_name, result};
 use algonaut_algod::models::{Application, ApplicationParams, DryrunSource};
 use algonaut_core::{Address, AppId, CompiledTeal, MicroAlgos};
 use algonaut_encoding::Bytes;
-use algonaut_transaction::{
-    Pay, TxnBuilder, builder::TransactionParams, contract_account::ContractAccount,
-};
+use algonaut_transaction::{Pay, builder::TransactionParams, contract_account::ContractAccount};
 use cucumber::{given, then, when};
 use std::fs;
 
@@ -37,8 +35,8 @@ impl TransactionParams for DryrunParams {
 
 fn dummy_payment_txn(sender: Address) -> algonaut_transaction::Transaction {
     let params = DryrunParams;
-    TxnBuilder::with(&params, Pay::new(sender, sender, MicroAlgos(0)).build())
-        .build()
+    Pay::new(sender, sender, MicroAlgos(0))
+        .build(&params)
         .expect("building dummy payment")
 }
 
@@ -175,29 +173,10 @@ fn build_dryrun_test_case(program_path: &str, kind: &str) -> algonaut_algod::mod
 
             // Build an app-call txn referencing app id 1.
             let params = DryrunParams;
-            let txn = algonaut_transaction::TxnBuilder::with(
-                &params,
-                algonaut_transaction::transaction::TransactionType::ApplicationCallTransaction(
-                    algonaut_transaction::transaction::ApplicationCallTransaction {
-                        sender: creator,
-                        app_id: Some(AppId(DRYRUN_APP_ID)),
-                        on_complete:
-                            algonaut_transaction::transaction::ApplicationCallOnComplete::NoOp,
-                        accounts: None,
-                        approval_program: None,
-                        app_arguments: None,
-                        clear_state_program: None,
-                        foreign_apps: None,
-                        foreign_assets: None,
-                        global_state_schema: None,
-                        local_state_schema: None,
-                        extra_pages: 0,
-                        boxes: None,
-                    },
-                ),
-            )
-            .build()
-            .expect("app call txn");
+            let txn =
+                algonaut_transaction::builder::CallApplication::new(creator, AppId(DRYRUN_APP_ID))
+                    .build(&params)
+                    .expect("app call txn");
 
             // Sign as a no-op contract account (the dryrun endpoint does
             // not validate signatures).

--- a/tests/step_defs/integration/general.rs
+++ b/tests/step_defs/integration/general.rs
@@ -4,7 +4,7 @@ use crate::step_defs::{
 };
 use algonaut::{algod::v2::Algod, kmd::v1::Kmd};
 use algonaut_core::{Address, MicroAlgos, TxId};
-use algonaut_transaction::{Pay, TxnBuilder};
+use algonaut_transaction::Pay;
 use cucumber::{given, then, when};
 use rand::Rng;
 use std::error::Error;
@@ -132,16 +132,12 @@ async fn i_create_a_new_transient_account_and_fund_it_with_microalgos(
     let sender_account = account_from_kmd_response(&sender_key)?;
 
     let params = algod.txn_params().await?;
-    let tx = TxnBuilder::with(
-        &params,
-        Pay::new(
-            sender_address,
-            sender_account.address(),
-            MicroAlgos(micro_algos + dust),
-        )
-        .build(),
+    let tx = Pay::new(
+        sender_address,
+        sender_account.address(),
+        MicroAlgos(micro_algos + dust),
     )
-    .build()?;
+    .build(&params)?;
 
     let s_tx = sender_account.sign_transaction(tx)?;
 

--- a/tests/step_defs/integration/rekey.rs
+++ b/tests/step_defs/integration/rekey.rs
@@ -1,6 +1,6 @@
 use crate::step_defs::{integration::world::World, util::wait_for_pending_transaction};
 use algonaut_core::{Address, MicroAlgos, TxId};
-use algonaut_transaction::{Pay, TxnBuilder, account::Account};
+use algonaut_transaction::{Pay, account::Account};
 use cucumber::{given, when};
 use std::error::Error;
 
@@ -23,11 +23,7 @@ async fn i_generate_a_key_using_kmd_for_rekeying_and_fund_it(
     let funder_key = kmd.export_key(handle, password, &funder).await?;
     let funder_account = Account::from_seed(funder_key.private_key[0..32].try_into()?);
     let params = algod.txn_params().await?;
-    let tx = TxnBuilder::with(
-        &params,
-        Pay::new(funder, new_addr, MicroAlgos(10_000_000)).build(),
-    )
-    .build()?;
+    let tx = Pay::new(funder, new_addr, MicroAlgos(10_000_000)).build(&params)?;
     let signed = funder_account.sign_transaction(tx)?;
     let resp = algod.send_txn(&signed).await?;
     let tx_id: TxId = resp.tx_id.into();
@@ -52,14 +48,11 @@ async fn default_transaction_with_parameters_and_rekeying_key(
     } else {
         data_encoding::BASE64.decode(note_b64.as_bytes())?
     };
-    let mut builder = TxnBuilder::with(
-        &params,
-        Pay::new(rekey_target, accounts[1], MicroAlgos(amt)).build(),
-    );
+    let mut builder = Pay::new(rekey_target, accounts[1], MicroAlgos(amt));
     if !note.is_empty() {
         builder = builder.note(note.clone());
     }
-    w.tx = Some(builder.build()?);
+    w.tx = Some(builder.build(&params)?);
     w.note = Some(note);
     Ok(())
 }

--- a/tests/step_defs/integration/send.rs
+++ b/tests/step_defs/integration/send.rs
@@ -1,7 +1,7 @@
 use crate::step_defs::{integration::world::World, util::account_from_kmd_response};
 use algonaut_core::{MicroAlgos, MultisigAddress, Round, StateProofPk, TxId, VotePk, VrfPk};
 use algonaut_transaction::{
-    Pay, RegisterKey, SignedTransaction, TxnBuilder, transaction::TransactionSignature,
+    Pay, RegisterKey, SignedTransaction, transaction::TransactionSignature,
 };
 use cucumber::{given, then, when};
 use data_encoding::BASE64;
@@ -28,19 +28,15 @@ async fn build_default_payment(
         BASE64.decode(note_b64.as_bytes())?
     };
 
-    let mut tx_builder = TxnBuilder::with(
-        &params,
-        Pay::new(
-            accounts[sender_index],
-            accounts[receiver_index],
-            MicroAlgos(amt),
-        )
-        .build(),
+    let mut tx_builder = Pay::new(
+        accounts[sender_index],
+        accounts[receiver_index],
+        MicroAlgos(amt),
     );
     if !note.is_empty() {
         tx_builder = tx_builder.note(note.clone());
     }
-    w.tx = Some(tx_builder.build()?);
+    w.tx = Some(tx_builder.build(&params)?);
     w.note = Some(note);
     Ok(())
 }
@@ -72,14 +68,11 @@ async fn default_multisig_transaction_with_parameters(
         BASE64.decode(note_b64.as_bytes())?
     };
 
-    let mut tx_builder = TxnBuilder::with(
-        &params,
-        Pay::new(msig.address(), accounts[1], MicroAlgos(amt)).build(),
-    );
+    let mut tx_builder = Pay::new(msig.address(), accounts[1], MicroAlgos(amt));
     if !note.is_empty() {
         tx_builder = tx_builder.note(note.clone());
     }
-    w.tx = Some(tx_builder.build()?);
+    w.tx = Some(tx_builder.build(&params)?);
     w.note = Some(note);
     w.multisig = Some(msig);
     Ok(())
@@ -173,7 +166,7 @@ async fn default_v2_key_registration_transaction(
         other => return Err(format!("unknown keyreg variant: {other}").into()),
     };
 
-    w.tx = Some(TxnBuilder::with(&params, keyreg.build()).build()?);
+    w.tx = Some(keyreg.build(&params)?);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Second sub-PR of the type-safe-API roadmap (index ADR #284). Implements **D1**: every per-type transaction builder grows the six header setters and a single terminal `build(&params)`, retiring the outer `TxnBuilder`.

\`\`\`rust
// Was:
let t = TxnBuilder::with(
    &params,
    Pay::new(alice, bob, MicroAlgos(123_456)).build(),
)
.note(b"hello".to_vec())
.build()?;

// Now:
let t = Pay::new(alice, bob, MicroAlgos(123_456))
    .note(b"hello".to_vec())
    .build(&params)?;
\`\`\`

The same word (\`build\`) no longer means two different things, and the type-specific setters live in the same namespace as the header setters.

### How it works

- New \`TxnHeader { fee, note, lease, rekey_to, group, genesis_id }\` struct embedded in every builder.
- \`impl_txn_header_setters!(BuilderName)\` macro mints the six fluent setters as inherent methods (no trait import).
- \`TxnHeader::into_transaction(params, txn_type)\` (`pub(crate)`) finishes the construction, applying suggested params and the chosen fee.
- 16 builders get the uniform shape: \`Pay\`, \`RegisterKey\`, \`CreateAsset\`, \`UpdateAsset\`, \`DestroyAsset\`, \`TransferAsset\`, \`AcceptAsset\`, \`ClawbackAsset\`, \`FreezeAsset\`, \`CreateApplication\`, \`UpdateApplication\`, \`CallApplication\`, \`ClearApplication\`, \`CloseApplication\`, \`DeleteApplication\`, \`OptInApplication\`.

### Composer

\`AtomicTransactionComposer::add_method_call\` used \`TxnBuilder::with_fee\` directly. It now builds the \`Transaction\` inline (the struct's fields are \`pub\`), preserving the identical shape \`TxnHeader::into_transaction\` produces. The eventual cleanup of that path is **D6** (the \`MethodCall\` fluent builder), a separate sub-ADR.

### Migration

Mechanical, no migration shim. ~40 caller sites updated across \`examples/\` and \`tests/step_defs/\`.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo check --workspace --all-targets\` (\`RUSTFLAGS=-D warnings\`)
- [x] \`cargo check --target wasm32-unknown-unknown\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --lib --examples --tests\`
- [ ] Cucumber integration features pass on CI

## Refs

- Index ADR: #284 (\`docs/adr/ideal-type-safe-ergonomic-api.md\`)
- Sub-ADR added in this PR: \`docs/adr/one-build-per-transaction.md\`
- Previous sub-PR: #299 (D4 + D9)