### PR TITLE
ci: allow the "!" breaking-change marker in the commit-msg hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,5 +7,5 @@ commit-msg:
   commands:
     conventional-commit:
       run: >
-        head -1 {1} | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?: .+'
-        || { echo "Commit message must follow Conventional Commits: <type>(scope): <description>"; exit 1; }
+        head -1 {1} | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+'
+        || { echo "Commit message must follow Conventional Commits: <type>(scope)!: <description>"; exit 1; }


### PR DESCRIPTION
## Problem

The `commit-msg` conventional-commit check matched `<type>(scope): <desc>` but had no slot for the `!` that Conventional Commits uses to flag a breaking change. Subjects like `refactor(atomic)!: ...` were rejected locally, forcing the breaking marker to be smuggled in via the squash-merge PR title instead of living in the commit itself.

## Fix

Add an optional `!?` between the (optional) scope and the colon, and update the error hint to show it:

```diff
-grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?: .+'
+grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+'
```

## Verification

| subject | before | after |
|---|---|---|
| `refactor(atomic)!: breaking` | FAIL | PASS |
| `feat!: breaking no scope` | FAIL | PASS |
| `docs(adr): normal` | PASS | PASS |
| `nope: bad type` | FAIL | FAIL |

One-line change to `lefthook.yml`; no behavior change for existing non-breaking subjects.