### PR TITLE
refactor(core): extract protocol domain separators into constants

### DIFF
--- a/algonaut_core/src/address.rs
+++ b/algonaut_core/src/address.rs
@@ -1,4 +1,5 @@
 use crate::Signature;
+use crate::domain_separator::{MESSAGE_PREFIX, MULTISIG_ADDR_PREFIX};
 use algonaut_crypto::Ed25519PublicKey;
 use algonaut_encoding::U8_32Visitor;
 use data_encoding::BASE32_NOPAD;
@@ -55,7 +56,7 @@ impl Address {
     }
 
     pub fn verify_bytes(&self, message: &[u8], signature: &Signature) -> bool {
-        let mut message_to_verify = b"MX".to_vec();
+        let mut message_to_verify = MESSAGE_PREFIX.to_vec();
         message_to_verify.extend_from_slice(message);
         self.as_public_key().verify(&message_to_verify, signature)
     }
@@ -162,7 +163,7 @@ impl MultisigAddress {
 
     /// Generates a checksum from the contained public keys usable as an address
     pub fn address(&self) -> Address {
-        let mut buf = b"MultisigAddr".to_vec();
+        let mut buf = MULTISIG_ADDR_PREFIX.to_vec();
         buf.push(self.version);
         buf.push(self.threshold);
         for key in &self.public_keys {

--- a/algonaut_core/src/domain_separator.rs
+++ b/algonaut_core/src/domain_separator.rs
@@ -1,0 +1,22 @@
+//! Algorand protocol domain separators (hash prefixes).
+//!
+//! These byte-string prefixes are prepended to data before hashing to ensure
+//! domain separation across different contexts (transactions, groups, bids, etc.).
+
+/// Prefix for signing arbitrary messages ("MX").
+pub const MESSAGE_PREFIX: &[u8] = b"MX";
+
+/// Prefix for transaction hashes ("TX").
+pub const TRANSACTION_PREFIX: &[u8] = b"TX";
+
+/// Prefix for transaction group hashes ("TG").
+pub const TRANSACTION_GROUP_PREFIX: &[u8] = b"TG";
+
+/// Prefix for multisig address derivation ("MultisigAddr").
+pub const MULTISIG_ADDR_PREFIX: &[u8] = b"MultisigAddr";
+
+/// Prefix for program (TEAL) hashes ("Program").
+pub const PROGRAM_PREFIX: &[u8] = b"Program";
+
+/// Prefix for bid signatures ("aB").
+pub const BID_PREFIX: &[u8] = b"aB";

--- a/algonaut_core/src/lib.rs
+++ b/algonaut_core/src/lib.rs
@@ -17,6 +17,7 @@ pub use address::MultisigAddress;
 pub use multisig::MultisigSubsig;
 
 mod address;
+pub mod domain_separator;
 pub mod error;
 mod multisig;
 
@@ -375,7 +376,7 @@ pub struct CompiledTeal(pub Vec<u8>);
 
 impl CompiledTeal {
     pub fn bytes_to_sign(&self) -> Vec<u8> {
-        let mut prefix_encoded_tx = b"Program".to_vec();
+        let mut prefix_encoded_tx = domain_separator::PROGRAM_PREFIX.to_vec();
         prefix_encoded_tx.extend_from_slice(&self.0);
         prefix_encoded_tx
     }

--- a/algonaut_transaction/src/account.rs
+++ b/algonaut_transaction/src/account.rs
@@ -3,6 +3,7 @@ use std::convert::TryInto;
 use crate::auction::{Bid, SignedBid};
 use crate::error::TransactionError;
 use crate::transaction::{SignedTransaction, Transaction, TransactionSignature};
+use algonaut_core::domain_separator::{BID_PREFIX, MESSAGE_PREFIX};
 use algonaut_core::{
     Address, CompiledTeal, MultisigAddress, MultisigSignature, MultisigSubsig, ToMsgPack,
 };
@@ -91,7 +92,7 @@ impl Account {
 
     /// Sign the given bytes, and wrap in signature. The message is prepended with an identifier for domain separation.
     pub fn generate_sig(&self, bytes: &[u8]) -> Signature {
-        let mut bytes_sign_prefix = b"MX".to_vec();
+        let mut bytes_sign_prefix = MESSAGE_PREFIX.to_vec();
         bytes_sign_prefix.extend_from_slice(bytes);
         self.generate_raw_sig(&bytes_sign_prefix)
     }
@@ -110,7 +111,7 @@ impl Account {
     /// Sign a bid with the account's private key
     pub fn sign_bid(&self, bid: Bid) -> Result<SignedBid, TransactionError> {
         let encoded_bid = bid.to_msg_pack()?;
-        let mut prefix_encoded_bid = b"aB".to_vec();
+        let mut prefix_encoded_bid = BID_PREFIX.to_vec();
         prefix_encoded_bid.extend_from_slice(&encoded_bid);
         let signature = self.generate_raw_sig(&prefix_encoded_bid);
         Ok(SignedBid {

--- a/algonaut_transaction/src/group.rs
+++ b/algonaut_transaction/src/group.rs
@@ -1,4 +1,5 @@
 use algonaut_core::ToMsgPack;
+use algonaut_core::domain_separator::TRANSACTION_GROUP_PREFIX;
 use algonaut_crypto::HashDigest;
 use serde::{Deserialize, Serialize, Serializer};
 use sha2::Digest;
@@ -118,7 +119,7 @@ impl ToMsgPack for TransactionGroupDigests {}
 impl TransactionGroupDigests {
     fn bytes_to_sign(&self) -> Result<Vec<u8>, TransactionError> {
         let encoded_tx = self.to_msg_pack()?;
-        let mut prefix_encoded_tx = b"TG".to_vec();
+        let mut prefix_encoded_tx = TRANSACTION_GROUP_PREFIX.to_vec();
         prefix_encoded_tx.extend_from_slice(&encoded_tx);
         Ok(prefix_encoded_tx)
     }

--- a/algonaut_transaction/src/transaction.rs
+++ b/algonaut_transaction/src/transaction.rs
@@ -4,6 +4,7 @@ use algonaut_core::LogicSignature;
 use algonaut_core::SuggestedTransactionParams;
 use algonaut_core::ToMsgPack;
 use algonaut_core::TransactionTypeEnum;
+use algonaut_core::domain_separator::TRANSACTION_PREFIX;
 use algonaut_core::{Address, MultisigSignature};
 use algonaut_core::{AppId, AssetId, TransactionId};
 use algonaut_core::{MicroAlgos, Round, StateProofPk, VotePk, VrfPk};
@@ -90,7 +91,7 @@ pub struct Transaction {
 impl Transaction {
     pub fn bytes_to_sign(&self) -> Result<Vec<u8>, TransactionError> {
         let encoded_tx = self.to_owned().to_msg_pack()?;
-        let mut prefix_encoded_tx = b"TX".to_vec();
+        let mut prefix_encoded_tx = TRANSACTION_PREFIX.to_vec();
         prefix_encoded_tx.extend_from_slice(&encoded_tx);
         Ok(prefix_encoded_tx)
     }


### PR DESCRIPTION
## Summary
- Add new `domain_separator` module in `algonaut_core` with named constants for Algorand protocol hash prefixes
- Replace magic byte-string literals (`b"MX"`, `b"TX"`, `b"TG"`, `b"MultisigAddr"`, `b"Program"`, `b"aB"`) with named constants
- Eliminates duplication (e.g., `MESSAGE_PREFIX` was defined in two places)

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt` passes  
- [x] `cargo clippy` passes (via pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)