### PR TITLE
feat(kmd): implement program-signing endpoints (SignProgram, SignProgramMultisig)

### DIFF
--- a/algonaut_kmd/src/kmd/v1/mod.rs
+++ b/algonaut_kmd/src/kmd/v1/mod.rs
@@ -13,7 +13,8 @@ use algonaut_model::kmd::v1::{
     ListKeysResponse, ListMultisigRequest, ListMultisigResponse, ListWalletsResponse,
     ReleaseWalletHandleRequest, ReleaseWalletHandleResponse, RenameWalletRequest,
     RenameWalletResponse, RenewWalletHandleRequest, RenewWalletHandleResponse,
-    SignMultisigTransactionRequest, SignMultisigTransactionResponse, SignTransactionRequest,
+    SignMultisigTransactionRequest, SignMultisigTransactionResponse, SignProgramMultisigRequest,
+    SignProgramMultisigResponse, SignProgramRequest, SignProgramResponse, SignTransactionRequest,
     SignTransactionResponse, VersionsResponse,
 };
 use reqwest::Url;
@@ -379,6 +380,34 @@ impl Client {
         Ok(response)
     }
 
+    pub async fn sign_program(
+        &self,
+        wallet_handle: &str,
+        wallet_password: &str,
+        address: &Address,
+        data: Vec<u8>,
+    ) -> Result<SignProgramResponse, ClientError> {
+        let req = SignProgramRequest {
+            wallet_handle_token: wallet_handle.to_string(),
+            address: address.to_string(),
+            data,
+            wallet_password: wallet_password.to_string(),
+        };
+        let response = self
+            .http_client
+            .post(format!("{}v1/program/sign", self.address))
+            .header("Accept", "application/json")
+            .headers(self.headers.clone())
+            .json(&req)
+            .send()
+            .await?
+            .http_error_for_status()
+            .await?
+            .json()
+            .await?;
+        Ok(response)
+    }
+
     pub async fn list_multisig(
         &self,
         wallet_handle: &str,
@@ -497,6 +526,38 @@ impl Client {
         let response = self
             .http_client
             .post(format!("{}v1/multisig/sign", self.address))
+            .header("Accept", "application/json")
+            .headers(self.headers.clone())
+            .json(&req)
+            .send()
+            .await?
+            .http_error_for_status()
+            .await?
+            .json()
+            .await?;
+        Ok(response)
+    }
+
+    pub async fn sign_program_multisig(
+        &self,
+        wallet_handle: &str,
+        wallet_password: &str,
+        address: &Address,
+        data: Vec<u8>,
+        public_key: Ed25519PublicKey,
+        partial_multisig: Option<MultisigSignature>,
+    ) -> Result<SignProgramMultisigResponse, ClientError> {
+        let req = SignProgramMultisigRequest {
+            wallet_handle_token: wallet_handle.to_string(),
+            address: address.to_string(),
+            data,
+            public_key,
+            partial_multisig,
+            wallet_password: wallet_password.to_string(),
+        };
+        let response = self
+            .http_client
+            .post(format!("{}v1/multisig/signprogram", self.address))
             .header("Accept", "application/json")
             .headers(self.headers.clone())
             .json(&req)

--- a/algonaut_model/src/kmd/v1/mod.rs
+++ b/algonaut_model/src/kmd/v1/mod.rs
@@ -297,6 +297,42 @@ pub struct SignMultisigTransactionResponse {
     pub multisig: Vec<u8>,
 }
 
+/// SignProgramRequest is the request for `POST /v1/program/sign`
+#[derive(Serialize, Clone)]
+pub struct SignProgramRequest {
+    pub wallet_handle_token: String,
+    pub address: String,
+    #[serde(serialize_with = "serialize_bytes")]
+    pub data: Vec<u8>,
+    pub wallet_password: String,
+}
+
+/// SignProgramResponse is the response to `POST /v1/program/sign`
+#[derive(Debug, Deserialize, Clone)]
+pub struct SignProgramResponse {
+    #[serde(deserialize_with = "deserialize_bytes")]
+    pub sig: Vec<u8>,
+}
+
+/// SignProgramMultisigRequest is the request for `POST /v1/multisig/signprogram`
+#[derive(Serialize, Clone)]
+pub struct SignProgramMultisigRequest {
+    pub wallet_handle_token: String,
+    pub address: String,
+    #[serde(serialize_with = "serialize_bytes")]
+    pub data: Vec<u8>,
+    pub public_key: Ed25519PublicKey,
+    pub partial_multisig: Option<MultisigSignature>,
+    pub wallet_password: String,
+}
+
+/// SignProgramMultisigResponse is the response to `POST /v1/multisig/signprogram`
+#[derive(Debug, Deserialize, Clone)]
+pub struct SignProgramMultisigResponse {
+    #[serde(deserialize_with = "deserialize_bytes")]
+    pub multisig: Vec<u8>,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct ApiV1ResponseEnvelope {
     pub error: bool,


### PR DESCRIPTION
## Summary

- Add `sign_program` and `sign_program_multisig` methods to the kmd client for TEAL-program / LogicSig signing
- Add matching request/response types (`SignProgramRequest`, `SignProgramResponse`, `SignProgramMultisigRequest`, `SignProgramMultisigResponse`) to the model

These are the two missing kmd v1 operations verified against upstream [`daemon/kmd/api/swagger.json`](https://github.com/algorand/go-algorand/blob/master/daemon/kmd/api/swagger.json).

## Test plan

- [x] Code compiles successfully
- [x] Existing tests pass
- [ ] Manual testing against a running kmd instance (requires wallet setup)

Closes #327

🤖 Generated with [Claude Code](https://claude.ai/code)