### PR TITLE
fix(tests): fall back to shared wallet handle in KMD steps

### DIFF
--- a/tests/step_defs/integration/kmd.rs
+++ b/tests/step_defs/integration/kmd.rs
@@ -112,7 +112,8 @@ async fn i_renew_the_wallet_handle(w: &mut World) -> Result<(), Error> {
     let handle = w
         .created_wallet_handle
         .as_ref()
-        .expect("created wallet handle not set");
+        .or(w.handle.as_ref())
+        .expect("no wallet handle set");
     kmd.renew_wallet_handle(handle).await?;
     Ok(())
 }
@@ -123,7 +124,8 @@ async fn i_release_the_wallet_handle(w: &mut World) -> Result<(), Error> {
     let handle = w
         .created_wallet_handle
         .as_ref()
-        .expect("created wallet handle not set");
+        .or(w.handle.as_ref())
+        .expect("no wallet handle set");
     kmd.release_wallet_handle(handle).await?;
     Ok(())
 }
@@ -134,7 +136,8 @@ async fn the_wallet_handle_should_not_work(w: &mut World) {
     let handle = w
         .created_wallet_handle
         .as_ref()
-        .expect("created wallet handle not set");
+        .or(w.handle.as_ref())
+        .expect("no wallet handle set");
     assert!(
         kmd.get_wallet_info(handle).await.is_err(),
         "released wallet handle still works"


### PR DESCRIPTION
## Summary
- The wallet renew, release, and handle verification steps now check both `created_wallet_handle` (for newly created wallets) and `handle` (for the shared default wallet) to support scenarios that test handle operations on either context

This fixes cucumber test failures where KMD wallet handle operations were failing because they only looked at the newly-created wallet handle, not the shared handle from the test setup.

## Test plan
- [x] Pre-commit hooks pass (fmt, clippy, unit tests)
- [ ] Integration tests with sandbox (requires local sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)