### PR TITLE
feat(error): structured variants for composer failure modes (D8)

### DIFF
--- a/docs/adr/structured-errors.md
+++ b/docs/adr/structured-errors.md
@@ -1,0 +1,113 @@
+---
+id: structured-errors
+title: Structured error variants
+abstract: Promote the `Error::Msg("...")` sites that callers actually branch on into typed variants — `EmptyTransactionGroup`, `ComposerStatusInvalid`, `ComposerGroupFull`, `MissingReturnLog`, `MissingSourcemap`. Reserve `Msg` / `Internal` for the genuinely unstructured cases. Third sub-ADR addressing decision item D8 of the ideal-type-safe-ergonomic-api index.
+status: proposed
+date: 2026-05-20
+deciders: []
+tags: [api, errors, type-safety]
+---
+
+# Structured error variants
+
+## Status
+
+Proposed. Implements decision item **D8** of
+[`ideal-type-safe-ergonomic-api`](ideal-type-safe-ergonomic-api.md).
+
+## Context
+
+`Error` has two catch-all variants — `Msg(String)` and `Internal(String)` —
+and ~27 construction sites inside the workspace use them for failure modes
+that callers genuinely care about. `build_group()` reports an empty group
+as `Error::Msg("attempting to build group with zero transactions")`; the
+ABI step-def asserts on it by **substring match**
+(`tests/step_defs/integration/abi.rs:540`). A message reword silently
+breaks the test.
+
+The atomic-transaction-composer has the same pattern in five other places:
+- `"status must be BUILDING in order to add transactions"` (twice)
+- `"status is already committed"`
+- `"reached max group size: 16"` (twice)
+- `"App call transaction did not log a return value"` (twice exactly,
+  once with a `(2)` suffix)
+
+And `algod.teal_compile_with_sourcemap` reports a missing source-map as
+`Error::Msg("algod did not return a sourcemap")`.
+
+## Decision
+
+`Error` gains five variants for the failure modes callers actually branch on:
+
+```rust
+#[error("transaction group is empty")]
+EmptyTransactionGroup,
+
+#[error("composer status invalid: {0}")]
+ComposerStatusInvalid(String),     // operation + expected status, free-form
+
+#[error("composer group full (max {max} transactions)")]
+ComposerGroupFull { max: usize },
+
+#[error("app call transaction did not log a return value")]
+MissingReturnLog,
+
+#[error("algod did not return a sourcemap")]
+MissingSourcemap,
+```
+
+`Msg(String)` and `Internal(String)` stay for the genuinely unstructured
+cases (BASE64 decode errors, arg-type mismatches with rich `{:?}` debug
+formatting, the "should not happen" SDK-internal paths).
+
+The step-def that previously substring-matched on the empty-group
+message now matches the variant:
+
+```rust
+// Was:
+match build_res {
+    Err(Error::Msg(m)) if m == "attempting to build group with zero transactions" => {}
+    _ => panic!(...),
+}
+
+// Now:
+match build_res {
+    Err(Error::EmptyTransactionGroup) => {}
+    _ => panic!(...),
+}
+```
+
+### Why `ComposerStatusInvalid(String)` over `ComposerStatusInvalid { expected, actual }`?
+
+The three sites that hit this variant all carry slightly different
+metadata — `submit` knows "after a previous submit/execute", `execute`
+knows "after the composer is committed", `add_method_call` knows "must
+be Building". A single `expected: ComposerStatus` enum field would
+either lose that nuance or force a `Vec<ComposerStatus>` /
+`Option<ComposerStatus>` shape that's harder to read. The `String` body
+captures the contextual hint as a one-shot diagnostic; tests should
+match on the **variant**, not on its body.
+
+## Consequences
+
+- **Compile-error breaking change.** Any caller that pattern-matched on
+  `Error::Msg(...)` for one of the now-typed failure modes will fail to
+  compile until they switch to the variant. The exact-message
+  substring assertion in `tests/step_defs/integration/abi.rs` is the
+  one such caller in-tree; it's migrated in this PR.
+- **`Msg` and `Internal` aren't gone — they're reserved.** The
+  remaining ~22 sites use `Msg` for arg-type mismatches, BASE64
+  decode failures, and similar cases where the error body carries
+  data callers can't reasonably branch on. Those messages are still
+  free to reword without breaking anything.
+- **Test-side hygiene improves.** Substring-matching on English prose
+  is the failure mode this ADR sets out to remove; the migrated
+  step-def is the template for any future test that wants to assert
+  on an error.
+- **Out of scope.** The audit also surfaced ~14 abi-arg-validation
+  `Error::Msg(...)` sites (`"Invalid value type: {arg_value:?} for arg
+  type: {arg_type:?}"`, "incorrect number of arguments were provided",
+  etc.). Those are heavily formatted with `{:?}` debug values and no
+  caller branches on them today. They stay as `Msg` for now; a
+  follow-up sub-ADR can promote them to a typed `AbiArgError` family if
+  the need arises.

--- a/src/algod/v2/mod.rs
+++ b/src/algod/v2/mod.rs
@@ -589,9 +589,7 @@ impl Algod {
                 .await
                 .map_err(Into::<AlgodError>::into)?;
         let bytes = decode_base64(api_compiled_teal.result.as_bytes())?;
-        let raw = api_compiled_teal
-            .sourcemap
-            .ok_or_else(|| Error::Msg("algod did not return a sourcemap".to_string()))?;
+        let raw = api_compiled_teal.sourcemap.ok_or(Error::MissingSourcemap)?;
         let json = serde_json::to_string(&raw).map_err(|e| Error::Msg(e.to_string()))?;
         let map = algonaut_abi::sourcemap::SourceMap::from_json(&json)
             .map_err(|e| Error::Msg(e.to_string()))?;

--- a/src/atomic_transaction_composer/mod.rs
+++ b/src/atomic_transaction_composer/mod.rs
@@ -256,15 +256,15 @@ impl AtomicTransactionComposer {
     /// or if adding this transaction causes the current group to exceed MaxAtomicGroupSize.
     pub fn add_transaction(&mut self, txn_with_signer: TransactionWithSigner) -> Result<(), Error> {
         if self.status != AtomicTransactionComposerStatus::Building {
-            return Err(Error::Msg(
-                "status must be BUILDING in order to add transactions".to_owned(),
+            return Err(Error::ComposerStatusInvalid(
+                "add_transaction requires status=Building".to_owned(),
             ));
         }
 
         if self.len() == MAX_ATOMIC_GROUP_SIZE {
-            return Err(Error::Msg(format!(
-                "reached max group size: {MAX_ATOMIC_GROUP_SIZE}"
-            )));
+            return Err(Error::ComposerGroupFull {
+                max: MAX_ATOMIC_GROUP_SIZE,
+            });
         }
 
         validate_tx(&txn_with_signer.tx, TransactionArgType::Any)?;
@@ -276,8 +276,8 @@ impl AtomicTransactionComposer {
 
     pub fn add_method_call(&mut self, params: &mut AddMethodCallParams) -> Result<(), Error> {
         if self.status != AtomicTransactionComposerStatus::Building {
-            return Err(Error::Msg(
-                "status must be BUILDING in order to add transactions".to_owned(),
+            return Err(Error::ComposerStatusInvalid(
+                "add_method_call requires status=Building".to_owned(),
             ));
         }
         if params.method_args.len() != params.method.args.len() {
@@ -288,9 +288,9 @@ impl AtomicTransactionComposer {
             )));
         }
         if self.len() + params.method.get_tx_count() > MAX_ATOMIC_GROUP_SIZE {
-            return Err(Error::Msg(format!(
-                "reached max group size: {MAX_ATOMIC_GROUP_SIZE}"
-            )));
+            return Err(Error::ComposerGroupFull {
+                max: MAX_ATOMIC_GROUP_SIZE,
+            });
         }
 
         let mut method_types = vec![];
@@ -390,9 +390,7 @@ impl AtomicTransactionComposer {
         }
 
         if self.txs.is_empty() {
-            return Err(Error::Msg(
-                "should not build transaction group with 0 transactions in composer".to_owned(),
-            ));
+            return Err(Error::EmptyTransactionGroup);
         } else if self.txs.len() > 1 {
             let mut group_txs = vec![];
             for tx in self.txs.iter_mut() {
@@ -460,8 +458,8 @@ impl AtomicTransactionComposer {
 
     pub async fn submit(&mut self, algod: &Algod) -> Result<Vec<String>, Error> {
         if self.status >= AtomicTransactionComposerStatus::Submitted {
-            return Err(Error::Msg(
-                "Atomic Transaction Composer cannot submit committed transaction".to_owned(),
+            return Err(Error::ComposerStatusInvalid(
+                "submit cannot be called after a previous submit/execute".to_owned(),
             ));
         }
 
@@ -476,7 +474,9 @@ impl AtomicTransactionComposer {
 
     pub async fn execute(&mut self, algod: &Algod) -> Result<ExecuteResult, Error> {
         if self.status >= AtomicTransactionComposerStatus::Committed {
-            return Err(Error::Msg("status is already committed".to_owned()));
+            return Err(Error::ComposerStatusInvalid(
+                "execute cannot be called after the composer is committed".to_owned(),
+            ));
         }
 
         self.submit(algod).await?;
@@ -838,18 +838,14 @@ fn get_return_value_with_abi_type(
     abi_type: &AbiType,
 ) -> Result<Result<AbiMethodReturnValue, AbiReturnDecodeError>, Error> {
     if pending_tx.logs.is_none() {
-        return Err(Error::Msg(
-            "App call transaction did not log a return value".to_owned(),
-        ));
+        return Err(Error::MissingReturnLog);
     }
 
     // safe to unwrap given the previous check
     let logs = &pending_tx.logs.clone().unwrap();
 
     if logs.is_empty() {
-        return Err(Error::Msg(
-            "App call transaction did not log a return value".to_owned(),
-        ));
+        return Err(Error::MissingReturnLog);
     }
 
     let ret_line = &logs[logs.len() - 1];
@@ -859,9 +855,7 @@ fn get_return_value_with_abi_type(
         .map_err(|e| Error::Msg(format!("BASE64 Decoding error: {e:?}")))?;
 
     if !check_log_ret(&decoded_ret_line) {
-        return Err(Error::Msg(
-            "App call transaction did not log a return value(2)".to_owned(),
-        ));
+        return Err(Error::MissingReturnLog);
     }
 
     let abi_encoded = &decoded_ret_line[ABI_RETURN_HASH.len()..decoded_ret_line.len()];

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,37 @@ pub enum Error {
     #[error("http error: {0}")]
     Request(RequestError),
 
+    /// Tried to build / submit / execute a transaction group with zero
+    /// transactions in the [`AtomicTransactionComposer`]. Equivalent of
+    /// [`algonaut_transaction::error::TransactionError::EmptyTransactionListError`]
+    /// at the top-level error layer.
+    ///
+    /// [`AtomicTransactionComposer`]: crate::atomic_transaction_composer::AtomicTransactionComposer
+    #[error("transaction group is empty")]
+    EmptyTransactionGroup,
+    /// An [`AtomicTransactionComposer`] operation was attempted in the wrong
+    /// status. The original `String` captures the operation and expected
+    /// status for diagnostics; tests should match on the variant, not the
+    /// message.
+    ///
+    /// [`AtomicTransactionComposer`]: crate::atomic_transaction_composer::AtomicTransactionComposer
+    #[error("composer status invalid: {0}")]
+    ComposerStatusInvalid(String),
+    /// The [`AtomicTransactionComposer`] is at maximum capacity (16 txns by
+    /// protocol).
+    ///
+    /// [`AtomicTransactionComposer`]: crate::atomic_transaction_composer::AtomicTransactionComposer
+    #[error("composer group full (max {max} transactions)")]
+    ComposerGroupFull { max: usize },
+    /// An ABI method call returned but the application did not emit a
+    /// matching `log` entry, so the return value cannot be decoded.
+    #[error("app call transaction did not log a return value")]
+    MissingReturnLog,
+    /// `algod` was asked to compile TEAL with a source-map but the response
+    /// did not carry one.
+    #[error("algod did not return a sourcemap")]
+    MissingSourcemap,
+
     /// General text-only errors. Dedicated error variants can be created, if needed.
     #[error("Msg: {0}")]
     Msg(String),

--- a/tests/step_defs/integration/abi.rs
+++ b/tests/step_defs/integration/abi.rs
@@ -525,20 +525,11 @@ fn i_build_the_transaction_group_with_the_composer(w: &mut World, error_type: St
             // no error expected
             build_res.unwrap();
         }
-        "zero group size error" => {
-            let message = match build_res {
-                Ok(_) => None,
-                Err(e) => match e {
-                    algonaut::Error::Msg(m) => Some(m),
-                    _ => None,
-                },
-            };
-
-            match message.as_deref() {
-                Some("attempting to build group with zero transactions") => {}
-                _ => panic!("expected error, but got: {:?}", message),
-            }
-        }
+        "zero group size error" => match build_res {
+            Err(algonaut::Error::EmptyTransactionGroup) => {}
+            Err(other) => panic!("expected Error::EmptyTransactionGroup, got: {:?}", other),
+            Ok(_) => panic!("expected Error::EmptyTransactionGroup, got Ok"),
+        },
         _ => panic!("Unknown error type: {}", error_type),
     }
 }


### PR DESCRIPTION
## Summary

Third sub-PR of the type-safe-API roadmap (index ADR #284). Implements **D8**: promote the \`Error::Msg(\"...\")\` sites that callers genuinely branch on into typed variants.

### New variants

\`\`\`rust
EmptyTransactionGroup
ComposerStatusInvalid(String)
ComposerGroupFull { max: usize }
MissingReturnLog
MissingSourcemap
\`\`\`

\`Msg\` and \`Internal\` stay for the genuinely unstructured cases (BASE64 decode errors, arg-type mismatches with \`{:?}\` debug bodies).

### Test migration

\`tests/step_defs/integration/abi.rs\` previously substring-matched \`Error::Msg(\"attempting to build group with zero transactions\")\`. It now matches \`Error::EmptyTransactionGroup\` — a message reword can't silently break the test anymore.

### Independent of other Ds

This sub-PR opens against \`main\` and doesn't depend on D1/D3/D7/etc. Conflicts on merge will be in \`src/atomic_transaction_composer/mod.rs\` (shared with the D1 PR) and \`src/algod/v2/mod.rs\` (shared with everything that touches the algod wrapper); both are trivial three-way merges.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo check --workspace --all-targets\` (\`RUSTFLAGS=-D warnings\`)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --lib --examples --tests\`
- [ ] Cucumber integration features on CI

## Refs

- Index ADR: #284
- Sub-ADR added in this PR: \`docs/adr/structured-errors.md\`