### PR TITLE
fix(tests): additional cucumber test fixes

### DIFF
--- a/tests/step_defs/integration/abi.rs
+++ b/tests/step_defs/integration/abi.rs
@@ -149,11 +149,20 @@ async fn the_composer_should_have_a_status_of(w: &mut World, status_str: String)
 }
 
 #[then(expr = "I clone the composer.")]
+#[given(expr = "I clone the composer.")]
 async fn i_clone_the_composer(w: &mut World) {
-    // AtomicGroupBuilder is Clone (group ids are only assigned at build), so the
-    // "snapshot a common prefix" use case is a plain clone.
-    let builder = w.group_builder.as_ref().expect("composer not building");
+    // Python SDK's AtomicTransactionComposer.clone() returns a new composer
+    // with status BUILDING containing the same transactions. If the composer
+    // was already built/signed, we restore from the backup taken before build.
+    let builder = w
+        .group_builder
+        .as_ref()
+        .or(w.group_builder_backup.as_ref())
+        .expect("composer not building");
     w.group_builder = Some(builder.clone());
+    // Clear any staged built/signed state so the cloned builder can be used fresh.
+    w.unsigned_group = None;
+    w.signed_group = None;
 }
 
 #[when(regex = r#"I create the Method object from method signature "([^"]*)"$"#)]

--- a/tests/step_defs/integration/compile.rs
+++ b/tests/step_defs/integration/compile.rs
@@ -11,7 +11,8 @@ fn read_resource(name: &str) -> Vec<u8> {
 }
 
 fn parse_status_from_error(err: &str) -> u16 {
-    regex::Regex::new(r"status:\s*(\d+)")
+    // Match "Http error: {status}" format from RequestErrorDetails.
+    regex::Regex::new(r"Http error: (\d+)")
         .unwrap()
         .captures(err)
         .and_then(|c| c.get(1))

--- a/tests/step_defs/integration/world.rs
+++ b/tests/step_defs/integration/world.rs
@@ -48,6 +48,9 @@ pub struct World {
     pub tx_signer: Option<Arc<dyn Signer>>,
     pub tx_with_signer: Option<TransactionWithSigner>,
     pub group_builder: Option<AtomicGroupBuilder>,
+    /// A backup of group_builder preserved when building/signing, so that
+    /// "I clone the composer" can restore to the pre-build state.
+    pub group_builder_backup: Option<AtomicGroupBuilder>,
     pub unsigned_group: Option<UnsignedAtomicGroup>,
     pub signed_group: Option<SignedAtomicGroup>,
     pub tx_composer_methods: Option<Vec<AbiMethod>>,
@@ -108,15 +111,17 @@ pub struct World {
 impl World {
     /// Take the staged group as an [`UnsignedAtomicGroup`], building it from the
     /// [`AtomicGroupBuilder`] if `build` hasn't been called yet.
+    ///
+    /// Before consuming `group_builder`, a clone is saved to `group_builder_backup`
+    /// so that "I clone the composer" can restore to the pre-build state.
     pub fn take_unsigned_group(&mut self) -> UnsignedAtomicGroup {
         if let Some(unsigned) = self.unsigned_group.take() {
             unsigned
         } else {
-            self.group_builder
-                .take()
-                .expect("no composer in progress")
-                .build()
-                .expect("group build failed")
+            let builder = self.group_builder.take().expect("no composer in progress");
+            // Backup the builder so clone can restore to the pre-build state.
+            self.group_builder_backup = Some(builder.clone());
+            builder.build().expect("group build failed")
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix composer clone after signing by preserving group_builder backup
- Fix HTTP status parsing for compile errors (regex mismatch)

## Changes

### Composer clone fix
The "I clone the composer" step failed when called after signatures were gathered because `take_unsigned_group()` consumed `group_builder`. Now we backup `group_builder` before building/signing, and restore from backup in clone if `group_builder` is already consumed.

### Compile status fix
The error format is `Http error: {status}` but the regex was looking for `status: {status}`. Updated regex to match the actual format.

## Test plan
- [x] Run cucumber tests for abi.feature - clone steps now pass
- [x] Run cucumber tests for compile.feature - all 8 scenarios pass

## Remaining failures
The following issues from #331 still need investigation:
- KMD signature mismatch (sdk signed tx != kmd signed tx)
- KMD wallet setup issues (created wallet handle not set)
- Overspend/funding issues (account balance issues)

🤖 Generated with [Claude Code](https://claude.ai/code)