### PR TITLE
refactor: re-export client types at crate root for ergonomic imports

### DIFF
--- a/examples/algod_client.rs
+++ b/examples/algod_client.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/app_call.rs
+++ b/examples/app_call.rs
@@ -2,8 +2,8 @@
 //! [`AtomicGroupBuilder`] typestate chain and the fluent [`MethodCall`]
 //! builder. This is the recommended path for application calls.
 
+use algonaut::Algod;
 use algonaut::abi::abi_call;
-use algonaut::algod::v2::Algod;
 use algonaut::atomic::{AtomicGroupBuilder, MethodCall};
 use algonaut::core::AppId;
 use algonaut::transaction::account::Account;

--- a/examples/app_clear_state.rs
+++ b/examples/app_clear_state.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
 use algonaut::core::AppId;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::builder::ClearApplication;

--- a/examples/app_close_out.rs
+++ b/examples/app_close_out.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
 use algonaut::core::AppId;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::builder::CloseApplication;

--- a/examples/app_create.rs
+++ b/examples/app_create.rs
@@ -1,7 +1,7 @@
-use algonaut::algod::v2::{Algod, SourceMap};
 use algonaut::transaction::CreateApplication;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::transaction::StateSchema;
+use algonaut::{Algod, SourceMap};
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/app_delete.rs
+++ b/examples/app_delete.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
 use algonaut::core::AppId;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::builder::DeleteApplication;

--- a/examples/app_optin.rs
+++ b/examples/app_optin.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
 use algonaut::core::AppId;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::builder::OptInApplication;

--- a/examples/app_update.rs
+++ b/examples/app_update.rs
@@ -1,7 +1,7 @@
-use algonaut::algod::v2::{Algod, SourceMap};
 use algonaut::core::AppId;
 use algonaut::transaction::account::Account;
 use algonaut::transaction::builder::UpdateApplication;
+use algonaut::{Algod, SourceMap};
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/asset_clawback.rs
+++ b/examples/asset_clawback.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
 use algonaut::core::AssetId;
 use algonaut::transaction::ClawbackAsset;
 use algonaut::transaction::account::Account;

--- a/examples/asset_create.rs
+++ b/examples/asset_create.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
 use algonaut::transaction::CreateAsset;
 use algonaut::transaction::account::Account;
 use dotenv::dotenv;

--- a/examples/asset_optin.rs
+++ b/examples/asset_optin.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
 use algonaut::core::AssetId;
 use algonaut::transaction::AcceptAsset;
 use algonaut::transaction::account::Account;

--- a/examples/asset_transfer.rs
+++ b/examples/asset_transfer.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
 use algonaut::core::AssetId;
 use algonaut::transaction::TransferAsset;
 use algonaut::transaction::account::Account;

--- a/examples/atomic.rs
+++ b/examples/atomic.rs
@@ -18,8 +18,8 @@
 //! argument encoding, group-id assignment, per-transaction signers, and
 //! return-value decoding for you.
 
+use algonaut::Algod;
 use algonaut::abi::abi_call;
-use algonaut::algod::v2::Algod;
 use algonaut::atomic::{AtomicGroupBuilder, MethodCall, TransactionWithSigner};
 use algonaut::core::{AppId, MicroAlgos};
 use algonaut::transaction::account::Account;

--- a/examples/atomic_swap.rs
+++ b/examples/atomic_swap.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
 use algonaut::core::MicroAlgos;
 use algonaut::transaction::Pay;
 use algonaut::transaction::account::Account;

--- a/examples/indexer_query.rs
+++ b/examples/indexer_query.rs
@@ -1,4 +1,4 @@
-use algonaut::indexer::v2::Indexer;
+use algonaut::Indexer;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/key_reg.rs
+++ b/examples/key_reg.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
 use algonaut::core::{Round, StateProofPk, VotePk, VrfPk};
 use algonaut::transaction::RegisterKey;
 use algonaut::transaction::account::Account;

--- a/examples/kmd_client.rs
+++ b/examples/kmd_client.rs
@@ -1,5 +1,5 @@
+use algonaut::Kmd;
 use algonaut::crypto::MasterDerivationKey;
-use algonaut::kmd::v1::Kmd;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/kmd_sign_submit_transaction.rs
+++ b/examples/kmd_sign_submit_transaction.rs
@@ -1,6 +1,6 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
+use algonaut::Kmd;
 use algonaut::core::MicroAlgos;
-use algonaut::kmd::v1::Kmd;
 use algonaut::transaction::Pay;
 use dotenv::dotenv;
 use std::env;

--- a/examples/last_block.rs
+++ b/examples/last_block.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/logic_sig_contract_account.rs
+++ b/examples/logic_sig_contract_account.rs
@@ -1,7 +1,7 @@
-use algonaut::algod::v2::{Algod, SourceMap};
 use algonaut::core::MicroAlgos;
 use algonaut::transaction::Pay;
 use algonaut::transaction::contract_account::ContractAccount;
+use algonaut::{Algod, SourceMap};
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/logic_sig_delegated.rs
+++ b/examples/logic_sig_delegated.rs
@@ -1,7 +1,7 @@
-use algonaut::algod::v2::{Algod, SourceMap};
 use algonaut::core::{LogicSignature, MicroAlgos};
 use algonaut::transaction::Pay;
 use algonaut::transaction::account::Account;
+use algonaut::{Algod, SourceMap};
 use algonaut_transaction::transaction::SignedLogic;
 use dotenv::dotenv;
 use std::env;

--- a/examples/logic_sig_delegated_multi.rs
+++ b/examples/logic_sig_delegated_multi.rs
@@ -1,7 +1,7 @@
-use algonaut::algod::v2::{Algod, SourceMap};
 use algonaut::core::{LogicSignature, MicroAlgos, MultisigAddress};
 use algonaut::transaction::Pay;
 use algonaut::transaction::account::Account;
+use algonaut::{Algod, SourceMap};
 use algonaut_transaction::transaction::SignedLogic;
 use dotenv::dotenv;
 use std::env;

--- a/examples/multi_sig.rs
+++ b/examples/multi_sig.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
 use algonaut::core::{MicroAlgos, MultisigAddress};
 use algonaut::transaction::Pay;
 use algonaut::transaction::account::Account;

--- a/examples/payment.rs
+++ b/examples/payment.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
 use algonaut::core::MicroAlgos;
 use algonaut::transaction::Pay;
 use algonaut::transaction::account::Account;

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -1,6 +1,6 @@
-use algonaut::algod::v2::Algod;
-use algonaut::indexer::v2::Indexer;
-use algonaut::kmd::v1::Kmd;
+use algonaut::Algod;
+use algonaut::Indexer;
+use algonaut::Kmd;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/rekey.rs
+++ b/examples/rekey.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
 use algonaut::transaction::account::Account;
 use algonaut_core::MicroAlgos;
 use algonaut_transaction::Pay;

--- a/examples/sign_offline.rs
+++ b/examples/sign_offline.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
 use algonaut::core::{MicroAlgos, ToMsgPack};
 use algonaut::transaction::Pay;
 use algonaut::transaction::account::Account;

--- a/examples/submit_file.rs
+++ b/examples/submit_file.rs
@@ -1,4 +1,4 @@
-use algonaut::algod::v2::Algod;
+use algonaut::Algod;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/wallet_backup.rs
+++ b/examples/wallet_backup.rs
@@ -1,5 +1,5 @@
+use algonaut::Kmd;
 use algonaut::crypto::mnemonic;
-use algonaut::kmd::v1::Kmd;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/examples/wallet_restore.rs
+++ b/examples/wallet_restore.rs
@@ -1,6 +1,6 @@
+use algonaut::Kmd;
 use algonaut::crypto::MasterDerivationKey;
 use algonaut::crypto::mnemonic;
-use algonaut::kmd::v1::Kmd;
 use dotenv::dotenv;
 use std::env;
 use std::error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,16 @@ pub mod indexer;
 #[cfg(feature = "kmd")]
 pub mod kmd;
 
+// Convenience re-exports for ergonomic top-level imports.
+// The versioned paths (e.g., `algod::v2::Algod`) remain available for
+// backwards compatibility and explicit version selection.
+#[cfg(feature = "algod")]
+pub use algod::v2::{Algod, PendingSubmission, SourceMap};
+#[cfg(feature = "indexer")]
+pub use indexer::v2::Indexer;
+#[cfg(feature = "kmd")]
+pub use kmd::v1::Kmd;
+
 // atomic / dryrun / simulate build on the algod models (now in
 // `algonaut_model::algod`) and the algod transport, so they ride the `algod`
 // gate.


### PR DESCRIPTION
## Summary
- Add convenience re-exports for `Algod`, `Indexer`, `Kmd`, `SourceMap`, and `PendingSubmission` at the crate root
- Users can now write `use algonaut::{Algod, Indexer, Kmd}` instead of the versioned paths
- The versioned paths (`algod::v2::Algod`, etc.) remain available for backwards compatibility
- Update all examples to use the simplified import style

## Test plan
- [x] `cargo check --examples` passes
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes