### PR TITLE
feat(features)!: gate algod, indexer, and kmd clients behind cargo features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,11 @@ members = [
 algonaut_abi = { path = "algonaut_abi", version = "0.7.0" }
 algonaut_abi_sig = { path = "algonaut_abi_sig", version = "0.7.0" }
 algonaut_abi_macros = { path = "algonaut_abi_macros", version = "0.7.0" }
-algonaut_algod = { path = "algonaut_algod", version = "0.7.0" }
+algonaut_algod = { path = "algonaut_algod", version = "0.7.0", default-features = false }
 algonaut_core = { path = "algonaut_core", version = "0.7.0" }
 algonaut_crypto = { path = "algonaut_crypto", version = "0.7.0" }
 algonaut_encoding = { path = "algonaut_encoding", version = "0.7.0" }
-algonaut_indexer = { path = "algonaut_indexer", version = "0.7.0" }
+algonaut_indexer = { path = "algonaut_indexer", version = "0.7.0", default-features = false }
 algonaut_kmd = { path = "algonaut_kmd", version = "0.7.0", default-features = false }
 algonaut_model = { path = "algonaut_model", version = "0.7.0" }
 algonaut_transaction = { path = "algonaut_transaction", version = "0.7.0" }
@@ -60,7 +60,9 @@ syn = { version = "2.0", features = ["full"] }
 ed25519-dalek = "2.2.0"
 rand = "0.8.5"
 regex = "1.12.3"
-reqwest = "0.13.3"
+# default-features = false so each client crate picks exactly one TLS backend
+# via its own native/rustls feature (no always-on native-tls). See ADR D4.
+reqwest = { version = "0.13.3", default-features = false }
 rmp-serde = "1.3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.19"
@@ -78,14 +80,16 @@ wiremock = "0.6.5"
 
 [dependencies]
 algonaut_abi = { workspace = true }
-algonaut_algod = { workspace = true }
 algonaut_core = { workspace = true }
 algonaut_crypto = { workspace = true }
 algonaut_encoding = { workspace = true }
-algonaut_indexer = { workspace = true }
-algonaut_kmd = { workspace = true }
 algonaut_model = { workspace = true }
 algonaut_transaction = { workspace = true }
+
+# Generated network clients — gated behind their respective features.
+algonaut_algod = { workspace = true, optional = true }
+algonaut_indexer = { workspace = true, optional = true }
+algonaut_kmd = { workspace = true, optional = true }
 
 data-encoding = { workspace = true }
 env_logger = { workspace = true }
@@ -94,7 +98,8 @@ instant = { workspace = true, features = ["now"] }
 log = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
-reqwest = { workspace = true }
+# Only the algod/indexer wrappers build a reqwest client; pulled by those features.
+reqwest = { workspace = true, optional = true }
 rmp-serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
@@ -115,12 +120,148 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 wiremock = { workspace = true }
 
 [features]
-default = ["native"]
-native = ["algonaut_kmd/native"]
-rustls = ["algonaut_kmd/rustls"]
+# rustls is the default TLS backend: pure-Rust, no system OpenSSL.
+default = ["algod", "indexer", "kmd", "rustls"]
+
+# High-level network clients. Each pulls its generated client crate and
+# unlocks the matching hand-written module(s). `algod` also gates the
+# atomic / simulate / dryrun modules, which build on algod's models.
+algod = ["dep:algonaut_algod", "dep:reqwest"]
+indexer = ["dep:algonaut_indexer", "dep:reqwest"]
+kmd = ["dep:algonaut_kmd"]
+
+# TLS backend, forwarded to every enabled client. The weak `?` deps mean an
+# unselected client is never pulled in just to set its TLS feature.
+native = ["algonaut_algod?/native", "algonaut_indexer?/native", "algonaut_kmd?/native"]
+rustls = ["algonaut_algod?/rustls", "algonaut_indexer?/rustls", "algonaut_kmd?/rustls"]
 
 [[test]]
 name = "features_runner"
 # Allows Cucumber to print output instead of libtest
 harness = false
 test = false
+# The cucumber acceptance suite drives the live algod/indexer/kmd clients.
+required-features = ["algod", "indexer", "kmd"]
+
+# Examples declare the client features they exercise, so a slimmer build
+# (e.g. `--no-default-features --features algod`) skips the ones it cannot
+# compile instead of failing.
+[[example]]
+name = "algod_client"
+required-features = ["algod"]
+
+[[example]]
+name = "app_call"
+required-features = ["algod"]
+
+[[example]]
+name = "app_clear_state"
+required-features = ["algod"]
+
+[[example]]
+name = "app_close_out"
+required-features = ["algod"]
+
+[[example]]
+name = "app_create"
+required-features = ["algod"]
+
+[[example]]
+name = "app_delete"
+required-features = ["algod"]
+
+[[example]]
+name = "app_optin"
+required-features = ["algod"]
+
+[[example]]
+name = "app_update"
+required-features = ["algod"]
+
+[[example]]
+name = "asset_clawback"
+required-features = ["algod"]
+
+[[example]]
+name = "asset_create"
+required-features = ["algod"]
+
+[[example]]
+name = "asset_optin"
+required-features = ["algod"]
+
+[[example]]
+name = "asset_transfer"
+required-features = ["algod"]
+
+[[example]]
+name = "atomic"
+required-features = ["algod"]
+
+[[example]]
+name = "atomic_swap"
+required-features = ["algod"]
+
+[[example]]
+name = "indexer_query"
+required-features = ["indexer"]
+
+[[example]]
+name = "key_reg"
+required-features = ["algod"]
+
+[[example]]
+name = "kmd_client"
+required-features = ["kmd"]
+
+[[example]]
+name = "kmd_sign_submit_transaction"
+required-features = ["algod", "kmd"]
+
+[[example]]
+name = "last_block"
+required-features = ["algod"]
+
+[[example]]
+name = "logic_sig_contract_account"
+required-features = ["algod"]
+
+[[example]]
+name = "logic_sig_delegated"
+required-features = ["algod"]
+
+[[example]]
+name = "logic_sig_delegated_multi"
+required-features = ["algod"]
+
+[[example]]
+name = "multi_sig"
+required-features = ["algod"]
+
+[[example]]
+name = "payment"
+required-features = ["algod"]
+
+[[example]]
+name = "quickstart"
+required-features = ["algod", "indexer", "kmd"]
+
+[[example]]
+name = "rekey"
+required-features = ["algod"]
+
+[[example]]
+name = "sign_offline"
+required-features = ["algod"]
+
+[[example]]
+name = "submit_file"
+required-features = ["algod"]
+
+[[example]]
+name = "wallet_backup"
+required-features = ["kmd"]
+
+[[example]]
+name = "wallet_restore"
+required-features = ["kmd"]

--- a/algonaut_algod/Cargo.toml
+++ b/algonaut_algod/Cargo.toml
@@ -14,10 +14,19 @@ algonaut_encoding = { workspace = true }
 algonaut_model = { workspace = true }
 algonaut_transaction = { workspace = true }
 data-encoding = { workspace = true }
-reqwest = { workspace = true, features = ["json", "multipart", "query"] }
+# default-features = false (workspace) drops reqwest's default TLS so the
+# backend is feature-selected; the other former defaults are re-added here.
+reqwest = { workspace = true, features = ["json", "multipart", "query", "charset", "http2", "system-proxy"] }
 rmp-serde = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
+
+# TLS backend. `default-features = false` on reqwest above means exactly one
+# of these picks the backend; the umbrella crate forwards its own native/rustls.
+[features]
+default = ["rustls"]
+native = ["reqwest/native-tls"]
+rustls = ["reqwest/rustls"]

--- a/algonaut_indexer/Cargo.toml
+++ b/algonaut_indexer/Cargo.toml
@@ -10,9 +10,18 @@ edition = "2024"
 [dependencies]
 algonaut_crypto = { workspace = true }
 algonaut_encoding = { workspace = true }
-reqwest = { workspace = true, features = ["json", "multipart", "query"] }
+# default-features = false (workspace) drops reqwest's default TLS so the
+# backend is feature-selected; the other former defaults are re-added here.
+reqwest = { workspace = true, features = ["json", "multipart", "query", "charset", "http2", "system-proxy"] }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
+
+# TLS backend. `default-features = false` on reqwest above means exactly one
+# of these picks the backend; the umbrella crate forwards its own native/rustls.
+[features]
+default = ["rustls"]
+native = ["reqwest/native-tls"]
+rustls = ["reqwest/rustls"]

--- a/algonaut_kmd/Cargo.toml
+++ b/algonaut_kmd/Cargo.toml
@@ -33,6 +33,6 @@ rand = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 
 [features]
-default = ["native"]
+default = ["rustls"]
 rustls = ["reqwest/rustls"]
 native = ["reqwest/native-tls"]

--- a/docs/adr/client-feature-gates.md
+++ b/docs/adr/client-feature-gates.md
@@ -2,7 +2,7 @@
 id: client-feature-gates
 title: Cargo feature gates for the client modules
 abstract: Put the algod, indexer, and kmd client modules behind additive Cargo features (algod, indexer, kmd), offline core always on, default = the three clients plus a TLS backend so the gating is non-breaking; default-features=false enables slim and wasm32 builds that drop reqwest. The raw openapi_* re-exports are not gated but removed, as the closing act of the hand-named-types migration (north-star D3 / hide-generated-types).
-status: proposed
+status: accepted
 date: 2026-05-22
 deciders: []
 tags: [build, features, wasm, modularity]
@@ -12,7 +12,7 @@ tags: [build, features, wasm, modularity]
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -38,12 +38,14 @@ rustls  = ["algonaut_kmd/rustls"]
 `native`/`rustls` forward only to `algonaut_kmd`. But `algonaut_algod` and
 `algonaut_indexer` declare their `reqwest` dependency as
 `reqwest = { workspace = true, features = ["json", "multipart", "query"] }`,
-and the workspace `reqwest` carries default features — so `native-tls` is
-*always* compiled into the algod and indexer clients regardless of which
-feature the consumer picked. Selecting `rustls` does not give you a
-rustls-only build; it gives you rustls for kmd and native-tls everywhere
-else. The one feature axis the crate already has is silently broken for two
-of its three clients.
+and the workspace `reqwest` carries default features — so reqwest's
+`default-tls` backend is *always* compiled into the algod and indexer clients
+regardless of which feature the consumer picked. (In reqwest 0.13,
+`default-tls` resolves to **rustls**, so today algod/indexer are pinned to
+rustls while kmd follows the feature — selecting `native` gives you native-tls
+for kmd but rustls for algod/indexer, i.e. both stacks linked at once.) The one
+feature axis the crate already has is silently ignored by two of its three
+clients.
 
 ### 2. Offline users still pay for three HTTP clients
 
@@ -118,7 +120,8 @@ gates are a capability for people who want *less*, not a removal of anything.
 
 ```toml
 [features]
-default = ["algod", "indexer", "kmd", "native"]
+# rustls is the default TLS backend: pure-Rust, no system OpenSSL.
+default = ["algod", "indexer", "kmd", "rustls"]
 
 # High-level network clients. Each pulls its generated crate and unlocks
 # the matching hand-written module(s).
@@ -243,13 +246,18 @@ features `algonaut_kmd` already has, declaring their `reqwest` with
 rather than always-on:
 
 ```toml
-# in algonaut_algod / algonaut_indexer
-reqwest = { workspace = true, default-features = false, features = ["json", "multipart", "query"] }
+# workspace.dependencies — drop reqwest's default TLS for every client crate.
+# (default-features must be set here, not on the inheriting member.)
+reqwest = { version = "0.13.3", default-features = false }
+
+# in algonaut_algod / algonaut_indexer — add the TLS-backend axis kmd already
+# has, and re-declare the non-TLS former defaults so only TLS is feature-gated.
+reqwest = { workspace = true, features = ["json", "multipart", "query", "charset", "http2", "system-proxy"] }
 
 [features]
-default = ["native"]
+default = ["rustls"]
 native  = ["reqwest/native-tls"]
-rustls  = ["reqwest/rustls"]
+rustls  = ["reqwest/rustls"]   # reqwest 0.13's feature is `rustls`, not `rustls-tls`
 ```
 
 After this, the root `native`/`rustls` features forward to all three clients
@@ -271,10 +279,17 @@ After this, the root `native`/`rustls` features forward to all three clients
   signing, ABI, the domain model — with no `reqwest` and no TLS stack. A
   browser/wasm signer can build and sign without dragging in a native HTTP
   client. This is the headline win.
-- **The broken TLS axis is fixed.** `rustls` finally means rustls everywhere,
-  not "rustls for kmd, native-tls for the rest." This is a behavioural change
-  for anyone who selected `rustls` and unknowingly still linked native-tls via
-  algod/indexer; on most platforms it removes a system OpenSSL dependency.
+- **The broken TLS axis is fixed, and the default is now rustls.** The
+  `native`/`rustls` feature controls all three clients uniformly — umbrella and
+  leaf-crate defaults agree, so a `--workspace` build does not compile both
+  stacks. Previously algod/indexer ignored the axis, pinned to reqwest's
+  `default-tls` (rustls in reqwest 0.13), while kmd used native-tls — so the old
+  default linked *both*. With `default-features = false` on the shared reqwest
+  and `default = ["rustls"]`, the default build is **pure-Rust rustls with no
+  system OpenSSL** (a strict improvement: `main` pulled OpenSSL via kmd), and
+  `--features rustls` is verifiably native-tls-free. `native` is available
+  opt-in. The non-TLS former defaults (`http2`, `charset`, `system-proxy`) are
+  re-declared on algod/indexer so only the TLS backend changes.
 - **The raw re-exports are removed, not gated.** This ADR introduces no
   escape-hatch feature; the `openapi_*` re-exports are deleted as the closing
   act of north-star D3 / [`hide-generated-types`](hide-generated-types.md),

--- a/src/error.rs
+++ b/src/error.rs
@@ -194,6 +194,7 @@ impl RequestErrorDetails {
     }
 }
 
+#[cfg(feature = "algod")]
 impl From<crate::algod::v2::error::AlgodError> for Error {
     fn from(error: crate::algod::v2::error::AlgodError) -> Self {
         use crate::algod::v2::error::AlgodError;
@@ -222,6 +223,7 @@ impl From<crate::algod::v2::error::AlgodError> for Error {
     }
 }
 
+#[cfg(feature = "indexer")]
 impl From<crate::indexer::v2::error::IndexerError> for Error {
     fn from(error: crate::indexer::v2::error::IndexerError) -> Self {
         use crate::indexer::v2::error::IndexerError;
@@ -249,6 +251,7 @@ impl From<crate::indexer::v2::error::IndexerError> for Error {
     }
 }
 
+#[cfg(feature = "kmd")]
 impl From<algonaut_kmd::error::ClientError> for Error {
     fn from(error: algonaut_kmd::error::ClientError) -> Self {
         match error {
@@ -261,12 +264,14 @@ impl From<algonaut_kmd::error::ClientError> for Error {
     }
 }
 
+#[cfg(feature = "kmd")]
 impl From<algonaut_kmd::error::RequestError> for RequestError {
     fn from(error: algonaut_kmd::error::RequestError) -> Self {
         RequestError::new(error.url.clone(), error.details.into())
     }
 }
 
+#[cfg(feature = "kmd")]
 impl From<algonaut_kmd::error::RequestErrorDetails> for RequestErrorDetails {
     fn from(details: algonaut_kmd::error::RequestErrorDetails) -> Self {
         match details {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,16 +12,30 @@ pub use algonaut_crypto as crypto;
 pub use algonaut_model as model;
 pub use algonaut_transaction as transaction;
 
+// Raw generated clients. These re-exports are a transitional escape hatch:
+// they ride their client's feature gate today and are removed once the
+// hand-named-types migration completes (see ADR `hide-generated-types`).
+#[cfg(feature = "algod")]
 pub use algonaut_algod as openapi_algod;
+#[cfg(feature = "indexer")]
 pub use algonaut_indexer as openapi_indexer;
+#[cfg(feature = "kmd")]
 pub use algonaut_kmd as openapi_kmd;
 
+#[cfg(feature = "algod")]
 pub mod algod;
+#[cfg(feature = "indexer")]
 pub mod indexer;
+#[cfg(feature = "kmd")]
 pub mod kmd;
 
+// atomic / dryrun / simulate consume `algonaut_algod::models` directly, so
+// they ride the `algod` gate until that coupling is removed (ADR D3).
+#[cfg(feature = "algod")]
 pub mod atomic;
+#[cfg(feature = "algod")]
 pub mod dryrun;
+#[cfg(feature = "algod")]
 pub mod simulate;
 
 pub mod error;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,5 @@
+// The dryrun printer renders an algod `DryrunResponse`, so it needs the algod client.
+#[cfg(feature = "algod")]
 pub mod dryrun_printer;
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
## Summary

Implements ADR [`client-feature-gates`](docs/adr/client-feature-gates.md) (flipped **proposed → accepted** in this PR). The umbrella `algonaut` crate's three network clients become additive, opt-out Cargo features; the offline core (transactions, signing, ABI, model) is always on.

```toml
# rustls is the default TLS backend: pure-Rust, no system OpenSSL.
default = ["algod", "indexer", "kmd", "rustls"]
algod   = ["dep:algonaut_algod", "dep:reqwest"]
indexer = ["dep:algonaut_indexer", "dep:reqwest"]
kmd     = ["dep:algonaut_kmd"]
native  = ["algonaut_algod?/native", "algonaut_indexer?/native", "algonaut_kmd?/native"]
rustls  = ["algonaut_algod?/rustls", "algonaut_indexer?/rustls", "algonaut_kmd?/rustls"]
```

`default` keeps today's module surface, so the gating is **non-breaking for default builds**. `default-features = false` gives an offline build with **no reqwest / TLS stack** — for slim and `wasm32` consumers.

## What changed

- **`lib.rs` / `error.rs` / `util`** — `#[cfg]` gate the client modules, the `openapi_*` re-exports, the algod-coupled `atomic`/`simulate`/`dryrun` modules, and the per-client `From` impls.
- **Root `Cargo.toml`** — `reqwest` and the three generated client crates become optional, pulled by their feature.
- **D4 (TLS) — default is now rustls.** The shared `reqwest` is `default-features = false`, so the backend is feature-selected, and the `native`/`rustls` axis controls **all three** clients uniformly. Umbrella and leaf-crate defaults agree, so a `--workspace` build never compiles both stacks. Previously algod/indexer were pinned to reqwest's `default-tls` (which is **rustls** in 0.13) while kmd used native-tls — the old default linked *both*. The non-TLS former reqwest defaults (`http2`/`charset`/`system-proxy`) are re-declared so only the TLS backend changes.
- **Examples + cucumber runner** — declare `required-features` so slim builds skip what they can't compile.

## TLS backends

- **`rustls` (default)** — pure-Rust, **no system OpenSSL**; trusts the bundled webpki roots. Best for most consumers, cross-compilation, and `wasm32`. A strict improvement over `main`, which pulled OpenSSL via kmd's native default.
- **`native` (opt-in)** — platform TLS using the **OS trust store**. Needed when the peer's CA is in the OS store but not in webpki roots — e.g. a corporate TLS-intercepting proxy or a private algod node with an internal CA. reqwest 0.13 exposes no rustls+native-roots feature, so `native` is the only path to OS-trust-store TLS. Select with `--no-default-features --features "algod,…,native"`.

## Verification

| build | result |
|---|---|
| `--no-default-features` | ✅ compiles; `reqwest` **absent** from dep tree |
| `--features algod` / `indexer` / `kmd` (each alone) | ✅ |
| default (`--all-targets`, 30 examples + cucumber runner) | ✅ |
| default tree (umbrella, leaves, whole workspace) | `native-tls` **absent**, `rustls` present |
| `--features native` (opt-in) | `native-tls` present |
| `cargo fmt --check`, `clippy --workspace --all-targets -D warnings` | ✅ (lefthook) |

## ADR corrections (from implementation)

- Context §1 was **factually inverted**: reqwest 0.13's `default-tls` is *rustls*, not native-tls — so algod/indexer were pinned to rustls. The structural bug (TLS not controlled by the feature) was real; the named backend was wrong. Corrected.
- The D4 sketch's `default-features = false`-on-the-member doesn't compile (Cargo rejects overriding workspace `default-features`); corrected to set it on the workspace dep. reqwest 0.13's feature is `rustls`, not `rustls-tls`.

## Breaking change

`default-features = false` no longer pulls the algod/indexer/kmd clients — opt in via their features. The `openapi_*` re-exports are gated on their client feature. The default TLS backend is now rustls for all clients (previously native-tls for kmd, rustls for algod/indexer). Pre-1.0; one-line migration.

## Note

`raw_openapi_clients` is intentionally **not** a feature — the re-exports ride their client gate transitionally and are removed when the hand-named-types migration (`hide-generated-types` / D3) completes.
