### PR TITLE
fix(model): treat zero address as None in optional AssetParams fields

### DIFF
--- a/algonaut_encoding/Cargo.toml
+++ b/algonaut_encoding/Cargo.toml
@@ -11,3 +11,6 @@ version = "0.7.0"
 [dependencies]
 data-encoding = { workspace = true }
 serde = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/algonaut_encoding/src/lib.rs
+++ b/algonaut_encoding/src/lib.rs
@@ -396,3 +396,68 @@ where
 {
     Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
 }
+
+/// The zero address in base32-checksum format (32 bytes of zeros).
+///
+/// The Algorand indexer returns this value for optional address fields (like
+/// `clawback`, `freeze`, `manager`, `reserve`) when they were not set during
+/// asset creation. This should be interpreted as `None` rather than a real
+/// address.
+pub const ZERO_ADDRESS: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ";
+
+/// Deserialize an optional address string, treating the zero address as `None`.
+///
+/// The Algorand indexer returns the zero address
+/// (`AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ`) for optional
+/// address fields that were not set. This deserializer converts such values to
+/// `None`, which better represents their semantic meaning.
+///
+/// See: <https://github.com/manuelmauro/algonaut/issues/142>
+pub fn deserialize_opt_addr_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt: Option<String> = Option::deserialize(deserializer)?;
+    Ok(opt.filter(|s| s != ZERO_ADDRESS))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct TestAsset {
+        #[serde(deserialize_with = "deserialize_opt_addr_string", default)]
+        clawback: Option<String>,
+    }
+
+    #[test]
+    fn zero_address_becomes_none() {
+        let json = r#"{"clawback": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ"}"#;
+        let asset: TestAsset = serde_json::from_str(json).unwrap();
+        assert_eq!(asset.clawback, None);
+    }
+
+    #[test]
+    fn real_address_is_preserved() {
+        let addr = "7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q";
+        let json = format!(r#"{{"clawback": "{}"}}"#, addr);
+        let asset: TestAsset = serde_json::from_str(&json).unwrap();
+        assert_eq!(asset.clawback, Some(addr.to_string()));
+    }
+
+    #[test]
+    fn null_address_becomes_none() {
+        let json = r#"{"clawback": null}"#;
+        let asset: TestAsset = serde_json::from_str(json).unwrap();
+        assert_eq!(asset.clawback, None);
+    }
+
+    #[test]
+    fn missing_address_becomes_none() {
+        let json = r#"{}"#;
+        let asset: TestAsset = serde_json::from_str(json).unwrap();
+        assert_eq!(asset.clawback, None);
+    }
+}

--- a/algonaut_model/src/algod/asset_params.rs
+++ b/algonaut_model/src/algod/asset_params.rs
@@ -11,14 +11,19 @@
 use serde::{Deserialize, Serialize};
 
 use algonaut_crypto::{HashDigest, deserialize_opt_hash};
-use algonaut_encoding::Bytes;
+use algonaut_encoding::{Bytes, deserialize_opt_addr_string};
 
 /// AssetParams : AssetParams specifies the parameters for an asset.  \\[apar\\] when part of an AssetConfig transaction.  Definition: data/transactions/asset.go : AssetParams
 
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct AssetParams {
     /// \\[c\\] Address of account used to clawback holdings of this asset.  If empty, clawback is not permitted.
-    #[serde(rename = "clawback", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "clawback",
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_opt_addr_string",
+        default
+    )]
     pub clawback: Option<String>,
     /// The address that created this asset. This is the address where the parameters for this asset can be found, and also the address where unwanted asset units can be sent in the worst case.
     #[serde(rename = "creator")]
@@ -30,10 +35,20 @@ pub struct AssetParams {
     #[serde(rename = "default-frozen", skip_serializing_if = "Option::is_none")]
     pub default_frozen: Option<bool>,
     /// \\[f\\] Address of account used to freeze holdings of this asset.  If empty, freezing is not permitted.
-    #[serde(rename = "freeze", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "freeze",
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_opt_addr_string",
+        default
+    )]
     pub freeze: Option<String>,
     /// \\[m\\] Address of account used to manage the keys of this asset and to destroy it.
-    #[serde(rename = "manager", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "manager",
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_opt_addr_string",
+        default
+    )]
     pub manager: Option<String>,
     /// \\[am\\] A commitment to some unspecified asset metadata. The format of this metadata is up to the application.
     #[serde(
@@ -50,7 +65,12 @@ pub struct AssetParams {
     #[serde(rename = "name-b64", skip_serializing_if = "Option::is_none")]
     pub name_b64: Option<Bytes>,
     /// \\[r\\] Address of account holding reserve (non-minted) units of this asset.
-    #[serde(rename = "reserve", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "reserve",
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_opt_addr_string",
+        default
+    )]
     pub reserve: Option<String>,
     /// \\[t\\] The total number of units of this asset.
     #[serde(rename = "total")]

--- a/algonaut_model/src/indexer/asset_params.rs
+++ b/algonaut_model/src/indexer/asset_params.rs
@@ -11,14 +11,19 @@
 use serde::{Deserialize, Serialize};
 
 use algonaut_crypto::{HashDigest, deserialize_opt_hash};
-use algonaut_encoding::Bytes;
+use algonaut_encoding::{Bytes, deserialize_opt_addr_string};
 
 /// AssetParams : AssetParams specifies the parameters for an asset.  \\[apar\\] when part of an AssetConfig transaction.  Definition: data/transactions/asset.go : AssetParams
 
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct AssetParams {
     /// \\[c\\] Address of account used to clawback holdings of this asset.  If empty, clawback is not permitted.
-    #[serde(rename = "clawback", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "clawback",
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_opt_addr_string",
+        default
+    )]
     pub clawback: Option<String>,
     /// The address that created this asset. This is the address where the parameters for this asset can be found, and also the address where unwanted asset units can be sent in the worst case.
     #[serde(rename = "creator")]
@@ -30,10 +35,20 @@ pub struct AssetParams {
     #[serde(rename = "default-frozen", skip_serializing_if = "Option::is_none")]
     pub default_frozen: Option<bool>,
     /// \\[f\\] Address of account used to freeze holdings of this asset.  If empty, freezing is not permitted.
-    #[serde(rename = "freeze", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "freeze",
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_opt_addr_string",
+        default
+    )]
     pub freeze: Option<String>,
     /// \\[m\\] Address of account used to manage the keys of this asset and to destroy it.
-    #[serde(rename = "manager", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "manager",
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_opt_addr_string",
+        default
+    )]
     pub manager: Option<String>,
     /// \\[am\\] A commitment to some unspecified asset metadata. The format of this metadata is up to the application.
     #[serde(
@@ -50,7 +65,12 @@ pub struct AssetParams {
     #[serde(rename = "name-b64", skip_serializing_if = "Option::is_none")]
     pub name_b64: Option<Bytes>,
     /// \\[r\\] Address of account holding reserve (non-minted) units of this asset.
-    #[serde(rename = "reserve", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "reserve",
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_opt_addr_string",
+        default
+    )]
     pub reserve: Option<String>,
     /// \\[t\\] The total number of units of this asset.
     #[serde(rename = "total")]


### PR DESCRIPTION
## Summary

- Add `deserialize_opt_addr_string` custom deserializer that converts the zero address (`AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ`) to `None`
- Apply the deserializer to optional address fields (`clawback`, `freeze`, `manager`, `reserve`) in both `algod` and `indexer` `AssetParams` structs
- Add unit tests covering all deserialization cases

## Context

The Algorand indexer returns the zero address for optional address fields when they were not set during asset creation. This should be interpreted as `None` rather than a real address.

Closes #142

## Test plan

- [x] All existing tests pass
- [x] New unit tests verify:
  - Zero address is converted to `None`
  - Real addresses are preserved as `Some(addr)`
  - Explicit `null` becomes `None`
  - Missing fields become `None`