### PR TITLE
feat(signer)!: async, group-aware Signer trait + external-signature ingress

### DIFF
--- a/algonaut_transaction/src/api_model.rs
+++ b/algonaut_transaction/src/api_model.rs
@@ -349,11 +349,21 @@ impl TryFrom<ApiSignedTransaction> for SignedTransaction {
     type Error = TransactionError;
 
     fn try_from(api_t: ApiSignedTransaction) -> Result<Self, Self::Error> {
+        let transaction: Transaction = api_t.transaction.clone().try_into()?;
+        // The wire format carries no `txid` (it is `#[serde(skip)]` on
+        // `ApiSignedTransaction`), so recompute the id from the decoded
+        // transaction instead of trusting the default-empty field. This
+        // keeps the D5 invariant — a `SignedTransaction`'s id is always
+        // the hash of its transaction — on the deserialize ingress that
+        // out-of-crate signers rely on (see the `external-signature-ingress`
+        // ADR). Preserve the decoded `sgnr` auth address rather than
+        // dropping it.
+        let transaction_id = transaction.id()?;
         Ok(SignedTransaction {
-            transaction: api_t.transaction.clone().try_into()?,
-            transaction_id: api_t.transaction_id.clone(),
+            transaction,
+            transaction_id,
             sig: transaction_signature(&api_t)?,
-            auth_address: None,
+            auth_address: api_t.auth_address,
         })
     }
 }
@@ -735,6 +745,58 @@ impl<'a> TryFrom<ApiBoxesInfo<'a, &ApiTransaction>> for Option<Vec<BoxReference>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::account::Account;
+    use crate::builder::{Pay, TransactionParams};
+    use algonaut_crypto::HashDigest;
+
+    struct StubParams {
+        genesis_id: String,
+    }
+
+    impl TransactionParams for StubParams {
+        fn last_round(&self) -> u64 {
+            1
+        }
+        fn min_fee(&self) -> u64 {
+            1_000
+        }
+        fn genesis_hash(&self) -> HashDigest {
+            HashDigest([0; 32])
+        }
+        fn genesis_id(&self) -> &String {
+            &self.genesis_id
+        }
+    }
+
+    /// The msgpack-deserialize path is the public ingress out-of-crate
+    /// signers use to turn signed bytes into a `SignedTransaction` (see the
+    /// `external-signature-ingress` ADR). It must recompute the id (the
+    /// wire format omits `txid`) and preserve the decoded `sgnr` rather
+    /// than dropping it — the two bugs that path previously had.
+    #[test]
+    fn signed_transaction_msgpack_round_trip_recomputes_id_and_keeps_auth_address() {
+        let params = StubParams {
+            genesis_id: "testnet-v1.0".to_owned(),
+        };
+        let alice = Account::generate();
+        let bob = Account::generate();
+
+        // Sender is alice but bob signs, so the signed transaction carries
+        // a rekey `auth_address` of bob.
+        let tx = Pay::new(alice.address(), alice.address(), MicroAlgos(1_000))
+            .build(&params)
+            .unwrap();
+        let signed = bob.sign_transaction(tx).unwrap();
+        assert_eq!(signed.auth_address(), Some(&bob.address()));
+        assert!(!signed.transaction_id().0.is_empty());
+
+        let bytes = signed.to_msg_pack().unwrap();
+        let round_tripped: SignedTransaction = rmp_serde::from_slice(&bytes).unwrap();
+
+        assert_eq!(round_tripped.transaction_id(), signed.transaction_id());
+        assert!(!round_tripped.transaction_id().0.is_empty());
+        assert_eq!(round_tripped.auth_address(), Some(&bob.address()));
+    }
 
     struct DummyAppCall {
         app_id: Option<AppId>,

--- a/algonaut_transaction/src/lib.rs
+++ b/algonaut_transaction/src/lib.rs
@@ -16,5 +16,6 @@ pub use builder::{
 };
 pub use signer::{
     InProgressMultisigSigningSession, MultisigSigner, MultisigSigningSession, Signer,
+    SigningFuture, SigningRequest,
 };
 pub use transaction::{SignedTransaction, Transaction, TransactionType, signed_transaction};

--- a/algonaut_transaction/src/signer.rs
+++ b/algonaut_transaction/src/signer.rs
@@ -12,6 +12,9 @@
 //! between multiple `TransactionWithSigner` values inside an atomic
 //! group.
 
+use std::future::Future;
+use std::pin::Pin;
+
 use algonaut_core::{MultisigAddress, MultisigSignature};
 
 use crate::account::Account;
@@ -19,48 +22,70 @@ use crate::contract_account::ContractAccount;
 use crate::error::TransactionError;
 use crate::transaction::{SignedTransaction, Transaction, TransactionSignature};
 
-/// Anything that can turn a slice of unsigned [`Transaction`]s into a
-/// matching `Vec<SignedTransaction>`. Implementors must be `Send +
-/// Sync` so the atomic transaction composer can hand them out across
-/// threads, and `Debug` so the composer keeps its derived `Debug` impl.
+/// The future returned by [`Signer::sign_transactions`].
+///
+/// Spelled out as an explicit boxed future rather than `async fn` in the
+/// trait so that `Signer` stays object safe (the composer stores signers
+/// behind `Arc<dyn Signer>`, and native `async fn` in traits is
+/// `dyn`-incompatible). The future is `Send` so that the composer's
+/// signing step stays `Send` on multi-threaded executors.
+pub type SigningFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<Vec<SignedTransaction>, TransactionError>> + Send + 'a>>;
+
+/// What a [`Signer`] is asked to sign: the whole group, plus the slots it
+/// owns.
+///
+/// `transactions` is the full, group-id-stamped array, so a remote wallet
+/// can display the entire atomic group; `indexes` are the positions in it
+/// this signer must produce signatures for. Group-awareness lets a
+/// WalletConnect-style signer sign every slot it controls in a single
+/// approval round-trip while still seeing the full context.
+pub struct SigningRequest<'a> {
+    /// The full group, after group ids have been assigned.
+    pub transactions: &'a [Transaction],
+    /// Positions in `transactions` this signer is expected to sign.
+    pub indexes: &'a [usize],
+}
+
+/// Anything that can sign the requested slots of an atomic group,
+/// possibly awaiting remote I/O or user approval. Implementors must be
+/// `Send + Sync` so the atomic transaction composer can hand them out
+/// across threads, and `Debug` so the composer keeps its derived `Debug`
+/// impl.
 pub trait Signer: std::fmt::Debug + Send + Sync {
-    /// Sign every transaction in `txs`, returning one
-    /// [`SignedTransaction`] per input in the same order. Implementors
-    /// should return an error if any single transaction can't be signed
-    /// rather than producing a partial result.
-    fn sign_transactions(
-        &self,
-        txs: &[Transaction],
-    ) -> Result<Vec<SignedTransaction>, TransactionError>;
+    /// Sign the slots named by `request.indexes`, returning one
+    /// [`SignedTransaction`] per requested index, in `request.indexes`
+    /// order. Implementors should return an error if any requested
+    /// transaction can't be signed rather than producing a partial
+    /// result.
+    fn sign_transactions<'a>(&'a self, request: SigningRequest<'a>) -> SigningFuture<'a>;
 }
 
 impl Signer for Account {
-    fn sign_transactions(
-        &self,
-        txs: &[Transaction],
-    ) -> Result<Vec<SignedTransaction>, TransactionError> {
-        let mut signed = Vec::with_capacity(txs.len());
-        for tx in txs {
-            signed.push(self.sign_transaction(tx.clone())?);
-        }
-        Ok(signed)
+    fn sign_transactions<'a>(&'a self, request: SigningRequest<'a>) -> SigningFuture<'a> {
+        Box::pin(async move {
+            request
+                .indexes
+                .iter()
+                .map(|&i| self.sign_transaction(request.transactions[i].clone()))
+                .collect()
+        })
     }
 }
 
 impl Signer for ContractAccount {
-    fn sign_transactions(
-        &self,
-        txs: &[Transaction],
-    ) -> Result<Vec<SignedTransaction>, TransactionError> {
-        let mut signed = Vec::with_capacity(txs.len());
-        for tx in txs {
-            // The previous `TransactionSigner::ContractAccount` enum
-            // variant always signed with an empty program-args list.
-            // Callers that need non-empty args should call
-            // `ContractAccount::sign` directly.
-            signed.push(self.sign(tx.clone(), vec![])?);
-        }
-        Ok(signed)
+    fn sign_transactions<'a>(&'a self, request: SigningRequest<'a>) -> SigningFuture<'a> {
+        Box::pin(async move {
+            request
+                .indexes
+                .iter()
+                // The previous `TransactionSigner::ContractAccount` enum
+                // variant always signed with an empty program-args list.
+                // Callers that need non-empty args should call
+                // `ContractAccount::sign` directly.
+                .map(|&i| self.sign(request.transactions[i].clone(), vec![]))
+                .collect()
+        })
     }
 }
 
@@ -84,15 +109,20 @@ impl MultisigSigner {
 }
 
 impl Signer for MultisigSigner {
-    fn sign_transactions(
-        &self,
-        txs: &[Transaction],
-    ) -> Result<Vec<SignedTransaction>, TransactionError> {
-        let mut signed = Vec::with_capacity(txs.len());
-        for tx in txs {
-            signed.push(sign_msig_tx(&self.address, &self.accounts, tx.clone())?);
-        }
-        Ok(signed)
+    fn sign_transactions<'a>(&'a self, request: SigningRequest<'a>) -> SigningFuture<'a> {
+        Box::pin(async move {
+            request
+                .indexes
+                .iter()
+                .map(|&i| {
+                    sign_msig_tx(
+                        &self.address,
+                        &self.accounts,
+                        request.transactions[i].clone(),
+                    )
+                })
+                .collect()
+        })
     }
 }
 

--- a/docs/adr/async-signer-trait.md
+++ b/docs/adr/async-signer-trait.md
@@ -2,7 +2,7 @@
 id: async-signer-trait
 title: Async signer trait for remote and interactive signing
 abstract: Replace the synchronous Signer contract with an async, group-aware Signer so WalletConnect and custodial/KMS flows can await approval or I/O.
-status: proposed
+status: accepted
 date: 2026-05-21
 deciders: []
 tags: [api, async, signing]
@@ -12,7 +12,7 @@ tags: [api, async, signing]
 
 ## Status
 
-Proposed. Follow-up to [`signer-trait`](signer-trait.md) and the
+Accepted. Follow-up to [`signer-trait`](signer-trait.md) and the
 async-signer out-of-scope note in
 [`atomic-transaction-composer-typestate`](atomic-transaction-composer-typestate.md).
 Depends on [`external-signature-ingress`](external-signature-ingress.md) for

--- a/docs/adr/async-signer-trait.md
+++ b/docs/adr/async-signer-trait.md
@@ -185,10 +185,14 @@ pub struct TransactionWithSigner {
 }
 ```
 
-`None` keeps the D7 meaning: an unsigned simulate-only slot that the
-composer fills with the all-zero placeholder signature. The constructor
-shape can stay the same, but all implementations behind the trait use
-the new async contract.
+`None` marks a **simulate-only** slot. It no longer doubles as a "sign
+me with a placeholder" instruction: signing produces a group meant for
+submit/execute, and an all-zero placeholder is not a submittable
+signature, so `sign()` rejects a `None` slot (a `MissingSigner` error)
+rather than emitting one. Placeholder signing now lives only on the
+simulate path (see below), which placeholder-signs every slot regardless
+of its signer. The constructor shape can stay the same, but all
+implementations behind the trait use the new async contract.
 
 `MethodCall::new(...)` also keeps taking `Arc<dyn Signer>`. The breaking
 change is borne by signer implementations and by callers that execute
@@ -210,7 +214,9 @@ The async signing flow is:
 1. Build the full, group-id-stamped transaction array.
 2. Group slot indexes by signer **identity** — `Arc::ptr_eq` on the
    `Arc<dyn Signer>` — so every slot a given signer instance owns is
-   collected into one request and signed in one call.
+   collected into one request and signed in one call. A slot with no
+   signer is a `MissingSigner` error: an unsigned slot cannot produce a
+   submittable signature, and it is valid only for simulate.
 3. Call `Signer::sign_transactions(SigningRequest { transactions,
    indexes })` and await the result.
 4. Validate the result against the request: exactly one signed
@@ -221,8 +227,7 @@ The async signing flow is:
    transaction for the *wrong* transaction is the case this guards
    against. How a signer constructs those values is decided in
    [`external-signature-ingress`](external-signature-ingress.md).
-5. Reassemble the signed group in original transaction order; fill
-   `None` slots with the existing all-zero placeholder used by simulate.
+5. Reassemble the signed group in original transaction order.
 
 **Grouping by `Arc::ptr_eq` is deliberate, and has a caller-visible
 consequence.** The trait exposes no address or key identity — multisig and
@@ -253,10 +258,11 @@ one-group flow.
 
 So simulate does **not** call `Signer::sign_transactions`. It signs every
 slot — `Some(signer)` and `None` alike — with the all-zero placeholder
-signature (the same mechanism the `None` slots already use), setting
-algod's allow-empty-signatures option as needed, and never awaits a real
-signer. Simulate stays cheap and prompt-free; only `sign()` and the
-`execute` path that follows it exercise real signers. A caller that
+signature, setting algod's allow-empty-signatures option as needed, and
+never awaits a real signer. This placeholder path is simulate's alone:
+`sign()` no longer placeholder-signs anything (a `None` slot there is a
+`MissingSigner` error). Simulate stays cheap and prompt-free; only
+`sign()` and the `execute` path that follows it exercise real signers. A caller that
 specifically needs to simulate the *actually-signed* group can
 `sign().await?` first and simulate the signed group — but that is the
 explicit, prompt-incurring choice, not the default. This is a behavioral
@@ -316,6 +322,13 @@ transaction it didn't ask for.
   placeholder signature, even for slots that carry a real signer, so a
   dry-run never prompts a wallet. This is a behavioral change from the
   pre-async composer, which signed `Some(signer)` slots during simulate.
+- **`sign()` rejects unsigned slots.** A `None`-signer slot
+  (`TransactionWithSigner::unsigned`) is a `MissingSigner` error at
+  `sign()` instead of being silently placeholder-signed into an
+  unsubmittable group. Placeholder signing belongs to simulate alone.
+  Pre-async, `sign()` and simulate shared one signing routine, so a
+  `None` slot quietly produced a placeholder; now that simulate has its
+  own all-placeholder path, that behavior was a footgun and is removed.
 - **The `Send` bound excludes `!Send` wasm signers for now.** Native
   multi-threaded executors get a `Send` composer; a single-threaded
   browser WalletConnect signer needs the deferred `?Send` variant. The

--- a/docs/adr/external-signature-ingress.md
+++ b/docs/adr/external-signature-ingress.md
@@ -2,7 +2,7 @@
 id: external-signature-ingress
 title: Constructing SignedTransaction from an external signature
 abstract: Bless and correct the existing msgpack-deserialize path as the single public ingress by which an out-of-crate signer turns externally-produced signed bytes into a SignedTransaction. Recompute transaction_id from the decoded transaction and preserve the decoded sgnr, fixing a path that today yields an empty id and drops the rekey auth address. Add no new public constructor — the fix reopens nothing D5 closed and matches how reference SDKs return signed transactions as bytes.
-status: proposed
+status: accepted
 date: 2026-05-21
 deciders: []
 tags: [api, signing, type-safety]
@@ -12,7 +12,7 @@ tags: [api, signing, type-safety]
 
 ## Status
 
-Proposed. Amends [`closed-signed-transaction`](closed-signed-transaction.md)
+Accepted. Amends [`closed-signed-transaction`](closed-signed-transaction.md)
 (**D5**) and builds on [`signer-trait`](signer-trait.md) (**D7**).
 Prerequisite for [`async-signer-trait`](async-signer-trait.md): that ADR's
 remote signers cannot produce their return value without the ingress

--- a/examples/app_call.rs
+++ b/examples/app_call.rs
@@ -47,7 +47,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let result = AtomicGroupBuilder::new()
         .add_method_call(call)
         .build()?
-        .sign()?
+        .sign()
+        .await?
         .execute(&algod)
         .await?;
     info!("confirmed in round {:?}", result.confirmed_round);

--- a/examples/atomic_transaction_composer.rs
+++ b/examples/atomic_transaction_composer.rs
@@ -91,10 +91,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
 
     // Sign every transaction with its own signer, then submit and wait for
-    // confirmation. (For fire-and-forget, `unsigned.sign()?.submit(&algod)`
+    // confirmation. (For fire-and-forget, `unsigned.sign().await?.submit(&algod)`
     // returns a `PendingSubmission` handle you can `.confirm()` later.)
     info!("signing and executing the group");
-    let outcome = unsigned.sign()?.execute(&algod).await?;
+    let outcome = unsigned.sign().await?.execute(&algod).await?;
     info!("group confirmed in round {:?}", outcome.confirmed_round);
     for (i, result) in outcome.method_results.iter().enumerate() {
         info!("method call {i} returned: {:?}", result.return_value);

--- a/src/atomic_transaction_composer/mod.rs
+++ b/src/atomic_transaction_composer/mod.rs
@@ -76,19 +76,21 @@ const MAX_ABI_ARG_TYPE_LEN: usize = 15;
 
 const FOREIGN_OBJ_ABI_UINT_SIZE: usize = 8;
 
-/// Represents an unsigned transactions and a signer that can authorize that transaction.
+/// Represents an unsigned transaction and a signer that can authorize that transaction.
 ///
-/// `signer` is optional: when `None`, signing produces a placeholder
-/// `SignedTransaction` whose signature is the all-zero 64-byte sentinel.
-/// That mirrors the old `TransactionSigner::Empty` enum variant and is
-/// useful for the `/v2/transactions/simulate` "allow-empty-signatures =
-/// false" scenarios; never use it against the live submit endpoint.
+/// `signer` is optional. `None` marks a **simulate-only** slot: it has no
+/// signer, so [`UnsignedAtomicGroup::sign`] rejects it with
+/// [`Error::MissingSigner`], but
+/// [`simulate`](UnsignedAtomicGroup::simulate) accepts it (simulate
+/// placeholder-signs every slot and asks algod to allow empty
+/// signatures). Use it to dry-run a transaction you cannot sign — e.g.
+/// one sent from an account you do not control.
 #[derive(Debug, Clone)]
 pub struct TransactionWithSigner {
     /// An unsigned transaction
     pub tx: Transaction,
     /// A transaction signer that can authorize the transaction, or
-    /// `None` for an unsigned simulate slot.
+    /// `None` for a simulate-only slot.
     pub signer: Option<Arc<dyn Signer>>,
 }
 
@@ -102,9 +104,10 @@ impl TransactionWithSigner {
         }
     }
 
-    /// Build a `TransactionWithSigner` that has no real signer
-    /// attached. Signing fills the corresponding slot with an all-zero
-    /// placeholder signature — only safe for simulate.
+    /// Build a `TransactionWithSigner` with no signer attached, for
+    /// **simulate only**. [`UnsignedAtomicGroup::sign`] rejects a group
+    /// containing such a slot ([`Error::MissingSigner`]); only
+    /// [`simulate`](UnsignedAtomicGroup::simulate) accepts it.
     pub fn unsigned(tx: Transaction) -> Self {
         Self { tx, signer: None }
     }
@@ -285,13 +288,19 @@ impl UnsignedAtomicGroup {
     }
 
     /// Sign every transaction with its attached signer, advancing to the
-    /// [`SignedAtomicGroup`] state. Transactions whose signer is `None` get an
-    /// all-zero placeholder signature (simulate-only).
+    /// [`SignedAtomicGroup`] state.
     ///
     /// This is `async`: signers may await user approval (WalletConnect) or
     /// remote I/O (custodial/KMS). Each distinct signer is asked to sign
     /// all of the slots it owns in a single call, so an interactive wallet
     /// prompts once for the whole group.
+    ///
+    /// Every slot must have a signer. A slot with no signer
+    /// ([`TransactionWithSigner::unsigned`]) is an
+    /// [`Error::MissingSigner`]: it cannot produce a submittable
+    /// signature, and the resulting group is meant for `submit`/`execute`.
+    /// Unsigned slots are only valid for
+    /// [`simulate`](Self::simulate)/[`simulate_with`](Self::simulate_with).
     pub async fn sign(self) -> Result<SignedAtomicGroup, Error> {
         let signed_txs = sign_group(&self.txs).await?;
         Ok(SignedAtomicGroup {
@@ -448,8 +457,13 @@ impl SignedAtomicGroup {
 /// wallet. Each signer sees the whole group via
 /// [`SigningRequest::transactions`] but signs only its
 /// [`indexes`](SigningRequest::indexes). Output is validated against the
-/// request and reassembled into original group order; `None`-signer slots
-/// get the all-zero placeholder signature (simulate-only).
+/// request and reassembled into original group order.
+///
+/// Every slot must have a signer: a `None`-signer slot
+/// ([`TransactionWithSigner::unsigned`]) cannot produce a submittable
+/// signature, so it is an [`Error::MissingSigner`] here. Unsigned slots
+/// are only valid for [`simulate`](UnsignedAtomicGroup::simulate), which
+/// uses [`placeholder_group`] instead.
 async fn sign_group(txs: &[TransactionWithSigner]) -> Result<Vec<SignedTransaction>, Error> {
     let all_txs: Vec<Transaction> = txs.iter().map(|t| t.tx.clone()).collect();
     let mut signed: Vec<Option<SignedTransaction>> = (0..txs.len()).map(|_| None).collect();
@@ -463,14 +477,10 @@ async fn sign_group(txs: &[TransactionWithSigner]) -> Result<Vec<SignedTransacti
                 Some((_, indexes)) => indexes.push(i),
                 None => groups.push((Arc::clone(signer), vec![i])),
             },
-            None => {
-                // Mirrors the old `TransactionSigner::Empty` variant:
-                // produce a placeholder `SignedTransaction` whose 64-byte
-                // signature is all zeros. Algod's simulator detects this
-                // as a missing signature; never submit it to the live
-                // endpoint.
-                signed[i] = Some(signed_transaction::placeholder(tx_with_signer.tx.clone())?);
-            }
+            // An unsigned slot has no signature to produce. Signing is the
+            // path to a submittable group, so reject it here rather than
+            // emitting an all-zero placeholder that algod would refuse.
+            None => return Err(Error::MissingSigner { index: i }),
         }
     }
 
@@ -1039,6 +1049,28 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, Error::SignerOutputInvalid { .. }));
+    }
+
+    /// Signing a group that contains an unsigned (simulate-only) slot is
+    /// rejected: an unsigned slot cannot produce a submittable signature.
+    #[tokio::test]
+    async fn sign_rejects_unsigned_slot() {
+        let alice = Account::generate();
+        let bob = Account::generate();
+
+        let err = AtomicGroupBuilder::new()
+            .add_transaction(TransactionWithSigner::new(
+                pay(&alice, bob.address()),
+                Arc::new(alice.clone()),
+            ))
+            .add_transaction(TransactionWithSigner::unsigned(pay(&bob, alice.address())))
+            .build()
+            .unwrap()
+            .sign()
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::MissingSigner { index: 1 }));
     }
 
     /// Signing a built group whose transactions are authorized by

--- a/src/atomic_transaction_composer/mod.rs
+++ b/src/atomic_transaction_composer/mod.rs
@@ -12,7 +12,7 @@ use algonaut_algod::models::{
 };
 use algonaut_core::{Address, AppId, AssetId, Round, TxId};
 use algonaut_transaction::{
-    SignedTransaction, Signer, Transaction, TransactionType,
+    SignedTransaction, Signer, SigningRequest, Transaction, TransactionType,
     builder::TransactionParams,
     signed_transaction,
     transaction::{ApplicationCallTransaction, to_tx_type_enum},
@@ -287,8 +287,13 @@ impl UnsignedAtomicGroup {
     /// Sign every transaction with its attached signer, advancing to the
     /// [`SignedAtomicGroup`] state. Transactions whose signer is `None` get an
     /// all-zero placeholder signature (simulate-only).
-    pub fn sign(self) -> Result<SignedAtomicGroup, Error> {
-        let signed_txs = sign_group(&self.txs)?;
+    ///
+    /// This is `async`: signers may await user approval (WalletConnect) or
+    /// remote I/O (custodial/KMS). Each distinct signer is asked to sign
+    /// all of the slots it owns in a single call, so an interactive wallet
+    /// prompts once for the whole group.
+    pub async fn sign(self) -> Result<SignedAtomicGroup, Error> {
+        let signed_txs = sign_group(&self.txs).await?;
         Ok(SignedAtomicGroup {
             signed_txs,
             method_map: self.method_map,
@@ -309,17 +314,24 @@ impl UnsignedAtomicGroup {
     /// toggle the power-pack fields (extra opcode budget,
     /// allow-more-logging, exec-trace-config, etc.).
     ///
-    /// The request's `txn_groups` is ignored; this method always
-    /// substitutes the group's own (placeholder-)signed transactions.
-    /// Any other field on the request is forwarded as given.
+    /// Simulate never invokes the real signers: it signs every slot with
+    /// the all-zero placeholder signature and asks algod to allow empty
+    /// signatures, so dry-running a group that carries an interactive
+    /// signer (e.g. WalletConnect) never pops an approval prompt. To
+    /// simulate the actually-signed group, [`sign`](Self::sign) it first
+    /// and simulate that.
+    ///
+    /// The request's `txn_groups` and `allow_empty_signatures` are
+    /// overwritten; any other field is forwarded as given.
     pub async fn simulate_with(
         &self,
         algod: &Algod,
         mut request: SimulateRequest,
     ) -> Result<SimulateOutcome, Error> {
-        let signed_txs = sign_group(&self.txs)?;
+        let signed_txs = placeholder_group(&self.txs)?;
 
         request.txn_groups = vec![SimulateRequestTransactionGroup::new(signed_txs.clone())];
+        request.allow_empty_signatures = Some(true);
 
         let response: SimulateTransaction200Response = algod.simulate_txns(request).await?;
 
@@ -428,32 +440,94 @@ impl SignedAtomicGroup {
     }
 }
 
-/// Sign every transaction in `txs` with its own signer, one input at a
-/// time, so the signed group keeps input order regardless of how many
-/// distinct signers are involved. Transactions whose signer is `None`
-/// get an all-zero placeholder signature (simulate-only).
-fn sign_group(txs: &[TransactionWithSigner]) -> Result<Vec<SignedTransaction>, Error> {
-    let mut signed_txs = Vec::with_capacity(txs.len());
-    for tx_with_signer in txs {
-        let signed = match &tx_with_signer.signer {
-            Some(signer) => {
-                let one = [tx_with_signer.tx.clone()];
-                signer.sign_transactions(&one)?.pop().ok_or_else(|| {
-                    Error::Internal("signer returned no signed transactions".to_owned())
-                })?
-            }
+/// Sign the group with its attached signers, awaiting each one.
+///
+/// Slots are grouped by signer **identity** (`Arc::ptr_eq`) so every slot
+/// a given signer instance owns is signed in a single
+/// [`Signer::sign_transactions`] call — one approval round-trip per
+/// wallet. Each signer sees the whole group via
+/// [`SigningRequest::transactions`] but signs only its
+/// [`indexes`](SigningRequest::indexes). Output is validated against the
+/// request and reassembled into original group order; `None`-signer slots
+/// get the all-zero placeholder signature (simulate-only).
+async fn sign_group(txs: &[TransactionWithSigner]) -> Result<Vec<SignedTransaction>, Error> {
+    let all_txs: Vec<Transaction> = txs.iter().map(|t| t.tx.clone()).collect();
+    let mut signed: Vec<Option<SignedTransaction>> = (0..txs.len()).map(|_| None).collect();
+
+    // Group slot indexes by signer identity, preserving first-appearance
+    // order so any approval prompts happen in a deterministic order.
+    let mut groups: Vec<(Arc<dyn Signer>, Vec<usize>)> = Vec::new();
+    for (i, tx_with_signer) in txs.iter().enumerate() {
+        match &tx_with_signer.signer {
+            Some(signer) => match groups.iter_mut().find(|(s, _)| Arc::ptr_eq(s, signer)) {
+                Some((_, indexes)) => indexes.push(i),
+                None => groups.push((Arc::clone(signer), vec![i])),
+            },
             None => {
                 // Mirrors the old `TransactionSigner::Empty` variant:
                 // produce a placeholder `SignedTransaction` whose 64-byte
                 // signature is all zeros. Algod's simulator detects this
                 // as a missing signature; never submit it to the live
                 // endpoint.
-                signed_transaction::placeholder(tx_with_signer.tx.clone())?
+                signed[i] = Some(signed_transaction::placeholder(tx_with_signer.tx.clone())?);
             }
-        };
-        signed_txs.push(signed);
+        }
     }
-    Ok(signed_txs)
+
+    for (signer, indexes) in &groups {
+        let request = SigningRequest {
+            transactions: &all_txs,
+            indexes,
+        };
+        let result = signer.sign_transactions(request).await?;
+
+        if result.len() != indexes.len() {
+            return Err(Error::SignerOutputInvalid {
+                reason: format!(
+                    "signer returned {} signed transaction(s) for {} requested",
+                    result.len(),
+                    indexes.len()
+                ),
+            });
+        }
+
+        // Each returned transaction must wrap the transaction we asked the
+        // signer to sign, in `indexes` order — this catches a signer that
+        // returns a valid signature for the wrong transaction (or returns
+        // them out of order).
+        for (&index, signed_tx) in indexes.iter().zip(result) {
+            let expected_id = all_txs[index].id()?;
+            if signed_tx.transaction_id() != &expected_id {
+                return Err(Error::SignerOutputInvalid {
+                    reason: format!(
+                        "signer returned a signature for an unexpected transaction at index {index}"
+                    ),
+                });
+            }
+            signed[index] = Some(signed_tx);
+        }
+    }
+
+    signed
+        .into_iter()
+        .enumerate()
+        .map(|(i, slot)| {
+            slot.ok_or_else(|| {
+                Error::Internal(format!(
+                    "no signature produced for transaction at index {i}"
+                ))
+            })
+        })
+        .collect()
+}
+
+/// Sign every slot with the all-zero placeholder signature, ignoring the
+/// attached signers entirely. Used by the simulate path so a dry-run
+/// never invokes a real (possibly interactive) signer.
+fn placeholder_group(txs: &[TransactionWithSigner]) -> Result<Vec<SignedTransaction>, Error> {
+    txs.iter()
+        .map(|t| signed_transaction::placeholder(t.tx.clone()).map_err(Error::from))
+        .collect()
 }
 
 /// Collect the base32 transaction ids of a signed group, in order.
@@ -815,8 +889,10 @@ mod tests {
     use super::*;
     use algonaut_core::MicroAlgos;
     use algonaut_crypto::HashDigest;
+    use algonaut_transaction::SigningFuture;
     use algonaut_transaction::account::Account;
     use algonaut_transaction::builder::{Pay, TransactionParams};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     struct StubParams {
         genesis_id: String,
@@ -846,11 +922,130 @@ mod tests {
             .expect("failed to build payment transaction")
     }
 
+    /// Wraps an [`Account`] and counts how many times the composer calls
+    /// it, so a test can assert that slots sharing one `Arc` are signed in
+    /// a single request.
+    #[derive(Debug)]
+    struct CountingSigner {
+        inner: Account,
+        calls: AtomicUsize,
+    }
+
+    impl Signer for CountingSigner {
+        fn sign_transactions<'a>(&'a self, request: SigningRequest<'a>) -> SigningFuture<'a> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async move {
+                request
+                    .indexes
+                    .iter()
+                    .map(|&i| self.inner.sign_transaction(request.transactions[i].clone()))
+                    .collect()
+            })
+        }
+    }
+
+    /// Returns a fixed, caller-supplied output regardless of the request —
+    /// used to drive the composer's signer-output validation.
+    #[derive(Debug)]
+    struct CannedSigner {
+        output: Vec<SignedTransaction>,
+    }
+
+    impl Signer for CannedSigner {
+        fn sign_transactions<'a>(&'a self, _request: SigningRequest<'a>) -> SigningFuture<'a> {
+            let output = self.output.clone();
+            Box::pin(async move { Ok(output) })
+        }
+    }
+
+    /// Two slots that share one `Arc<dyn Signer>` are grouped by identity
+    /// and signed in a single call — one approval round-trip per wallet.
+    #[tokio::test]
+    async fn sign_groups_slots_sharing_one_signer_into_one_call() {
+        let alice = Account::generate();
+        let bob = Account::generate();
+        let signer = Arc::new(CountingSigner {
+            inner: alice.clone(),
+            calls: AtomicUsize::new(0),
+        });
+
+        let signed = AtomicGroupBuilder::new()
+            .add_transaction(TransactionWithSigner::new(
+                pay(&alice, bob.address()),
+                signer.clone(),
+            ))
+            .add_transaction(TransactionWithSigner::new(
+                pay(&alice, alice.address()),
+                signer.clone(),
+            ))
+            .build()
+            .unwrap()
+            .sign()
+            .await
+            .unwrap();
+
+        assert_eq!(signed.signed_transactions().len(), 2);
+        assert_eq!(
+            signer.calls.load(Ordering::SeqCst),
+            1,
+            "slots sharing one signer instance must be signed in a single call"
+        );
+    }
+
+    /// A signer that returns a signature for a transaction other than the
+    /// one requested is rejected, not submitted.
+    #[tokio::test]
+    async fn sign_rejects_signer_returning_wrong_transaction() {
+        let alice = Account::generate();
+        let bob = Account::generate();
+        // A signed transaction over an unrelated transaction.
+        let decoy = bob.sign_transaction(pay(&bob, alice.address())).unwrap();
+        let signer = Arc::new(CannedSigner {
+            output: vec![decoy],
+        });
+
+        let err = AtomicGroupBuilder::new()
+            .add_transaction(TransactionWithSigner::new(
+                pay(&alice, bob.address()),
+                signer,
+            ))
+            .build()
+            .unwrap()
+            .sign()
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::SignerOutputInvalid { .. }));
+    }
+
+    /// A signer that returns the wrong number of signed transactions is
+    /// rejected.
+    #[tokio::test]
+    async fn sign_rejects_signer_returning_wrong_count() {
+        let alice = Account::generate();
+        let bob = Account::generate();
+        // Asked to sign one slot, returns none.
+        let signer = Arc::new(CannedSigner { output: vec![] });
+
+        let err = AtomicGroupBuilder::new()
+            .add_transaction(TransactionWithSigner::new(
+                pay(&alice, bob.address()),
+                signer,
+            ))
+            .build()
+            .unwrap()
+            .sign()
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::SignerOutputInvalid { .. }));
+    }
+
     /// Signing a built group whose transactions are authorized by
     /// *different* signers must yield exactly one signed transaction per
     /// input, in input order.
-    #[test]
-    fn sign_signs_every_tx_with_distinct_signers() {
+    #[tokio::test]
+    async fn sign_signs_every_tx_with_distinct_signers() {
         let alice = Account::generate();
         let bob = Account::generate();
 
@@ -866,6 +1061,7 @@ mod tests {
             .build()
             .unwrap()
             .sign()
+            .await
             .unwrap();
 
         let txs = signed.signed_transactions();

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,13 @@ pub enum Error {
     /// [`PendingSubmission::confirm_with`]: crate::algod::v2::PendingSubmission::confirm_with
     #[error("pending transaction timed out ({timeout:?})")]
     PendingTransactionTimeout { timeout: Duration },
+    /// A [`Signer`](algonaut_transaction::Signer) returned output that does
+    /// not match the request the composer made: wrong count, wrong order,
+    /// or a signature wrapping a different transaction than the one asked
+    /// for. The signed group is rejected rather than submitted. `reason`
+    /// is diagnostic only.
+    #[error("signer returned invalid output: {reason}")]
+    SignerOutputInvalid { reason: String },
 
     /// A transaction construction or signing error from
     /// [`algonaut_transaction`], preserved as the error source.

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,6 +69,13 @@ pub enum Error {
     /// is diagnostic only.
     #[error("signer returned invalid output: {reason}")]
     SignerOutputInvalid { reason: String },
+    /// [`sign`](crate::atomic_transaction_composer::UnsignedAtomicGroup::sign)
+    /// was called on a group whose slot at `index` has no signer
+    /// (`TransactionWithSigner::unsigned`). An unsigned slot cannot
+    /// produce a submittable signature; it is only valid for `simulate`.
+    /// Attach a signer, or simulate the group instead of signing it.
+    #[error("transaction at index {index} has no signer (only valid for simulate)")]
+    MissingSigner { index: usize },
 
     /// A transaction construction or signing error from
     /// [`algonaut_transaction`], preserved as the error source.

--- a/tests/step_defs/integration/abi.rs
+++ b/tests/step_defs/integration/abi.rs
@@ -109,7 +109,7 @@ async fn i_add_the_current_transaction_with_signer_tothecomposer(w: &mut World) 
 
 #[then(expr = "I gather signatures with the composer.")]
 async fn i_gather_signatures_with_the_composer(w: &mut World) {
-    let signed_group = w.take_signed_group();
+    let signed_group = w.take_signed_group().await;
 
     w.signed_txs = Some(signed_group.signed_transactions().to_vec());
     w.signed_group = Some(signed_group);
@@ -468,7 +468,7 @@ fn i_build_the_transaction_group_with_the_composer(w: &mut World, error_type: St
 #[then(expr = "I execute the current transaction group with the composer.")]
 async fn i_execute_the_current_transaction_group_with_the_composer(w: &mut World) {
     let algod = w.algod.as_ref().unwrap().clone();
-    let signed_group = w.take_signed_group();
+    let signed_group = w.take_signed_group().await;
 
     let res = signed_group
         .execute(&algod)

--- a/tests/step_defs/integration/world.rs
+++ b/tests/step_defs/integration/world.rs
@@ -120,11 +120,14 @@ impl World {
 
     /// Take the staged group as a [`SignedAtomicGroup`], building and signing as
     /// needed.
-    pub fn take_signed_group(&mut self) -> SignedAtomicGroup {
+    pub async fn take_signed_group(&mut self) -> SignedAtomicGroup {
         if let Some(signed) = self.signed_group.take() {
             signed
         } else {
-            self.take_unsigned_group().sign().expect("signing failed")
+            self.take_unsigned_group()
+                .sign()
+                .await
+                .expect("signing failed")
         }
     }
 }


### PR DESCRIPTION
## Summary

Accepts and implements two ADRs landed in #309:

- [`async-signer-trait`](https://github.com/manuelmauro/algonaut/blob/main/docs/adr/async-signer-trait.md) — replace the synchronous `Signer` with an **async, group-aware** trait.
- [`external-signature-ingress`](https://github.com/manuelmauro/algonaut/blob/main/docs/adr/external-signature-ingress.md) — correct the msgpack-deserialize path so out-of-crate signers can produce a `SignedTransaction`.

Both ADRs move `proposed → accepted` in this PR.

## Async, group-aware signing

- `Signer::sign_transactions` now takes a `SigningRequest { transactions, indexes }` and returns a boxed `SigningFuture` (object-safe + `Send`), so WalletConnect/custodial/KMS signers can await user approval or remote I/O.
- `UnsignedAtomicGroup::sign()` is now `async`. Slots are grouped by signer **identity** (`Arc::ptr_eq`), so each signer signs every slot it owns in a single call — one approval round-trip per wallet. The caller contract: share one `Arc<dyn Signer>` clone across a wallet's slots.
- Signer output is validated against the request — count, order, and that each signed transaction wraps the *expected* transaction (id recomputed and compared) — then reassembled into group order. New `Error::SignerOutputInvalid` covers the failures.
- **Simulate never invokes real signers**: it placeholder-signs every slot and sets `allow-empty-signatures`, so a dry-run on a group carrying an interactive signer never pops a wallet prompt.
- Built-in signers (`Account`, `ContractAccount`, `MultisigSigner`) wrap their existing sync helpers in immediate async impls.

## External-signature ingress

`TryFrom<ApiSignedTransaction> for SignedTransaction` is corrected to recompute `transaction_id` from the decoded transaction (the wire format omits `txid`, so it was previously **empty**) and to preserve the decoded `sgnr` auth address (previously **dropped**). This is the single public ingress out-of-crate signers use (`rmp_serde::from_slice::<SignedTransaction>`), and it no longer violates D5's "id is always the hash of the transaction" invariant.

## Breaking changes

- Every custom `Signer` implementation must adopt the new `sign_transactions(SigningRequest) -> SigningFuture` signature.
- Every `UnsignedAtomicGroup::sign()` caller must `.await` it. Examples and step-defs are migrated.

## Tests

- `Arc::ptr_eq` grouping signs two shared-signer slots in **one** call (counting mock signer).
- Signer-output validation rejects wrong count and wrong-transaction output.
- A msgpack round-trip proves the deserialize path recomputes the id and preserves `sgnr`.

## Validation

- `arkouda check`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --lib --examples --tests`
- `cargo check --target wasm32-unknown-unknown`
- `cargo test --test features_runner --no-run` + `cargo build --workspace`

Integration step-defs (`features_runner`) compile here; they run against a sandbox in CI.
