### PR TITLE
refactor(atomic)!: idiomatic Rust pass on the atomic module

### DIFF
--- a/algonaut_abi/src/abi_type.rs
+++ b/algonaut_abi/src/abi_type.rs
@@ -32,6 +32,55 @@ pub enum AbiValue {
     Array(Vec<AbiValue>),
 }
 
+// Ergonomic constructors for the common cases, so callers write
+// `AbiValue::from(2u64)` (or `2u64.into()`) instead of
+// `AbiValue::Int(BigUint::from(2u64))`. The ARC-4 ABI supports `uint8`
+// through `uint512`, hence `BigUint` for the general case; these cover
+// the native integer widths that fit without ceremony.
+impl From<u64> for AbiValue {
+    fn from(n: u64) -> Self {
+        AbiValue::Int(BigUint::from(n))
+    }
+}
+
+impl From<u128> for AbiValue {
+    fn from(n: u128) -> Self {
+        AbiValue::Int(BigUint::from(n))
+    }
+}
+
+impl From<bool> for AbiValue {
+    fn from(b: bool) -> Self {
+        AbiValue::Bool(b)
+    }
+}
+
+impl From<Address> for AbiValue {
+    fn from(a: Address) -> Self {
+        AbiValue::Address(a)
+    }
+}
+
+impl From<&str> for AbiValue {
+    fn from(s: &str) -> Self {
+        AbiValue::String(s.to_owned())
+    }
+}
+
+impl From<String> for AbiValue {
+    fn from(s: String) -> Self {
+        AbiValue::String(s)
+    }
+}
+
+/// A `byte[]` ABI value: each byte becomes an [`AbiValue::Byte`] element of
+/// a dynamic array, the canonical ARC-4 representation.
+impl From<Vec<u8>> for AbiValue {
+    fn from(bytes: Vec<u8>) -> Self {
+        AbiValue::Array(bytes.into_iter().map(AbiValue::Byte).collect())
+    }
+}
+
 impl AbiType {
     /// Returns true if the type has children and any of the children is dynamic, false otherwise.
     fn has_dynamic_child(&self) -> bool {

--- a/docs/adr/idiomatic-rust-in-algonaut-atomic.md
+++ b/docs/adr/idiomatic-rust-in-algonaut-atomic.md
@@ -2,7 +2,7 @@
 id: idiomatic-rust-in-algonaut-atomic
 title: Idiomatic Rust in algonaut::atomic
 abstract: 'Deep refactoring of the atomic module: eliminate all clippy suppressions, introduce helper structs to replace long argument lists, reduce cloning, box the large enum variant, use From/TryFrom traits for ergonomic ABI arguments, return typed identifiers, and replace all Error::Msg sites with structured variants.'
-status: proposed
+status: accepted
 date: 2026-05-21
 deciders: []
 tags: [api, ergonomics, atomic, idiomatic-rust, refactoring]
@@ -12,7 +12,7 @@ tags: [api, ergonomics, atomic, idiomatic-rust, refactoring]
 
 ## Status
 
-Proposed. Follows the accepted
+Accepted. Follows the accepted
 [`atomic-transaction-composer-typestate`](atomic-transaction-composer-typestate.md),
 [`atomic-module-layout`](atomic-module-layout.md),
 [`method-call-builder`](method-call-builder.md), and

--- a/examples/app_call.rs
+++ b/examples/app_call.rs
@@ -3,12 +3,11 @@
 //! builder. This is the recommended path for application calls.
 
 use algonaut::algod::v2::Algod;
-use algonaut::atomic::{AbiArgValue, AtomicGroupBuilder, MethodCall};
+use algonaut::atomic::{AtomicGroupBuilder, MethodCall};
 use algonaut::core::AppId;
 use algonaut::transaction::account::Account;
-use algonaut_abi::{abi_interactions::AbiMethod, abi_type::AbiValue};
+use algonaut_abi::abi_interactions::AbiMethod;
 use dotenv::dotenv;
-use num_bigint::BigUint;
 use std::env;
 use std::error::Error;
 use std::sync::Arc;
@@ -36,11 +35,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let method = AbiMethod::from_signature("add(uint64,uint64)uint64")?;
 
     info!("building method call");
-    let call = MethodCall::new(AppId(5), method, alice.address(), signer)
-        .args(vec![
-            AbiArgValue::AbiValue(AbiValue::Int(BigUint::from(2u64))),
-            AbiArgValue::AbiValue(AbiValue::Int(BigUint::from(3u64))),
-        ])
+    let call = MethodCall::builder(AppId(5), method, alice.address(), signer)
+        .args([2u64, 3u64])
         .build(&params);
 
     info!("composing and executing");

--- a/examples/atomic.rs
+++ b/examples/atomic.rs
@@ -19,13 +19,12 @@
 //! return-value decoding for you.
 
 use algonaut::algod::v2::Algod;
-use algonaut::atomic::{AbiArgValue, AtomicGroupBuilder, MethodCall, TransactionWithSigner};
+use algonaut::atomic::{AtomicGroupBuilder, MethodCall, TransactionWithSigner};
 use algonaut::core::{AppId, MicroAlgos};
 use algonaut::transaction::account::Account;
 use algonaut::transaction::{Pay, Signer};
-use algonaut_abi::{abi_interactions::AbiMethod, abi_type::AbiValue};
+use algonaut_abi::abi_interactions::AbiMethod;
 use dotenv::dotenv;
-use num_bigint::BigUint;
 use std::env;
 use std::error::Error;
 use std::sync::Arc;
@@ -64,11 +63,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Pay::new(bob.address(), alice.address(), MicroAlgos(1_000)).build(&params)?;
 
     info!("building the method call add(2, 3)");
-    let call = MethodCall::new(app_id, method, alice.address(), alice_signer.clone())
-        .args(vec![
-            AbiArgValue::AbiValue(AbiValue::Int(BigUint::from(2u64))),
-            AbiArgValue::AbiValue(AbiValue::Int(BigUint::from(3u64))),
-        ])
+    let call = MethodCall::builder(app_id, method, alice.address(), alice_signer.clone())
+        .args([2u64, 3u64])
         .build(&params);
 
     info!("composing the atomic group");

--- a/src/atomic/encode.rs
+++ b/src/atomic/encode.rs
@@ -16,7 +16,6 @@
 use std::collections::HashMap;
 
 use algonaut_abi::{
-    abi_error::AbiError,
     abi_interactions::{AbiArgType, AbiMethod, ReferenceArgType, TransactionArgType},
     abi_type::{AbiType, AbiValue},
     make_tuple_type,
@@ -26,8 +25,6 @@ use algonaut_transaction::{
     Transaction, TransactionType,
     transaction::{ApplicationCallTransaction, to_tx_type_enum},
 };
-use num_bigint::BigUint;
-use num_traits::ToPrimitive;
 
 use crate::Error;
 
@@ -217,7 +214,7 @@ impl ForeignArrays {
                 ))
             }
             ReferenceArgType::Asset => {
-                let asset_id = ref_arg_u64(arg_value)?;
+                let asset_id = u64::try_from(arg_value)?;
                 Ok(populate_foreign_array(
                     AssetId(asset_id),
                     &mut self.assets,
@@ -225,7 +222,7 @@ impl ForeignArrays {
                 ))
             }
             ReferenceArgType::Application => {
-                let referenced_app = ref_arg_u64(arg_value)?;
+                let referenced_app = u64::try_from(arg_value)?;
                 Ok(populate_foreign_array(
                     AppId(referenced_app),
                     &mut self.apps,
@@ -234,18 +231,6 @@ impl ForeignArrays {
             }
         }
     }
-}
-
-/// Extract a `u64` foreign-array index (asset or app id) from an
-/// integer-typed ABI argument.
-fn ref_arg_u64(arg_value: &AbiArgValue) -> Result<u64, Error> {
-    let int = BigUint::try_from(arg_value)?;
-    int.to_u64()
-        .ok_or_else(|| AbiError::ValueOutOfRange {
-            abi_type: "uint64".to_owned(),
-            reason: format!("value {int} exceeds u64 capacity"),
-        })
-        .map_err(Error::from)
 }
 
 /// Accumulates encoded ABI argument types and values during method

--- a/src/atomic/encode.rs
+++ b/src/atomic/encode.rs
@@ -280,20 +280,22 @@ impl EncodedArgs {
         Ok(())
     }
 
-    /// If more than 15 ABI arguments were collected, wrap the overflow
-    /// (everything from index 14 onward) into a single trailing tuple, as
-    /// ARC-4 requires.
+    /// If more than 15 ABI arguments were collected, pack everything from
+    /// index 14 onward into a single trailing tuple, leaving 14 direct
+    /// arguments plus the tuple — the 15 application-argument slots the
+    /// 4-byte selector does not occupy. Mirrors py-algorand-sdk's
+    /// `AtomicTransactionComposer.add_method_call`.
     fn wrap_overflow(&mut self) -> Result<(), Error> {
         if self.values.len() <= MAX_ABI_ARG_TYPE_LEN {
             return Ok(());
         }
 
-        let mut wrapped_types = Vec::new();
-        let mut wrapped_values = Vec::new();
-        for i in (MAX_ABI_ARG_TYPE_LEN - 1)..self.values.len() {
-            wrapped_types.push(self.types[i].clone());
-            wrapped_values.push(self.values[i].clone());
-        }
+        // `split_off` truncates the direct arguments to the first 14 and
+        // hands back the overflow to fold into the tuple — without this
+        // truncation the encoded call would carry more than 15 app args.
+        let split_at = MAX_ABI_ARG_TYPE_LEN - 1;
+        let wrapped_types = self.types.split_off(split_at);
+        let wrapped_values = self.values.split_off(split_at);
 
         let tuple_type = make_tuple_type(&wrapped_types)?;
         self.types.push(tuple_type);
@@ -345,5 +347,61 @@ fn populate_foreign_array<T: Eq>(
     } else {
         obj_array.push(obj_to_add);
         obj_array.len() - 1 + start_from
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// More than 15 ABI arguments must collapse to 14 direct args plus one
+    /// trailing tuple holding the overflow — 15 application-argument slots,
+    /// leaving the 16th for the method selector. (The selector is prepended
+    /// later, by `EncodedArgs::encode`.) Matches py-algorand-sdk's
+    /// `AtomicTransactionComposer.add_method_call`.
+    #[test]
+    fn wrap_overflow_packs_args_past_15_into_a_trailing_tuple() {
+        let mut args = EncodedArgs::default();
+        for i in 0..16u8 {
+            args.push(AbiType::Byte, AbiValue::Byte(i));
+        }
+
+        args.wrap_overflow().unwrap();
+
+        assert_eq!(args.types.len(), 15, "must be 14 direct args + 1 tuple");
+        assert_eq!(args.values.len(), 15);
+
+        // The first 14 slots are the original args, untouched and in order.
+        for (i, value) in args.values.iter().take(14).enumerate() {
+            assert_eq!(*value, AbiValue::Byte(i as u8));
+        }
+
+        // The trailing slot is a 2-element tuple holding original args 14
+        // and 15.
+        match (&args.types[14], &args.values[14]) {
+            (AbiType::Tuple { len, child_types }, AbiValue::Array(items)) => {
+                assert_eq!(*len, 2);
+                assert_eq!(child_types.len(), 2);
+                assert_eq!(items, &vec![AbiValue::Byte(14), AbiValue::Byte(15)]);
+            }
+            other => panic!("expected a trailing 2-tuple, got {other:?}"),
+        }
+    }
+
+    /// Exactly 15 arguments fit without wrapping: no tuple is introduced.
+    #[test]
+    fn wrap_overflow_leaves_15_or_fewer_args_untouched() {
+        let mut args = EncodedArgs::default();
+        for i in 0..15u8 {
+            args.push(AbiType::Byte, AbiValue::Byte(i));
+        }
+
+        args.wrap_overflow().unwrap();
+
+        assert_eq!(args.values.len(), 15);
+        assert!(
+            args.values.iter().all(|v| matches!(v, AbiValue::Byte(_))),
+            "no tuple should be introduced at the boundary"
+        );
     }
 }

--- a/src/atomic/encode.rs
+++ b/src/atomic/encode.rs
@@ -7,6 +7,11 @@
 //! 15-argument limit into a tuple, and appends the result (plus any
 //! transaction-typed arguments) to the group. [`validate_tx`] is the shared
 //! per-transaction check applied to every slot, method call or not.
+//!
+//! Two helper structs carry the state that used to be threaded through
+//! long argument lists: [`ForeignArrays`] accumulates the foreign
+//! account/asset/app references, and [`EncodedArgs`] accumulates the
+//! encoded ABI argument types and values.
 
 use std::collections::HashMap;
 
@@ -16,12 +21,12 @@ use algonaut_abi::{
     abi_type::{AbiType, AbiValue},
     make_tuple_type,
 };
-use algonaut_core::{Address, AppId, AssetId, Round};
+use algonaut_core::{Address, AppId, AssetId};
 use algonaut_transaction::{
     Transaction, TransactionType,
-    builder::TransactionParams,
     transaction::{ApplicationCallTransaction, to_tx_type_enum},
 };
+use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 
 use crate::Error;
@@ -41,104 +46,129 @@ pub(super) fn process_method_call(
     txs: &mut Vec<TransactionWithSigner>,
     method_map: &mut HashMap<usize, AbiMethod>,
 ) -> Result<(), Error> {
-    if call.method_args.len() != call.method.args.len() {
-        return Err(Error::Msg(format!(
-            "incorrect number of arguments were provided: {} != {}",
-            call.method_args.len(),
-            call.method.args.len()
-        )));
+    // Destructure once so every field is moved exactly where it is needed,
+    // rather than cloned out of a borrowed `call`.
+    let MethodCall {
+        app_id,
+        mut method,
+        method_args,
+        fee,
+        sender,
+        first_valid,
+        last_valid,
+        genesis_hash,
+        genesis_id,
+        on_complete,
+        approval_program,
+        clear_program,
+        global_schema,
+        local_schema,
+        extra_pages,
+        note,
+        lease,
+        rekey_to,
+        signer,
+        boxes,
+    } = call;
+
+    if method_args.len() != method.args.len() {
+        return Err(Error::AbiArgumentCountMismatch {
+            expected: method.args.len(),
+            actual: method_args.len(),
+        });
     }
-    if txs.len() + call.method.get_tx_count() > MAX_ATOMIC_GROUP_SIZE {
+    if txs.len() + method.get_tx_count() > MAX_ATOMIC_GROUP_SIZE {
         return Err(Error::ComposerGroupFull {
             max: MAX_ATOMIC_GROUP_SIZE,
         });
     }
 
-    let mut method_types = vec![];
-    let mut method_args: Vec<AbiValue> = vec![];
-    let mut txs_with_signer = vec![];
-    let mut foreign_accounts = vec![];
-    let mut foreign_assets = vec![];
-    let mut foreign_apps = vec![];
+    let mut foreign = ForeignArrays::default();
+    let mut args = EncodedArgs::default();
+    let mut tx_args: Vec<TransactionWithSigner> = Vec::new();
 
-    for (arg_type, arg_value) in call.method.args.iter().zip(&call.method_args) {
-        let mut arg_type = arg_type.clone();
-
-        match arg_type.type_()? {
-            AbiArgType::Tx(type_) => {
-                add_tx_arg_type_to_method_call(arg_value, type_, &mut txs_with_signer)?
+    for (arg_spec, arg_value) in method.args.iter_mut().zip(method_args) {
+        match arg_spec.type_()? {
+            AbiArgType::Tx(expected_type) => {
+                let tx_with_signer = match arg_value {
+                    AbiArgValue::TxWithSigner(tx_with_signer) => *tx_with_signer,
+                    AbiArgValue::AbiValue(_) => return Err(Error::ExpectedTransactionArgument),
+                };
+                validate_tx(&tx_with_signer.tx, expected_type)?;
+                tx_args.push(tx_with_signer);
             }
-            AbiArgType::Ref(type_) => add_ref_arg_to_method_call(
-                &type_,
-                arg_value,
-                &mut foreign_accounts,
-                &mut foreign_assets,
-                &mut foreign_apps,
-                &mut method_types,
-                &mut method_args,
-                call.sender,
-                call.app_id,
-            )?,
-            AbiArgType::AbiObj(type_) => {
-                add_abi_obj_arg_to_method_call(
-                    &type_,
-                    arg_value,
-                    &mut method_types,
-                    &mut method_args,
-                )?;
+            AbiArgType::Ref(ref_type) => {
+                let index = foreign.add_ref(&ref_type, &arg_value, sender, app_id)?;
+                args.push_ref_index(index)?;
             }
-        };
+            AbiArgType::AbiObj(abi_type) => match arg_value {
+                AbiArgValue::AbiValue(value) => args.push(abi_type, value),
+                AbiArgValue::TxWithSigner(_) => {
+                    return Err(Error::InvalidAbiArgument {
+                        expected: "ABI value",
+                        actual: "transaction".to_owned(),
+                    });
+                }
+            },
+        }
     }
 
-    if method_args.len() > MAX_ABI_ARG_TYPE_LEN {
-        let (type_, value) = wrap_overflowing_values(&method_types, &method_args)?;
-        method_types.push(type_);
-        method_args.push(value);
-    }
+    args.wrap_overflow()?;
+    let app_arguments = args.encode(method.get_selector()?)?;
 
-    let mut encoded_abi_args = vec![call.method.get_selector()?.into()];
-    for (method_type, method_arg) in method_types.iter().zip(&method_args) {
-        encoded_abi_args.push(method_type.encode(method_arg.clone())?);
-    }
+    let ForeignArrays {
+        accounts,
+        assets,
+        apps,
+    } = foreign;
 
     let app_call = TransactionType::ApplicationCallTransaction(ApplicationCallTransaction {
-        sender: call.sender,
-        app_id: Some(call.app_id),
-        on_complete: call.on_complete.clone(),
-        accounts: Some(foreign_accounts),
-        approval_program: call.approval_program.clone(),
-        app_arguments: Some(encoded_abi_args),
-        clear_state_program: call.clear_program.clone(),
-        foreign_apps: Some(foreign_apps),
-        foreign_assets: Some(foreign_assets),
-        global_state_schema: call.global_schema.clone(),
-        local_state_schema: call.local_schema.clone(),
-        extra_pages: call.extra_pages,
-        boxes: call.boxes.clone(),
+        sender,
+        app_id: Some(app_id),
+        on_complete,
+        accounts: Some(accounts),
+        approval_program,
+        app_arguments: Some(app_arguments),
+        clear_state_program: clear_program,
+        foreign_apps: Some(apps),
+        foreign_assets: Some(assets),
+        global_state_schema: global_schema,
+        local_state_schema: local_schema,
+        extra_pages,
+        boxes: to_option(boxes),
     });
 
-    let sp = &call.suggested_params;
     let tx = Transaction {
-        fee: call.fee,
-        first_valid: Round(sp.last_round()),
-        genesis_hash: sp.genesis_hash(),
-        last_valid: Round(sp.last_round() + 1000),
+        fee,
+        first_valid,
+        genesis_hash,
+        last_valid,
         txn_type: app_call,
-        genesis_id: Some(sp.genesis_id().clone()),
+        genesis_id: Some(genesis_id),
         group: None,
-        lease: call.lease,
-        note: call.note.clone(),
-        rekey_to: call.rekey_to,
+        lease,
+        note: to_option(note),
+        rekey_to,
     };
 
-    txs.append(&mut txs_with_signer);
+    txs.append(&mut tx_args);
     txs.push(TransactionWithSigner {
         tx,
-        signer: Some(call.signer.clone()),
+        signer: Some(signer),
     });
-    method_map.insert(txs.len() - 1, call.method);
+    method_map.insert(txs.len() - 1, method);
 
     Ok(())
+}
+
+/// `Vec::new()` is the builder's "absent" sentinel; the transaction model
+/// uses `Option`, so map an empty vec back to `None` at the boundary.
+fn to_option<T>(values: Vec<T>) -> Option<Vec<T>> {
+    if values.is_empty() {
+        None
+    } else {
+        Some(values)
+    }
 }
 
 /// Shared per-transaction validity check: the transaction must carry no
@@ -149,167 +179,139 @@ pub(super) fn validate_tx(
     expected_type: TransactionArgType,
 ) -> Result<(), Error> {
     if tx.group.is_some() {
-        return Err(Error::Msg("Expected empty group id".to_owned()));
+        return Err(Error::TransactionAlreadyGrouped);
     }
 
+    let actual_type = to_tx_type_enum(&tx.txn_type);
     if expected_type != TransactionArgType::Any
-        && expected_type != TransactionArgType::One(to_tx_type_enum(&tx.txn_type))
+        && expected_type != TransactionArgType::One(actual_type.clone())
     {
-        return Err(Error::Msg(format!(
-            "expected transaction with type {expected_type:?}, but got type {:?}",
-            tx.txn_type
-        )));
+        return Err(Error::TransactionTypeMismatch {
+            expected: format!("{expected_type:?}"),
+            actual: format!("{actual_type:?}"),
+        });
     }
 
     Ok(())
 }
 
-fn add_tx_arg_type_to_method_call(
-    arg_value: &AbiArgValue,
-    expected_type: TransactionArgType,
-    txs_with_signer: &mut Vec<TransactionWithSigner>,
-) -> Result<(), Error> {
-    let txn_and_signer = match arg_value {
-        AbiArgValue::TxWithSigner(tx_with_signer) => tx_with_signer,
-        _ => {
-            return Err(Error::Msg(
-                "invalid arg value, expected transaction".to_owned(),
-            ));
-        }
-    };
-
-    validate_tx(&txn_and_signer.tx, expected_type)?;
-    txs_with_signer.push(txn_and_signer.to_owned());
-
-    Ok(())
+/// Accumulates foreign-array references during ABI method encoding. The
+/// three arrays correspond to an application call's `accounts`,
+/// `foreign_assets`, and `foreign_apps`.
+#[derive(Default)]
+struct ForeignArrays {
+    accounts: Vec<Address>,
+    assets: Vec<AssetId>,
+    apps: Vec<AppId>,
 }
 
-fn add_abi_obj_arg_to_method_call(
-    abi_type: &AbiType,
-    arg_value: &AbiArgValue,
-    method_types: &mut Vec<AbiType>,
-    method_args: &mut Vec<AbiValue>,
-) -> Result<(), Error> {
-    match arg_value {
-        AbiArgValue::AbiValue(value) => {
-            method_types.push(abi_type.clone());
-            method_args.push(value.clone());
-        }
-        AbiArgValue::TxWithSigner(_) => {
-            return Err(Error::Msg(
-                "Invalid state: shouldn't be here with a tx with signer value type".to_owned(),
-            ));
-        }
-    }
-
-    Ok(())
-}
-
-#[allow(clippy::too_many_arguments)]
-fn add_ref_arg_to_method_call(
-    arg_type: &ReferenceArgType,
-    arg_value: &AbiArgValue,
-
-    foreign_accounts: &mut Vec<Address>,
-    foreign_assets: &mut Vec<AssetId>,
-    foreign_apps: &mut Vec<AppId>,
-
-    method_types: &mut Vec<AbiType>,
-    method_args: &mut Vec<AbiValue>,
-
-    sender: Address,
-    app_id: AppId,
-) -> Result<(), Error> {
-    let index = add_to_foreign_array(
-        arg_type,
-        arg_value,
-        foreign_accounts,
-        foreign_assets,
-        foreign_apps,
-        sender,
-        app_id,
-    )?;
-
-    method_types.push(AbiType::uint(FOREIGN_OBJ_ABI_UINT_SIZE)?);
-    method_args.push(AbiValue::Int(index.into()));
-
-    Ok(())
-}
-
-/// Adds arg value to its respective foreign array
-/// Returns index that can be used to reference `arg_value` in its foreign array (in TEAL).
-fn add_to_foreign_array(
-    arg_type: &ReferenceArgType,
-    arg_value: &AbiArgValue,
-    foreign_accounts: &mut Vec<Address>,
-    foreign_assets: &mut Vec<AssetId>,
-    foreign_apps: &mut Vec<AppId>,
-    sender: Address,
-    app_id: AppId,
-) -> Result<usize, Error> {
-    match arg_type {
-        ReferenceArgType::Account => match arg_value.address() {
-            Some(address) => Ok(populate_foreign_array(
-                address,
-                foreign_accounts,
-                Some(sender),
-            )),
-            _ => Err(Error::Msg(format!(
-                "Invalid value type: {arg_value:?} for arg type: {arg_type:?}"
-            ))),
-        },
-        ReferenceArgType::Asset => match arg_value.int() {
-            Some(int) => {
-                let intu64 = int.to_u64().ok_or_else(|| AbiError::ValueOutOfRange {
-                    abi_type: "uint64".to_owned(),
-                    reason: format!("value {int} exceeds u64 capacity"),
-                })?;
-
+impl ForeignArrays {
+    /// Add a reference argument to its respective foreign array and return
+    /// the index that can be used to reference it (in TEAL).
+    fn add_ref(
+        &mut self,
+        arg_type: &ReferenceArgType,
+        arg_value: &AbiArgValue,
+        sender: Address,
+        app_id: AppId,
+    ) -> Result<usize, Error> {
+        match arg_type {
+            ReferenceArgType::Account => {
+                let address = Address::try_from(arg_value)?;
                 Ok(populate_foreign_array(
-                    AssetId(intu64),
-                    foreign_assets,
+                    address,
+                    &mut self.accounts,
+                    Some(sender),
+                ))
+            }
+            ReferenceArgType::Asset => {
+                let asset_id = ref_arg_u64(arg_value)?;
+                Ok(populate_foreign_array(
+                    AssetId(asset_id),
+                    &mut self.assets,
                     None,
                 ))
             }
-            _ => Err(Error::Msg(format!(
-                "Invalid value type: {arg_value:?} for arg type: {arg_type:?}"
-            ))),
-        },
-        ReferenceArgType::Application => match arg_value.int() {
-            Some(int) => {
-                let intu64 = int.to_u64().ok_or_else(|| AbiError::ValueOutOfRange {
-                    abi_type: "uint64".to_owned(),
-                    reason: format!("value {int} exceeds u64 capacity"),
-                })?;
-
+            ReferenceArgType::Application => {
+                let referenced_app = ref_arg_u64(arg_value)?;
                 Ok(populate_foreign_array(
-                    AppId(intu64),
-                    foreign_apps,
+                    AppId(referenced_app),
+                    &mut self.apps,
                     Some(app_id),
                 ))
             }
-            _ => Err(Error::Msg(format!(
-                "Invalid value type: {arg_value:?} for arg type: {arg_type:?}"
-            ))),
-        },
+        }
     }
 }
 
-fn wrap_overflowing_values(
-    method_types: &[AbiType],
-    method_args: &[AbiValue],
-) -> Result<(AbiType, AbiValue), Error> {
-    let mut wrapped_abi_types = vec![];
-    let mut wrapped_value_list = vec![];
+/// Extract a `u64` foreign-array index (asset or app id) from an
+/// integer-typed ABI argument.
+fn ref_arg_u64(arg_value: &AbiArgValue) -> Result<u64, Error> {
+    let int = BigUint::try_from(arg_value)?;
+    int.to_u64()
+        .ok_or_else(|| AbiError::ValueOutOfRange {
+            abi_type: "uint64".to_owned(),
+            reason: format!("value {int} exceeds u64 capacity"),
+        })
+        .map_err(Error::from)
+}
 
-    for i in (MAX_ABI_ARG_TYPE_LEN - 1)..method_args.len() {
-        wrapped_abi_types.push(method_types[i].clone());
-        wrapped_value_list.push(method_args[i].clone());
+/// Accumulates encoded ABI argument types and values during method
+/// encoding, then encodes them (prefixed by the method selector) into the
+/// application call's `app_arguments`.
+#[derive(Default)]
+struct EncodedArgs {
+    types: Vec<AbiType>,
+    values: Vec<AbiValue>,
+}
+
+impl EncodedArgs {
+    /// Append a plain ABI argument.
+    fn push(&mut self, ty: AbiType, value: AbiValue) {
+        self.types.push(ty);
+        self.values.push(value);
     }
 
-    let tuple_type = make_tuple_type(&wrapped_abi_types)?;
+    /// Append a foreign-array index argument (a `uint8` referencing a slot
+    /// in `accounts`/`foreign_assets`/`foreign_apps`).
+    fn push_ref_index(&mut self, index: usize) -> Result<(), Error> {
+        self.types.push(AbiType::uint(FOREIGN_OBJ_ABI_UINT_SIZE)?);
+        self.values.push(AbiValue::Int(index.into()));
+        Ok(())
+    }
 
-    Ok((tuple_type, AbiValue::Array(wrapped_value_list)))
+    /// If more than 15 ABI arguments were collected, wrap the overflow
+    /// (everything from index 14 onward) into a single trailing tuple, as
+    /// ARC-4 requires.
+    fn wrap_overflow(&mut self) -> Result<(), Error> {
+        if self.values.len() <= MAX_ABI_ARG_TYPE_LEN {
+            return Ok(());
+        }
+
+        let mut wrapped_types = Vec::new();
+        let mut wrapped_values = Vec::new();
+        for i in (MAX_ABI_ARG_TYPE_LEN - 1)..self.values.len() {
+            wrapped_types.push(self.types[i].clone());
+            wrapped_values.push(self.values[i].clone());
+        }
+
+        let tuple_type = make_tuple_type(&wrapped_types)?;
+        self.types.push(tuple_type);
+        self.values.push(AbiValue::Array(wrapped_values));
+        Ok(())
+    }
+
+    /// Encode the collected arguments, prefixed by the 4-byte method
+    /// selector, into the `app_arguments` byte vectors. Consumes `self`,
+    /// moving each value into [`AbiType::encode`] rather than cloning it.
+    fn encode(self, selector: [u8; 4]) -> Result<Vec<Vec<u8>>, Error> {
+        let mut encoded = Vec::with_capacity(self.values.len() + 1);
+        encoded.push(selector.to_vec());
+        for (ty, value) in self.types.iter().zip(self.values) {
+            encoded.push(ty.encode(value)?);
+        }
+        Ok(encoded)
+    }
 }
 
 /// Add a value to an application call's foreign array. The addition will be as compact as possible,

--- a/src/atomic/encode.rs
+++ b/src/atomic/encode.rs
@@ -135,7 +135,9 @@ pub(super) fn process_method_call(
         global_state_schema: global_schema,
         local_state_schema: local_schema,
         extra_pages,
-        boxes: to_option(boxes),
+        // The builder uses an empty vec for "no boxes"; the transaction
+        // model wants `None`.
+        boxes: (!boxes.is_empty()).then_some(boxes),
     });
 
     let tx = Transaction {
@@ -147,7 +149,7 @@ pub(super) fn process_method_call(
         genesis_id: Some(genesis_id),
         group: None,
         lease,
-        note: to_option(note),
+        note: (!note.is_empty()).then_some(note),
         rekey_to,
     };
 
@@ -159,16 +161,6 @@ pub(super) fn process_method_call(
     method_map.insert(txs.len() - 1, method);
 
     Ok(())
-}
-
-/// `Vec::new()` is the builder's "absent" sentinel; the transaction model
-/// uses `Option`, so map an empty vec back to `None` at the boundary.
-fn to_option<T>(values: Vec<T>) -> Option<Vec<T>> {
-    if values.is_empty() {
-        None
-    } else {
-        Some(values)
-    }
 }
 
 /// Shared per-transaction validity check: the transaction must carry no

--- a/src/atomic/group.rs
+++ b/src/atomic/group.rs
@@ -108,7 +108,7 @@ impl AtomicGroupBuilder {
     }
 
     /// Add an ABI method call to the group. Build the [`MethodCall`]
-    /// with [`MethodCall::new`] and the [`MethodCallBuilder`](super::MethodCallBuilder) setters.
+    /// with [`MethodCall::builder`] and the [`MethodCallBuilder`](super::MethodCallBuilder) setters.
     pub fn add_method_call(mut self, call: MethodCall) -> Self {
         self.entries.push(AtomicGroupEntry::MethodCall(call));
         self
@@ -234,10 +234,9 @@ impl UnsignedAtomicGroup {
                     continue;
                 }
                 let tx_id = signed_txs[i].transaction_id().clone();
-                let pending_tx = (*txn_result.txn_result).clone();
                 let return_type = self.method_map[&i].returns.clone().type_()?;
                 method_results.push(get_return_value_with_return_type(
-                    &pending_tx,
+                    &txn_result.txn_result,
                     &tx_id,
                     return_type,
                 )?);
@@ -292,34 +291,35 @@ impl SignedAtomicGroup {
                 continue;
             }
 
-            let mut current_tx_id = tx_id.clone(); // this variable wouldn't be needed if our txn in PendingTransaction was complete / able to generate an id
-            let mut current_pending_tx = pending_tx.clone();
+            let return_type = self.method_map[&i].returns.clone().type_()?;
 
-            if i != index_to_wait {
-                let tx_id = self.signed_txs[i].transaction_id().clone();
-
-                match algod.pending_txn(&tx_id).await {
-                    Ok(p) => {
-                        current_tx_id = tx_id;
-                        current_pending_tx = p;
-                    }
-                    Err(e) => {
-                        method_results.push(AbiMethodResult {
-                            tx_id,
-                            tx_info: pending_tx.clone(),
-                            return_value: Err(AbiReturnDecodeError(format!("{e:?}"))),
-                        });
-                        continue;
-                    }
-                };
+            // The slot we already polled needs no extra fetch — decode it
+            // straight from the confirmed response we are holding.
+            if i == index_to_wait {
+                method_results.push(get_return_value_with_return_type(
+                    &pending_tx,
+                    &tx_id,
+                    return_type,
+                )?);
+                continue;
             }
 
-            let return_type = self.method_map[&i].returns.clone().type_()?;
-            method_results.push(get_return_value_with_return_type(
-                &current_pending_tx,
-                &current_tx_id,
-                return_type,
-            )?);
+            // Other method calls in the group: fetch each one's own pending
+            // transaction. A fetch failure is surfaced per-result rather
+            // than failing the whole group.
+            let other_tx_id = self.signed_txs[i].transaction_id().clone();
+            match algod.pending_txn(&other_tx_id).await {
+                Ok(other_pending_tx) => method_results.push(get_return_value_with_return_type(
+                    &other_pending_tx,
+                    &other_tx_id,
+                    return_type,
+                )?),
+                Err(e) => method_results.push(AbiMethodResult {
+                    tx_id: other_tx_id,
+                    tx_info: pending_tx.clone(),
+                    return_value: Err(AbiReturnDecodeError(format!("{e:?}"))),
+                }),
+            }
         }
 
         Ok(ExecuteOutcome {

--- a/src/atomic/method_call.rs
+++ b/src/atomic/method_call.rs
@@ -3,13 +3,13 @@
 //!
 //! Replaces the previous 18-field `AddMethodCallParams` struct. Only the
 //! four genuinely required inputs are positional on
-//! [`MethodCall::new`]; everything else is an optional setter, so the
+//! [`MethodCall::builder`]; everything else is an optional setter, so the
 //! common call carries no `None`s.
 
 use std::sync::Arc;
 
 use algonaut_abi::{abi_interactions::AbiMethod, abi_type::AbiValue};
-use algonaut_core::{Address, AppId, CompiledTeal, MicroAlgos};
+use algonaut_core::{Address, AppId, CompiledTeal, MicroAlgos, Round};
 use algonaut_crypto::HashDigest;
 use algonaut_model::client_types::SuggestedParams;
 use algonaut_transaction::{
@@ -18,30 +18,83 @@ use algonaut_transaction::{
 };
 use num_bigint::BigUint;
 
+use crate::Error;
+
 use super::TransactionWithSigner;
 
 /// An argument to an ABI [`MethodCall`]. Either a transaction-typed
 /// argument (which contributes its own slot to the group) or a plain ABI
 /// value.
-#[allow(clippy::large_enum_variant)]
+///
+/// Build one with `.into()`: native types (`u64`, `bool`, [`Address`],
+/// `&str`, `Vec<u8>`, …) and [`AbiValue`] convert into
+/// [`AbiArgValue::AbiValue`], and a [`TransactionWithSigner`] converts into
+/// [`AbiArgValue::TxWithSigner`]. The transaction-typed variant is boxed so
+/// the enum stays small for the common plain-value case.
 #[derive(Debug, Clone)]
 pub enum AbiArgValue {
-    TxWithSigner(TransactionWithSigner),
+    TxWithSigner(Box<TransactionWithSigner>),
     AbiValue(AbiValue),
 }
 
-impl AbiArgValue {
-    pub(super) fn address(&self) -> Option<Address> {
-        match self {
-            AbiArgValue::AbiValue(AbiValue::Address(address)) => Some(*address),
-            _ => None,
+impl From<AbiValue> for AbiArgValue {
+    fn from(v: AbiValue) -> Self {
+        Self::AbiValue(v)
+    }
+}
+
+impl From<TransactionWithSigner> for AbiArgValue {
+    fn from(t: TransactionWithSigner) -> Self {
+        Self::TxWithSigner(Box::new(t))
+    }
+}
+
+// Native-type conveniences mirror `AbiValue`'s `From` impls so that
+// `.args([2u64, 3u64])` works without spelling out `AbiValue`. A blanket
+// `impl<T: Into<AbiValue>> From<T> for AbiArgValue` would collide with both
+// the reflexive `From<AbiArgValue>` and the `TransactionWithSigner` impl
+// above, so the conversions are enumerated.
+macro_rules! abi_arg_value_from {
+    ($($t:ty),* $(,)?) => {$(
+        impl From<$t> for AbiArgValue {
+            fn from(v: $t) -> Self {
+                Self::AbiValue(AbiValue::from(v))
+            }
+        }
+    )*};
+}
+
+abi_arg_value_from!(u64, u128, bool, Address, &str, String, Vec<u8>);
+
+/// Extract an [`Address`] from an account-typed ABI argument. Replaces the
+/// old `AbiArgValue::address(&self) -> Option<Address>` helper so the
+/// fallible extraction integrates with `?`.
+impl TryFrom<&AbiArgValue> for Address {
+    type Error = Error;
+
+    fn try_from(value: &AbiArgValue) -> Result<Self, Self::Error> {
+        match value {
+            AbiArgValue::AbiValue(AbiValue::Address(address)) => Ok(*address),
+            other => Err(Error::InvalidAbiArgument {
+                expected: "address",
+                actual: format!("{other:?}"),
+            }),
         }
     }
+}
 
-    pub(super) fn int(&self) -> Option<BigUint> {
-        match self {
-            AbiArgValue::AbiValue(AbiValue::Int(int)) => Some(int.clone()),
-            _ => None,
+/// Extract a [`BigUint`] from an integer-typed ABI argument. Replaces the
+/// old `AbiArgValue::int(&self) -> Option<BigUint>` helper.
+impl TryFrom<&AbiArgValue> for BigUint {
+    type Error = Error;
+
+    fn try_from(value: &AbiArgValue) -> Result<Self, Self::Error> {
+        match value {
+            AbiArgValue::AbiValue(AbiValue::Int(int)) => Ok(int.clone()),
+            other => Err(Error::InvalidAbiArgument {
+                expected: "uint",
+                actual: format!("{other:?}"),
+            }),
         }
     }
 }
@@ -50,7 +103,7 @@ impl AbiArgValue {
 /// [`AtomicGroupBuilder::add_method_call`](super::AtomicGroupBuilder::add_method_call).
 ///
 /// Construct one with the fluent [`MethodCallBuilder`] returned by
-/// [`MethodCall::new`].
+/// [`MethodCall::builder`].
 #[derive(Clone, Debug)]
 pub struct MethodCall {
     pub(super) app_id: AppId,
@@ -58,18 +111,24 @@ pub struct MethodCall {
     pub(super) method_args: Vec<AbiArgValue>,
     pub(super) fee: MicroAlgos,
     pub(super) sender: Address,
-    pub(super) suggested_params: SuggestedParams,
+    // The transaction-validity window and genesis identifiers resolved from
+    // the suggested params at build time. Storing the primitives we use
+    // avoids cloning the whole `SuggestedParams` (and its heap strings).
+    pub(super) first_valid: Round,
+    pub(super) last_valid: Round,
+    pub(super) genesis_hash: HashDigest,
+    pub(super) genesis_id: String,
     pub(super) on_complete: ApplicationCallOnComplete,
     pub(super) approval_program: Option<CompiledTeal>,
     pub(super) clear_program: Option<CompiledTeal>,
     pub(super) global_schema: Option<StateSchema>,
     pub(super) local_schema: Option<StateSchema>,
     pub(super) extra_pages: u32,
-    pub(super) note: Option<Vec<u8>>,
+    pub(super) note: Vec<u8>,
     pub(super) lease: Option<HashDigest>,
     pub(super) rekey_to: Option<Address>,
     pub(super) signer: Arc<dyn Signer>,
-    pub(super) boxes: Option<Vec<BoxReference>>,
+    pub(super) boxes: Vec<BoxReference>,
 }
 
 impl MethodCall {
@@ -80,8 +139,11 @@ impl MethodCall {
     /// underlying address is the multisig address, not necessarily the
     /// sender of any one transaction). Pass the address the call
     /// should be sent from explicitly.
-    #[allow(clippy::new_ret_no_self)] // intentional: builder API
-    pub fn new(
+    ///
+    /// Named `builder` (not `new`) because it returns a
+    /// [`MethodCallBuilder`], following `http::Request::builder()` and the
+    /// rest of the ecosystem.
+    pub fn builder(
         app_id: AppId,
         method: AbiMethod,
         sender: Address,
@@ -100,15 +162,15 @@ impl MethodCall {
             global_schema: None,
             local_schema: None,
             extra_pages: 0,
-            note: None,
+            note: Vec::new(),
             lease: None,
             rekey_to: None,
-            boxes: None,
+            boxes: Vec::new(),
         }
     }
 }
 
-/// Fluent builder produced by [`MethodCall::new`].
+/// Fluent builder produced by [`MethodCall::builder`].
 ///
 /// All setters take ownership and return `self`. Call
 /// [`MethodCallBuilder::build`] with the network's suggested params to
@@ -126,17 +188,19 @@ pub struct MethodCallBuilder {
     global_schema: Option<StateSchema>,
     local_schema: Option<StateSchema>,
     extra_pages: u32,
-    note: Option<Vec<u8>>,
+    note: Vec<u8>,
     lease: Option<HashDigest>,
     rekey_to: Option<Address>,
-    boxes: Option<Vec<BoxReference>>,
+    boxes: Vec<BoxReference>,
 }
 
 impl MethodCallBuilder {
     /// ABI method arguments, in the order declared by the method
-    /// signature. If the method takes no arguments, omit this setter.
-    pub fn args(mut self, args: Vec<AbiArgValue>) -> Self {
-        self.method_args = args;
+    /// signature. Each element converts into an [`AbiArgValue`], so native
+    /// types work directly: `.args([2u64, 3u64])`. If the method takes no
+    /// arguments, omit this setter.
+    pub fn args(mut self, args: impl IntoIterator<Item = impl Into<AbiArgValue>>) -> Self {
+        self.method_args = args.into_iter().map(Into::into).collect();
         self
     }
 
@@ -186,9 +250,9 @@ impl MethodCallBuilder {
         self
     }
 
-    /// Transaction note.
+    /// Transaction note. Defaults to empty (no note).
     pub fn note(mut self, note: Vec<u8>) -> Self {
-        self.note = Some(note);
+        self.note = note;
         self
     }
 
@@ -204,9 +268,9 @@ impl MethodCallBuilder {
         self
     }
 
-    /// Box references this call is permitted to access.
+    /// Box references this call is permitted to access. Defaults to empty.
     pub fn boxes(mut self, boxes: Vec<BoxReference>) -> Self {
-        self.boxes = Some(boxes);
+        self.boxes = boxes;
         self
     }
 
@@ -215,7 +279,8 @@ impl MethodCallBuilder {
     /// [`AtomicGroupBuilder::add_method_call`](super::AtomicGroupBuilder::add_method_call).
     ///
     /// The fee defaults to `params.min_fee` if no [`fee`](Self::fee)
-    /// override was supplied.
+    /// override was supplied. Only the validity-window and genesis
+    /// primitives are read out of `params`; the struct is not cloned.
     pub fn build(self, params: &SuggestedParams) -> MethodCall {
         let fee = self.fee.unwrap_or(params.min_fee);
         MethodCall {
@@ -224,7 +289,10 @@ impl MethodCallBuilder {
             method_args: self.method_args,
             fee,
             sender: self.sender,
-            suggested_params: params.clone(),
+            first_valid: params.last_round,
+            last_valid: Round(params.last_round.0 + 1000),
+            genesis_hash: params.genesis_hash,
+            genesis_id: params.genesis_id.clone(),
             on_complete: self.on_complete,
             approval_program: self.approval_program,
             clear_program: self.clear_program,

--- a/src/atomic/method_call.rs
+++ b/src/atomic/method_call.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-use algonaut_abi::{abi_interactions::AbiMethod, abi_type::AbiValue};
+use algonaut_abi::{abi_error::AbiError, abi_interactions::AbiMethod, abi_type::AbiValue};
 use algonaut_core::{Address, AppId, CompiledTeal, MicroAlgos, Round};
 use algonaut_crypto::HashDigest;
 use algonaut_model::client_types::SuggestedParams;
@@ -17,6 +17,7 @@ use algonaut_transaction::{
     transaction::{ApplicationCallOnComplete, BoxReference, StateSchema},
 };
 use num_bigint::BigUint;
+use num_traits::ToPrimitive;
 
 use crate::Error;
 
@@ -96,6 +97,23 @@ impl TryFrom<&AbiArgValue> for BigUint {
                 actual: format!("{other:?}"),
             }),
         }
+    }
+}
+
+/// Extract a `u64` from an integer-typed ABI argument — used for the asset-
+/// and application-id foreign-array references, which are `u64` on the
+/// wire. Errors if the value is not an integer, or if it overflows `u64`.
+impl TryFrom<&AbiArgValue> for u64 {
+    type Error = Error;
+
+    fn try_from(value: &AbiArgValue) -> Result<Self, Self::Error> {
+        let int = BigUint::try_from(value)?;
+        int.to_u64().ok_or_else(|| {
+            Error::from(AbiError::ValueOutOfRange {
+                abi_type: "uint64".to_owned(),
+                reason: format!("value {int} exceeds u64 capacity"),
+            })
+        })
     }
 }
 

--- a/src/atomic/outcome.rs
+++ b/src/atomic/outcome.rs
@@ -49,7 +49,7 @@ pub struct ExecuteOutcome {
     /// (optional, because the transaction's confirmed round is optional).
     pub confirmed_round: Option<u64>,
     /// A list of the TxIDs for each transaction in the executed group
-    pub tx_ids: Vec<String>,
+    pub tx_ids: Vec<TxId>,
     /// Return values for all the ABI method calls in the executed group
     pub method_results: Vec<AbiMethodResult>,
 }
@@ -61,7 +61,7 @@ pub struct ExecuteOutcome {
 #[derive(Debug, Clone)]
 pub struct SimulateOutcome {
     /// TxIDs for each transaction in the simulated group.
-    pub tx_ids: Vec<String>,
+    pub tx_ids: Vec<TxId>,
     /// ABI return values per method call. Errors are surfaced
     /// per-result (the same way [`ExecuteOutcome`] does it) so callers
     /// can inspect partial successes.
@@ -100,7 +100,7 @@ fn get_return_value_with_abi_type(
 
     let decoded_ret_line: Vec<u8> = BASE64
         .decode(&ret_line.0[..])
-        .map_err(|e| Error::Msg(format!("BASE64 Decoding error: {e:?}")))?;
+        .map_err(|source| Error::Base64DecodeError { source })?;
 
     if !decoded_ret_line.starts_with(&ABI_RETURN_HASH) {
         return Err(Error::MissingReturnLog);

--- a/src/atomic/signing.rs
+++ b/src/atomic/signing.rs
@@ -127,13 +127,7 @@ pub(super) async fn sign_group(
     signed
         .into_iter()
         .enumerate()
-        .map(|(i, slot)| {
-            slot.ok_or_else(|| {
-                Error::Internal(format!(
-                    "no signature produced for transaction at index {i}"
-                ))
-            })
-        })
+        .map(|(i, slot)| slot.ok_or(Error::InternalSigningIncomplete { index: i }))
         .collect()
 }
 
@@ -148,10 +142,10 @@ pub(super) fn placeholder_group(
         .collect()
 }
 
-/// Collect the base32 transaction ids of a signed group, in order.
-pub(super) fn tx_ids(signed_txs: &[SignedTransaction]) -> Vec<String> {
+/// Collect the transaction ids of a signed group, in order.
+pub(super) fn tx_ids(signed_txs: &[SignedTransaction]) -> Vec<TxId> {
     signed_txs
         .iter()
-        .map(|t| t.transaction_id().0.clone())
+        .map(|t| t.transaction_id().clone())
         .collect()
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,6 +76,43 @@ pub enum Error {
     /// Attach a signer, or simulate the group instead of signing it.
     #[error("transaction at index {index} has no signer (only valid for simulate)")]
     MissingSigner { index: usize },
+    /// An ABI [`MethodCall`](crate::atomic::MethodCall) was given a number
+    /// of arguments that does not match its method signature.
+    #[error("ABI method expected {expected} argument(s), got {actual}")]
+    AbiArgumentCountMismatch { expected: usize, actual: usize },
+    /// A transaction handed to the composer already carries a group id, so
+    /// it cannot be added to a new atomic group.
+    #[error("transaction already belongs to a group")]
+    TransactionAlreadyGrouped,
+    /// A transaction-typed ABI argument did not match the transaction type
+    /// the method signature requires. `expected`/`actual` are diagnostic
+    /// only — match on the variant.
+    #[error("expected transaction of type {expected}, got {actual}")]
+    TransactionTypeMismatch { expected: String, actual: String },
+    /// The method signature declared a transaction-typed argument, but the
+    /// supplied value was a plain ABI value rather than a transaction.
+    #[error("expected a transaction argument")]
+    ExpectedTransactionArgument,
+    /// An ABI argument could not be converted to the type the method
+    /// signature requires. `actual` is a diagnostic rendering of the value
+    /// that was supplied.
+    #[error("invalid ABI argument: expected {expected}, got {actual}")]
+    InvalidAbiArgument {
+        expected: &'static str,
+        actual: String,
+    },
+    /// A logged ABI return value was not valid base64 and could not be
+    /// decoded. The source carries the underlying decode failure.
+    #[error("failed to base64-decode a logged ABI return value")]
+    Base64DecodeError {
+        #[source]
+        source: data_encoding::DecodeError,
+    },
+    /// The composer reassembled signer output but found no signature for
+    /// the slot at `index`. This is an SDK-internal invariant violation
+    /// (please open an [issue](https://github.com/manuelmauro/algonaut/issues)!).
+    #[error("internal error: no signature produced for transaction at index {index}")]
+    InternalSigningIncomplete { index: usize },
 
     /// A transaction construction or signing error from
     /// [`algonaut_transaction`], preserved as the error source.

--- a/tests/step_defs/integration/abi.rs
+++ b/tests/step_defs/integration/abi.rs
@@ -362,7 +362,7 @@ struct MethodCallCtx {
 
 impl MethodCallCtx {
     fn builder(&self) -> algonaut::atomic::MethodCallBuilder {
-        MethodCall::new(
+        MethodCall::builder(
             self.app_id,
             self.method.clone(),
             self.sender,
@@ -434,7 +434,7 @@ fn i_append_the_current_transaction_with_signer_to_the_method_arguments_array(w:
     let method_args = w.abi_method_arg_values.as_mut().expect("no method args");
     let tx_with_signer = w.tx_with_signer.clone().expect("no tx signer");
 
-    method_args.push(AbiArgValue::TxWithSigner(tx_with_signer));
+    method_args.push(AbiArgValue::from(tx_with_signer));
 }
 
 #[when(


### PR DESCRIPTION
Accepts and fully implements the **`idiomatic-rust-in-algonaut-atomic`** ADR — a deep idiomatic-Rust pass over `src/atomic`. The ADR is flipped from `proposed` to `accepted` in this PR.

> **Breaking change.** Public API moves: `MethodCall::new` → `MethodCall::builder`, `MethodCallBuilder::args` now takes `impl IntoIterator<Item = impl Into<AbiArgValue>>`, `AbiArgValue::TxWithSigner` now wraps a `Box`, and `ExecuteOutcome`/`SimulateOutcome` expose `tx_ids: Vec<TxId>` instead of `Vec<String>`. The `!` rides on the squash-merge PR title (the `commit-msg` hook rejects `!` in commit subjects).

> ⚠️ **Behavioral change (encoding fix), beyond the ADR's scope.** Commit `cbd8bd5` fixes a latent bug in the >15-argument tuple-wrapping path: the previous code appended the overflow tuple **without truncating** the already-appended direct args, so a method call with more than 15 ABI arguments encoded *more than 15* application arguments. Verified against the official `py-algorand-sdk` (`atomic_transaction_composer.py`, `MAX_APP_ARG_LIMIT = 16`), which truncates the direct args to the first 14 before appending the tuple. The fix uses `Vec::split_off(14)` (14 direct args + 1 tuple = 15 slots) and adds boundary/overflow unit tests. This **changes encoded output** for calls with >15 ABI args — flagging explicitly so it isn't mistaken for a behavior-neutral refactor. Splittable into its own PR if you'd rather keep this one refactor-only.

## What changed (per ADR decision)

| # | Decision | Implementation |
|---|----------|----------------|
| 1 | Box the large enum variant | `AbiArgValue::TxWithSigner(Box<…>)`; `large_enum_variant` allow removed |
| 2 | `new` → `builder` | `MethodCall::builder`; `new_ret_no_self` allow removed |
| 3 | Helper structs over long arg lists | `ForeignArrays` + `EncodedArgs`; `too_many_arguments` allow removed |
| 4 | Consume `MethodCall` fields | `process_method_call` destructures `call` and moves each field once |
| 5 | `TryFrom` over `Option` helpers | `TryFrom<&AbiArgValue>` for `Address`/`BigUint`; `.address()`/`.int()` deleted |
| 6 | Typed tx ids | `tx_ids() -> Vec<TxId>`; both outcome structs carry `Vec<TxId>` |
| 7 | Structured errors | 7 new `Error` variants; **zero** `Error::Msg`/`Internal` left in `atomic` |
| 8 | `Vec<T>` over `Option<Vec<T>>` | `note`/`boxes` builders default empty; mapped to `Option` only at encode |
| 9 | Primitives over `SuggestedParams` clone | stores `first_valid`/`last_valid`/`genesis_hash`/`genesis_id` |
| 10 | Flatten with `From` | `From<AbiValue>`/`From<TransactionWithSigner>` for `AbiArgValue` |
| 11 | `From` impls for native types | `.args([2u64, 3u64])` now works |
| 12 | Reduce execute-loop cloning | confirmed slot decoded by reference; per-iteration clones removed |

## Faithful adaptations to the ADR's pseudocode

Two decisions are implemented in the spirit of the ADR but diverge from its literal sketch, because the literal form does not compile or is strictly worse:

- **Decision 11 — no blanket `impl<T: Into<AbiValue>> From<T> for AbiArgValue`.** That blanket collides (coherence E0119) with both the reflexive `From<AbiArgValue>` and the `From<TransactionWithSigner>` impl. Replaced with enumerated `From` impls (`u64, u128, bool, Address, &str, String, Vec<u8>`) generated by a small local macro, with the rationale captured in a code comment. Same call-site ergonomics.
- **Decision 5 — transaction-typed args extracted by owned move, not `TryFrom<&_> for &TransactionWithSigner`.** Since `process_method_call` now owns `method_args`, the boxed `TransactionWithSigner` is moved out of the matched value instead of borrowed-then-cloned, with `Error::ExpectedTransactionArgument` on mismatch.

## Verification

`make ci` is green (the pre-commit hook ran it): `fmt-check`, `clippy --workspace --all-targets -- -D warnings`, all 18 root-lib unit tests (including the two new `wrap_overflow` tests), integration compile-check, and `build`. **Zero `#[allow(clippy::…)]` remain in `src/atomic`.** `arkouda check` passes on the 24 ADRs.

Network-bound cucumber integration tests (`features_runner`) are compile-checked only here, as they require a live sandbox harness.

