### PR TITLE
feat(abi): add contract! macro for typed ARC-4 contract clients

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,14 @@ members = [
   "algonaut_kmd",
   "algonaut_transaction",
   "algonaut_abi",
+  "algonaut_abi_model",
   "algonaut_abi_sig",
   "algonaut_abi_macros",
 ]
 
 [workspace.dependencies]
 algonaut_abi = { path = "algonaut_abi", version = "0.8.0" }
+algonaut_abi_model = { path = "algonaut_abi_model", version = "0.8.0" }
 algonaut_abi_sig = { path = "algonaut_abi_sig", version = "0.8.0" }
 algonaut_abi_macros = { path = "algonaut_abi_macros", version = "0.8.0" }
 algonaut_algod = { path = "algonaut_algod", version = "0.8.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,10 @@ name = "app_call"
 required-features = ["algod"]
 
 [[example]]
+name = "contract_client"
+required-features = ["algod"]
+
+[[example]]
 name = "app_clear_state"
 required-features = ["algod"]
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Each decision is recorded as an ADR under [`docs/adr/`](./docs/adr/); [CHANGELOG
 | `algonaut_crypto`      | Ed25519 sign/verify (via `ed25519-dalek`) and BIP-39 mnemonics                           |
 | `algonaut_transaction` | Transaction builders and the open `Signer` trait                                         |
 | `algonaut_abi`         | ARC-4 ABI types, method encoding, TEAL source-map decoder                                |
+| `algonaut_abi_model`   | Pure serde data model for ARC-4 ABI JSON, shared by the runtime and the macros           |
 | `algonaut_abi_sig`     | ARC-4 signature/type grammar shared by the macros and the runtime                        |
 | `algonaut_abi_macros`  | `contract!` client generator plus `abi_call!` / `abi_method!` compile-time-checked ABI proc-macros |
 | `algonaut_encoding`    | Shared `serde` visitors and base32/base64 helpers                                        |

--- a/README.md
+++ b/README.md
@@ -15,57 +15,61 @@ A Rust SDK for the [Algorand](https://www.algorand.com/) blockchain. Pre-1.0 —
 
 - Async clients for `algod` v2, `kmd` v1, and `indexer` v2
 - One-call transaction builders for payments, asset config / transfer / freeze / clawback, application calls, key registration, and state proofs
-- A typestate `AtomicGroupBuilder` — bundle transactions and compile-time-checked ARC-4 ABI calls (`abi_call!`), then `simulate`, `sign`, and `execute`
+- A typestate `AtomicGroupBuilder` — bundle transactions and ARC-4 ABI calls, then `simulate`, `sign`, and `execute`
+- Typed contract clients generated from an ARC-4 ABI JSON at compile time (`contract!`), or compile-time-checked one-off calls with `abi_call!`
 - An open, async `Signer` trait: `Account` out of the box, or plug in an HSM, remote KMS, or WalletConnect
 - TEAL compile / disassemble + V3 source-map decoder
 - Cucumber acceptance suite that exercises the algorand-sdk-testing harness end-to-end
 
 ## Quickstart: an atomic group
 
-Bundle two payments and an ARC-4 method call into one all-or-nothing group,
-dry-run it with `simulate`, then `sign` and `execute` the very same group —
-the headline `algonaut` flow as it stands today. See
-[`examples/atomic.rs`](./examples/atomic.rs) for the fully annotated version.
+Generate a typed client from an ARC-4 ABI with `contract!`, bundle two of its
+method calls into one all-or-nothing group, dry-run it with `simulate`, then
+`sign` and `execute` the very same group — the headline `algonaut` flow as it
+stands today. Raw transactions (payments, asset ops) drop into the same group
+via `add_transaction`. See
+[`examples/contract_client.rs`](./examples/contract_client.rs) for the fully
+annotated version.
 
 ```rust
-use algonaut::abi::abi_call;
 use algonaut::algod::v2::Algod;
-use algonaut::atomic::{AtomicGroupBuilder, MethodCall, TransactionWithSigner};
-use algonaut::core::{AppId, MicroAlgos};
+use algonaut::atomic::AtomicGroupBuilder;
+use algonaut::core::AppId;
+use algonaut::transaction::Signer;
 use algonaut::transaction::account::Account;
-use algonaut::transaction::{Pay, Signer};
 use std::sync::Arc;
 use std::{env, error::Error};
+
+// `contract!` reads an ARC-4 ABI JSON at compile time and generates a typed
+// `Calculator` client: one method per ABI entry, argument types checked by the
+// compiler, plus `testnet()` / `mainnet()` constructors when the JSON carries a
+// `networks` field.
+algonaut::contract!("contracts/calculator.json");
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let algod = Algod::new(&env::var("ALGOD_URL")?, &env::var("ALGOD_TOKEN")?)?;
 
     let alice = Account::from_mnemonic(&env::var("ALICE_MNEMONIC")?)?;
-    let bob = Account::from_mnemonic(&env::var("BOB_MNEMONIC")?)?;
 
     // A signer is shared as `Arc<dyn Signer>`: `Account` here, but any HSM,
     // remote KMS, or WalletConnect impl drops in the same way.
-    let alice_signer: Arc<dyn Signer> = Arc::new(alice.clone());
-    let bob_signer: Arc<dyn Signer> = Arc::new(bob.clone());
+    let signer: Arc<dyn Signer> = Arc::new(alice.clone());
 
     let params = algod.suggested_params().await?;
-    let app = AppId(123); // an ARC-4 `add(uint64,uint64)uint64` contract
 
-    let alice_to_bob = Pay::new(alice.address(), bob.address(), MicroAlgos(1_000)).build(&params)?;
-    let bob_to_alice = Pay::new(bob.address(), alice.address(), MicroAlgos(1_000)).build(&params)?;
-
-    // `abi_call!` checks the signature and the argument types at compile time.
-    let call = MethodCall::builder(app, alice.address(), alice_signer.clone())
-        .invoke(abi_call!("add(uint64,uint64)uint64", 2u64, 3u64))
-        .build(&params);
+    // The generated client holds the app id, sender, and signer. Each method
+    // returns a builder; `calculator.add(2, 3)` won't compile unless the ABI
+    // declares `add(uint64,uint64)uint64` and the argument types line up.
+    let calculator = Calculator::new(AppId(123), alice.address(), signer);
+    let add = calculator.add(2u64, 3u64).build(&params);
+    let subtract = calculator.subtract(10u64, 4u64).build(&params);
 
     // The typestate chain — AtomicGroupBuilder → UnsignedAtomicGroup →
     // SignedAtomicGroup — means "submit before sign" simply won't compile.
     let group = AtomicGroupBuilder::new()
-        .add_transaction(TransactionWithSigner::new(alice_to_bob, alice_signer))
-        .add_transaction(TransactionWithSigner::new(bob_to_alice, bob_signer))
-        .add_method_call(call)
+        .add_method_call(add)
+        .add_method_call(subtract)
         .build()?;
 
     // `simulate` borrows the group, so we dry-run it before touching a key.
@@ -91,7 +95,7 @@ modernization, and the example above is the API as it stands today:
 - **0.5** — Rust 2024 edition (MSRV 1.85); `ring` swapped for `ed25519-dalek`, so `wasm32` builds need no C toolchain; workspace-wide dependency refresh; `lefthook` + `make ci`.
 - **0.6** — `simulate` and dry-run request builders, a TEAL V3 source-map decoder, and domain types that serialize to both JSON and msgpack.
 - **0.7** — identifier newtypes (`AppId`, `AssetId`, `TxId`) at the client boundary, block / account-resource / ledger-delta endpoints, and msgpack response decoding.
-- **unreleased** — an open, async `Signer` trait (HSM / remote KMS / WalletConnect friendly), the typestate `AtomicGroupBuilder` shown above, and compile-time-checked ARC-4 calls via `abi_call!`.
+- **unreleased** — an open, async `Signer` trait (HSM / remote KMS / WalletConnect friendly), the typestate `AtomicGroupBuilder` shown above, compile-time-checked ARC-4 calls via `abi_call!`, and typed contract clients generated from ABI JSON with `contract!`.
 
 Each decision is recorded as an ADR under [`docs/adr/`](./docs/adr/); [CHANGELOG.md](./CHANGELOG.md) has the full entry-by-entry history.
 
@@ -108,7 +112,7 @@ Each decision is recorded as an ADR under [`docs/adr/`](./docs/adr/); [CHANGELOG
 | `algonaut_transaction` | Transaction builders and the open `Signer` trait                                         |
 | `algonaut_abi`         | ARC-4 ABI types, method encoding, TEAL source-map decoder                                |
 | `algonaut_abi_sig`     | ARC-4 signature/type grammar shared by the macros and the runtime                        |
-| `algonaut_abi_macros`  | `abi_call!` / `abi_method!` compile-time-checked ABI proc-macros                         |
+| `algonaut_abi_macros`  | `contract!` client generator plus `abi_call!` / `abi_method!` compile-time-checked ABI proc-macros |
 | `algonaut_encoding`    | Shared `serde` visitors and base32/base64 helpers                                        |
 | `algonaut_model`       | Hand-written response models shared between the clients                                  |
 

--- a/algonaut_abi/Cargo.toml
+++ b/algonaut_abi/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.8.0"
 
 [dependencies]
 algonaut_abi_macros = { workspace = true }
+algonaut_abi_model = { workspace = true }
 algonaut_abi_sig = { workspace = true }
 algonaut_core = { workspace = true }
 derive_more = { workspace = true, features = ["display", "from"] }

--- a/algonaut_abi/src/abi_interactions.rs
+++ b/algonaut_abi/src/abi_interactions.rs
@@ -1,5 +1,6 @@
 use super::abi_type::AbiType;
 use crate::abi_error::AbiError;
+use algonaut_abi_model as model;
 use algonaut_core::{AppId, TransactionTypeEnum, error::CoreError};
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
@@ -79,22 +80,19 @@ impl ReferenceArgType {
 
 /// Represents an ABI Method argument
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(from = "model::AbiMethodArg", into = "model::AbiMethodArg")]
 pub struct AbiMethodArg {
     /// User-friendly name for the argument
-    #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
     /// The type of the argument as a string.
     /// See [get_type_object](get_type_object) to obtain the ABI type object
-    #[serde(rename = "type")]
     pub(crate) type_: String,
 
     /// User-friendly description for the argument
-    #[serde(rename = "desc", skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
-    /// Cache that holds the parsed type object
-    #[serde(skip)]
+    /// Cache that holds the parsed type object (not part of the JSON shape)
     pub(crate) parsed: Option<AbiType>,
 }
 
@@ -154,18 +152,16 @@ impl AbiMethodArg {
 
 /// Represents an ABI method return value
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(from = "model::AbiReturn", into = "model::AbiReturn")]
 pub struct AbiReturn {
     /// The type of the argument as a string. See the [get_type_object](get_type_object) to
     /// obtain the ABI type object
-    #[serde(rename = "type")]
     pub(crate) type_: String,
 
     /// User-friendly description for the argument
-    #[serde(rename = "desc", skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
-    /// Cache that holds the parsed type object
-    #[serde(skip)]
+    /// Cache that holds the parsed type object (not part of the JSON shape)
     pub(crate) parsed: Option<AbiType>,
 }
 
@@ -210,21 +206,18 @@ pub enum AbiReturnType {
 
 /// Represents an ABI method return value
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(from = "model::AbiMethod", into = "model::AbiMethod")]
 pub struct AbiMethod {
     /// The name of the method
-    #[serde(rename = "name")]
     pub name: String,
 
     /// User-friendly description for the method
-    #[serde(rename = "desc", skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     /// The arguments of the method, in order
-    #[serde(default, rename = "args", skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<AbiMethodArg>,
 
     /// Information about the method's return value
-    #[serde(rename = "returns")]
     pub returns: AbiReturn,
 }
 
@@ -314,48 +307,168 @@ impl AbiMethod {
 
 /// Represents an ABI interface, which is a logically grouped collection of methods
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "model::AbiInterface", into = "model::AbiInterface")]
 pub struct AbiInterface {
     /// The name of the interface
-    #[serde(rename = "name")]
     pub name: String,
 
     /// User-friendly description for the interface
-    #[serde(rename = "desc", skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     /// The methods that the interface contains
-    #[serde(rename = "methods", skip_serializing_if = "Vec::is_empty")]
     pub methods: Vec<AbiMethod>,
 }
 
 /// Network-specific information about the contract
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    from = "model::AbiContractNetworkInfo",
+    into = "model::AbiContractNetworkInfo"
+)]
 pub struct AbiContractNetworkInfo {
     /// The application ID of the contract for this network
-    #[serde(rename = "appID")]
     pub app_id: AppId,
 }
 
 /// Represents an ABI contract, which is a concrete set of methods implemented by a single app
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "model::AbiContract", into = "model::AbiContract")]
 pub struct AbiContract {
     /// The name of the contract
-    #[serde(rename = "name")]
     pub name: String,
 
     /// User-friendly description for the contract
-    #[serde(rename = "desc", skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     /// Optional information about the contract's instances across different networks
-    #[serde(
-        default,
-        rename = "networks",
-        skip_serializing_if = "HashMap::is_empty"
-    )]
     pub networks: HashMap<String, AbiContractNetworkInfo>,
 
     /// The methods that the interface contains
-    #[serde(default, rename = "methods", skip_serializing_if = "Vec::is_empty")]
     pub methods: Vec<AbiMethod>,
+}
+
+// ---------------------------------------------------------------------------
+// Conversions to/from the wire model (`algonaut_abi_model`).
+//
+// The JSON shape is single-sourced in the model crate; these runtime types add
+// the lazily-parsed `AbiType` cache and a typed `AppId`, and (de)serialize by
+// delegating to the model via the `#[serde(from / into)]` attributes above.
+// ---------------------------------------------------------------------------
+
+impl From<model::AbiMethodArg> for AbiMethodArg {
+    fn from(m: model::AbiMethodArg) -> Self {
+        Self {
+            name: m.name,
+            type_: m.type_,
+            description: m.desc,
+            parsed: None,
+        }
+    }
+}
+
+impl From<AbiMethodArg> for model::AbiMethodArg {
+    fn from(a: AbiMethodArg) -> Self {
+        Self {
+            name: a.name,
+            type_: a.type_,
+            desc: a.description,
+        }
+    }
+}
+
+impl From<model::AbiReturn> for AbiReturn {
+    fn from(m: model::AbiReturn) -> Self {
+        Self {
+            type_: m.type_,
+            description: m.desc,
+            parsed: None,
+        }
+    }
+}
+
+impl From<AbiReturn> for model::AbiReturn {
+    fn from(r: AbiReturn) -> Self {
+        Self {
+            type_: r.type_,
+            desc: r.description,
+        }
+    }
+}
+
+impl From<model::AbiMethod> for AbiMethod {
+    fn from(m: model::AbiMethod) -> Self {
+        Self {
+            name: m.name,
+            description: m.desc,
+            args: m.args.into_iter().map(Into::into).collect(),
+            returns: m.returns.into(),
+        }
+    }
+}
+
+impl From<AbiMethod> for model::AbiMethod {
+    fn from(m: AbiMethod) -> Self {
+        Self {
+            name: m.name,
+            desc: m.description,
+            args: m.args.into_iter().map(Into::into).collect(),
+            returns: m.returns.into(),
+        }
+    }
+}
+
+impl From<model::AbiInterface> for AbiInterface {
+    fn from(m: model::AbiInterface) -> Self {
+        Self {
+            name: m.name,
+            description: m.desc,
+            methods: m.methods.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<AbiInterface> for model::AbiInterface {
+    fn from(i: AbiInterface) -> Self {
+        Self {
+            name: i.name,
+            desc: i.description,
+            methods: i.methods.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<model::AbiContractNetworkInfo> for AbiContractNetworkInfo {
+    fn from(m: model::AbiContractNetworkInfo) -> Self {
+        Self {
+            app_id: AppId(m.app_id),
+        }
+    }
+}
+
+impl From<AbiContractNetworkInfo> for model::AbiContractNetworkInfo {
+    fn from(n: AbiContractNetworkInfo) -> Self {
+        Self { app_id: n.app_id.0 }
+    }
+}
+
+impl From<model::AbiContract> for AbiContract {
+    fn from(m: model::AbiContract) -> Self {
+        Self {
+            name: m.name,
+            description: m.desc,
+            networks: m.networks.into_iter().map(|(k, v)| (k, v.into())).collect(),
+            methods: m.methods.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<AbiContract> for model::AbiContract {
+    fn from(c: AbiContract) -> Self {
+        Self {
+            name: c.name,
+            desc: c.description,
+            networks: c.networks.into_iter().map(|(k, v)| (k, v.into())).collect(),
+            methods: c.methods.into_iter().map(Into::into).collect(),
+        }
+    }
 }

--- a/algonaut_abi/src/lib.rs
+++ b/algonaut_abi/src/lib.rs
@@ -51,7 +51,7 @@ use abi_type::AbiType;
 /// // `&str` cannot stand in for `uint64`: no `AbiArg<Uint<64>>` impl.
 /// let _ = algonaut_abi::abi_call!("add(uint64,uint64)uint64", "two", 3u64);
 /// ```
-pub use algonaut_abi_macros::{abi_call, abi_method};
+pub use algonaut_abi_macros::{abi_call, abi_method, contract};
 
 #[doc(inline)]
 pub use macro_support::MethodInvocation;

--- a/algonaut_abi_macros/Cargo.toml
+++ b/algonaut_abi_macros/Cargo.toml
@@ -12,9 +12,9 @@ version = "0.8.0"
 proc-macro = true
 
 [dependencies]
+algonaut_abi_model = { workspace = true }
 algonaut_abi_sig = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 syn = { workspace = true }

--- a/algonaut_abi_macros/Cargo.toml
+++ b/algonaut_abi_macros/Cargo.toml
@@ -15,4 +15,6 @@ proc-macro = true
 algonaut_abi_sig = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 syn = { workspace = true }

--- a/algonaut_abi_macros/src/contract/codegen.rs
+++ b/algonaut_abi_macros/src/contract/codegen.rs
@@ -3,14 +3,14 @@
 //! Generates a typed contract struct with methods for each ABI method,
 //! plus optional network-specific constructors.
 
-use crate::contract::parse::{ContractJson, MethodJson, genesis_to_network};
+use crate::contract::parse::{AbiContract, AbiMethod, genesis_to_network};
 use crate::contract::type_map::{abi_marker_type, rust_param_type};
 use algonaut_abi_sig::{ArgClass, parse_signature};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 
 /// Generate all code for a contract from its parsed JSON.
-pub fn generate_contract(contract: &ContractJson) -> Result<TokenStream, String> {
+pub fn generate_contract(contract: &AbiContract) -> Result<TokenStream, String> {
     let struct_name = to_pascal_case(&contract.name);
     let struct_ident = Ident::new(&struct_name, Span::call_site());
 
@@ -47,7 +47,7 @@ fn generate_struct(struct_ident: &Ident) -> TokenStream {
 }
 
 /// Generate the main impl block with new() and all method functions.
-fn generate_impl(contract: &ContractJson, struct_ident: &Ident) -> Result<TokenStream, String> {
+fn generate_impl(contract: &AbiContract, struct_ident: &Ident) -> Result<TokenStream, String> {
     let mut methods = Vec::new();
 
     for method in &contract.methods {
@@ -96,8 +96,8 @@ fn generate_impl(contract: &ContractJson, struct_ident: &Ident) -> Result<TokenS
 }
 
 /// Generate a single method function.
-fn generate_method(method: &MethodJson, struct_ident: &Ident) -> Result<TokenStream, String> {
-    let signature = method.signature();
+fn generate_method(method: &AbiMethod, struct_ident: &Ident) -> Result<TokenStream, String> {
+    let signature = method.get_signature();
 
     // Parse and validate the signature using algonaut_abi_sig
     let parsed = parse_signature(&signature).map_err(|e| e.reason)?;
@@ -170,7 +170,7 @@ fn generate_method(method: &MethodJson, struct_ident: &Ident) -> Result<TokenStr
 }
 
 /// Generate network-specific constructors (e.g., testnet(), mainnet()).
-fn generate_network_constructors(contract: &ContractJson, struct_ident: &Ident) -> TokenStream {
+fn generate_network_constructors(contract: &AbiContract, struct_ident: &Ident) -> TokenStream {
     let mut constructors = Vec::new();
 
     for (genesis_hash, network_info) in &contract.networks {
@@ -209,11 +209,11 @@ fn generate_network_constructors(contract: &ContractJson, struct_ident: &Ident) 
 }
 
 /// Generate builder structs for each supported method.
-fn generate_builders(contract: &ContractJson, struct_ident: &Ident) -> Result<TokenStream, String> {
+fn generate_builders(contract: &AbiContract, struct_ident: &Ident) -> Result<TokenStream, String> {
     let mut builders = Vec::new();
 
     for method in &contract.methods {
-        let signature = method.signature();
+        let signature = method.get_signature();
 
         // Skip methods with unsupported types (they get compile_error! in the method)
         let parsed = match parse_signature(&signature) {

--- a/algonaut_abi_macros/src/contract/codegen.rs
+++ b/algonaut_abi_macros/src/contract/codegen.rs
@@ -1,0 +1,410 @@
+//! Code generation for the `contract!` macro.
+//!
+//! Generates a typed contract struct with methods for each ABI method,
+//! plus optional network-specific constructors.
+
+use crate::contract::parse::{ContractJson, MethodJson, genesis_to_network};
+use crate::contract::type_map::{abi_marker_type, rust_param_type};
+use algonaut_abi_sig::{ArgClass, parse_signature};
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::{format_ident, quote};
+
+/// Generate all code for a contract from its parsed JSON.
+pub fn generate_contract(contract: &ContractJson) -> Result<TokenStream, String> {
+    let struct_name = to_pascal_case(&contract.name);
+    let struct_ident = Ident::new(&struct_name, Span::call_site());
+
+    // Generate the struct definition
+    let struct_def = generate_struct(&struct_ident);
+
+    // Generate the impl block with new() and method functions
+    let impl_block = generate_impl(contract, &struct_ident)?;
+
+    // Generate network-specific constructors if networks are present
+    let network_constructors = generate_network_constructors(contract, &struct_ident);
+
+    // Generate builder structs for each method
+    let builders = generate_builders(contract, &struct_ident)?;
+
+    Ok(quote! {
+        #struct_def
+        #impl_block
+        #network_constructors
+        #builders
+    })
+}
+
+/// Generate the main contract struct definition.
+fn generate_struct(struct_ident: &Ident) -> TokenStream {
+    quote! {
+        #[doc = "Generated contract client."]
+        pub struct #struct_ident {
+            app_id: ::algonaut_core::AppId,
+            sender: ::algonaut_core::Address,
+            signer: ::std::sync::Arc<dyn ::algonaut_transaction::Signer>,
+        }
+    }
+}
+
+/// Generate the main impl block with new() and all method functions.
+fn generate_impl(contract: &ContractJson, struct_ident: &Ident) -> Result<TokenStream, String> {
+    let mut methods = Vec::new();
+
+    for method in &contract.methods {
+        match generate_method(method, struct_ident) {
+            Ok(m) => methods.push(m),
+            Err(e) => {
+                // Generate a compile_error! for unsupported methods
+                let method_name = &method.name;
+                let error_msg =
+                    format!("method `{method_name}` has unsupported argument type: {e}");
+                let method_ident = Ident::new(&to_snake_case(method_name), Span::call_site());
+                methods.push(quote! {
+                    #[doc = "This method has unsupported argument types."]
+                    pub fn #method_ident(&self) {
+                        ::core::compile_error!(#error_msg);
+                    }
+                });
+            }
+        }
+    }
+
+    Ok(quote! {
+        impl #struct_ident {
+            /// Create a new contract client.
+            pub fn new(
+                app_id: ::algonaut_core::AppId,
+                sender: ::algonaut_core::Address,
+                signer: ::std::sync::Arc<dyn ::algonaut_transaction::Signer>,
+            ) -> Self {
+                Self { app_id, sender, signer }
+            }
+
+            /// Returns the application ID.
+            pub fn app_id(&self) -> ::algonaut_core::AppId {
+                self.app_id
+            }
+
+            /// Returns the sender address.
+            pub fn sender(&self) -> ::algonaut_core::Address {
+                self.sender
+            }
+
+            #(#methods)*
+        }
+    })
+}
+
+/// Generate a single method function.
+fn generate_method(method: &MethodJson, struct_ident: &Ident) -> Result<TokenStream, String> {
+    let signature = method.signature();
+
+    // Parse and validate the signature using algonaut_abi_sig
+    let parsed = parse_signature(&signature).map_err(|e| e.reason)?;
+
+    // Generate parameter list
+    let mut params = Vec::new();
+    let mut param_idents = Vec::new();
+    let mut encode_calls = Vec::new();
+
+    for (i, arg_class) in parsed.args.iter().enumerate() {
+        let arg_name = method
+            .args
+            .get(i)
+            .and_then(|a| a.name.as_ref())
+            .map(|n| to_snake_case(n))
+            .unwrap_or_else(|| format!("arg{i}"));
+
+        // Escape Rust keywords
+        let arg_ident = if is_rust_keyword(&arg_name) {
+            format_ident!("r#{}", arg_name)
+        } else {
+            Ident::new(&arg_name, Span::call_site())
+        };
+
+        match arg_class {
+            ArgClass::Value(ty) => {
+                let rust_type = rust_param_type(ty)?;
+                let marker = abi_marker_type(ty)?;
+
+                params.push(quote! { #arg_ident: #rust_type });
+                encode_calls.push(quote! {
+                    ::algonaut_abi::macro_support::AbiArg::<#marker>::encode(#arg_ident)
+                });
+            }
+            ArgClass::Transaction(tx_type) => {
+                return Err(format!("transaction argument `{tx_type}`"));
+            }
+            ArgClass::Reference(ref_type) => {
+                return Err(format!("reference argument `{ref_type}`"));
+            }
+        }
+
+        param_idents.push(arg_ident);
+    }
+
+    let method_name_str = &method.name;
+    let method_ident = Ident::new(&to_snake_case(method_name_str), Span::call_site());
+    let builder_ident = format_ident!("{}{}", struct_ident, to_pascal_case(method_name_str));
+
+    let doc = method
+        .desc
+        .as_ref()
+        .map(|d| quote! { #[doc = #d] })
+        .unwrap_or_default();
+
+    Ok(quote! {
+        #doc
+        pub fn #method_ident(&self, #(#params),*) -> #builder_ident<'_> {
+            let method = ::algonaut_abi::abi_interactions::AbiMethod::from_signature(#signature)
+                .expect("contract!: signature validated at macro expansion");
+            let args: ::std::vec::Vec<::algonaut_abi::abi_type::AbiValue> =
+                ::std::vec![ #(#encode_calls),* ];
+            let invocation = ::algonaut_abi::MethodInvocation::new(method, args);
+            #builder_ident {
+                contract: self,
+                invocation,
+            }
+        }
+    })
+}
+
+/// Generate network-specific constructors (e.g., testnet(), mainnet()).
+fn generate_network_constructors(contract: &ContractJson, struct_ident: &Ident) -> TokenStream {
+    let mut constructors = Vec::new();
+
+    for (genesis_hash, network_info) in &contract.networks {
+        let network_name = genesis_to_network(genesis_hash)
+            .map(|s| s.to_owned())
+            .unwrap_or_else(|| sanitize_identifier(genesis_hash));
+
+        let method_ident = Ident::new(&network_name, Span::call_site());
+        let app_id = network_info.app_id;
+
+        let doc = format!(
+            "Create a client for the {} deployment (app ID {}).",
+            network_name, app_id
+        );
+
+        constructors.push(quote! {
+            #[doc = #doc]
+            pub fn #method_ident(
+                sender: ::algonaut_core::Address,
+                signer: ::std::sync::Arc<dyn ::algonaut_transaction::Signer>,
+            ) -> Self {
+                Self::new(::algonaut_core::AppId(#app_id), sender, signer)
+            }
+        });
+    }
+
+    if constructors.is_empty() {
+        TokenStream::new()
+    } else {
+        quote! {
+            impl #struct_ident {
+                #(#constructors)*
+            }
+        }
+    }
+}
+
+/// Generate builder structs for each supported method.
+fn generate_builders(contract: &ContractJson, struct_ident: &Ident) -> Result<TokenStream, String> {
+    let mut builders = Vec::new();
+
+    for method in &contract.methods {
+        let signature = method.signature();
+
+        // Skip methods with unsupported types (they get compile_error! in the method)
+        let parsed = match parse_signature(&signature) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        let has_unsupported = parsed.args.iter().any(|arg| {
+            matches!(arg, ArgClass::Transaction(_) | ArgClass::Reference(_))
+                || match arg {
+                    ArgClass::Value(ty) => rust_param_type(ty).is_err(),
+                    _ => false,
+                }
+        });
+
+        if has_unsupported {
+            continue;
+        }
+
+        let method_name = &method.name;
+        let builder_ident = format_ident!("{}{}", struct_ident, to_pascal_case(method_name));
+
+        let doc = format!("Builder for the `{}` method.", method_name);
+
+        builders.push(quote! {
+            #[doc = #doc]
+            pub struct #builder_ident<'a> {
+                contract: &'a #struct_ident,
+                invocation: ::algonaut_abi::MethodInvocation,
+            }
+
+            impl<'a> #builder_ident<'a> {
+                /// Build the method call with the given suggested parameters.
+                pub fn build(
+                    self,
+                    params: &::algonaut_model::algod::SuggestedParams,
+                ) -> ::algonaut::atomic::MethodCall {
+                    ::algonaut::atomic::MethodCall::builder(
+                        self.contract.app_id,
+                        self.contract.sender,
+                        ::std::sync::Arc::clone(&self.contract.signer),
+                    )
+                    .invoke(self.invocation)
+                    .build(params)
+                }
+            }
+        });
+    }
+
+    Ok(quote! { #(#builders)* })
+}
+
+/// Convert a string to PascalCase.
+fn to_pascal_case(s: &str) -> String {
+    let mut result = String::new();
+    let mut capitalize_next = true;
+
+    for c in s.chars() {
+        if c == '_' || c == '-' || c == ' ' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            result.push(c.to_ascii_uppercase());
+            capitalize_next = false;
+        } else {
+            result.push(c);
+        }
+    }
+
+    result
+}
+
+/// Convert a string to snake_case.
+fn to_snake_case(s: &str) -> String {
+    let mut result = String::new();
+
+    for (i, c) in s.chars().enumerate() {
+        if c.is_ascii_uppercase() {
+            if i > 0 {
+                result.push('_');
+            }
+            result.push(c.to_ascii_lowercase());
+        } else if c == '-' || c == ' ' {
+            result.push('_');
+        } else {
+            result.push(c);
+        }
+    }
+
+    result
+}
+
+/// Check if a string is a Rust keyword.
+fn is_rust_keyword(s: &str) -> bool {
+    matches!(
+        s,
+        "as" | "async"
+            | "await"
+            | "break"
+            | "const"
+            | "continue"
+            | "crate"
+            | "dyn"
+            | "else"
+            | "enum"
+            | "extern"
+            | "false"
+            | "fn"
+            | "for"
+            | "if"
+            | "impl"
+            | "in"
+            | "let"
+            | "loop"
+            | "match"
+            | "mod"
+            | "move"
+            | "mut"
+            | "pub"
+            | "ref"
+            | "return"
+            | "self"
+            | "Self"
+            | "static"
+            | "struct"
+            | "super"
+            | "trait"
+            | "true"
+            | "type"
+            | "unsafe"
+            | "use"
+            | "where"
+            | "while"
+            | "abstract"
+            | "become"
+            | "box"
+            | "do"
+            | "final"
+            | "macro"
+            | "override"
+            | "priv"
+            | "try"
+            | "typeof"
+            | "unsized"
+            | "virtual"
+            | "yield"
+    )
+}
+
+/// Sanitize a string to be a valid Rust identifier.
+fn sanitize_identifier(s: &str) -> String {
+    let sanitized: String = s
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+
+    // Ensure it doesn't start with a digit
+    if sanitized.starts_with(|c: char| c.is_ascii_digit()) {
+        format!("network_{sanitized}")
+    } else {
+        sanitized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_pascal_case() {
+        assert_eq!(to_pascal_case("calculator"), "Calculator");
+        assert_eq!(to_pascal_case("add_liquidity"), "AddLiquidity");
+        assert_eq!(to_pascal_case("myContract"), "MyContract");
+    }
+
+    #[test]
+    fn test_to_snake_case() {
+        assert_eq!(to_snake_case("addLiquidity"), "add_liquidity");
+        assert_eq!(to_snake_case("getBalance"), "get_balance");
+        assert_eq!(to_snake_case("add"), "add");
+    }
+
+    #[test]
+    fn test_is_rust_keyword() {
+        assert!(is_rust_keyword("type"));
+        assert!(is_rust_keyword("fn"));
+        assert!(!is_rust_keyword("add"));
+    }
+}

--- a/algonaut_abi_macros/src/contract/mod.rs
+++ b/algonaut_abi_macros/src/contract/mod.rs
@@ -1,0 +1,70 @@
+//! `contract!` macro implementation.
+//!
+//! Reads an ARC-4 ABI JSON file at compile time and generates a type-safe
+//! Rust struct with methods for each ABI method.
+
+mod codegen;
+mod parse;
+mod type_map;
+
+use quote::quote;
+use syn::{LitStr, parse_macro_input};
+
+/// Expand the `contract!` macro.
+///
+/// Input: a string literal path to an ARC-4 ABI JSON file, relative to
+/// `CARGO_MANIFEST_DIR`.
+///
+/// Output: a struct named after the contract with methods for each ABI method.
+pub fn expand(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let lit = parse_macro_input!(input as LitStr);
+    let path_str = lit.value();
+
+    // Resolve the path relative to CARGO_MANIFEST_DIR
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_owned());
+    let full_path = std::path::Path::new(&manifest_dir).join(&path_str);
+
+    // Read the file content
+    let json_content = match std::fs::read_to_string(&full_path) {
+        Ok(content) => content,
+        Err(e) => {
+            return syn::Error::new(
+                lit.span(),
+                format!("failed to read ABI file `{}`: {}", full_path.display(), e),
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    // Parse the JSON
+    let contract = match parse::parse_contract_json(&json_content) {
+        Ok(c) => c,
+        Err(e) => {
+            return syn::Error::new(lit.span(), e).to_compile_error().into();
+        }
+    };
+
+    // Generate code
+    let generated = match codegen::generate_contract(&contract) {
+        Ok(tokens) => tokens,
+        Err(e) => {
+            return syn::Error::new(lit.span(), e).to_compile_error().into();
+        }
+    };
+
+    // Emit include_str! to establish a dependency on the JSON file for rebuilds
+    let path_str_lit = path_str.as_str();
+    let output = quote! {
+        // Establish file dependency for incremental compilation
+        const _: &str = ::core::include_str!(::core::concat!(
+            ::core::env!("CARGO_MANIFEST_DIR"),
+            "/",
+            #path_str_lit
+        ));
+
+        #generated
+    };
+
+    output.into()
+}

--- a/algonaut_abi_macros/src/contract/parse.rs
+++ b/algonaut_abi_macros/src/contract/parse.rs
@@ -1,0 +1,171 @@
+//! Minimal JSON parsing for ARC-4 ABI contract files.
+//!
+//! We define our own minimal structs here rather than depending on algonaut_abi
+//! to avoid circular dependencies (algonaut_abi re-exports macros from this crate).
+
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// Top-level ARC-4 contract JSON structure.
+#[derive(Debug, Deserialize)]
+pub struct ContractJson {
+    /// Contract name (used to derive the generated struct name).
+    pub name: String,
+    /// Optional contract description (parsed but not currently used).
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub desc: Option<String>,
+    /// Method definitions.
+    #[serde(default)]
+    pub methods: Vec<MethodJson>,
+    /// Network deployments mapping genesis hash to app info.
+    #[serde(default)]
+    pub networks: HashMap<String, NetworkInfo>,
+}
+
+/// A method definition in the ARC-4 ABI.
+#[derive(Debug, Deserialize)]
+pub struct MethodJson {
+    /// Method name.
+    pub name: String,
+    /// Optional method description.
+    #[serde(default)]
+    pub desc: Option<String>,
+    /// Method arguments.
+    #[serde(default)]
+    pub args: Vec<ArgJson>,
+    /// Return type (ABI type string).
+    #[serde(default)]
+    pub returns: ReturnJson,
+}
+
+/// An argument definition in a method.
+#[derive(Debug, Deserialize)]
+pub struct ArgJson {
+    /// Argument name (optional per ARC-4).
+    #[serde(default)]
+    pub name: Option<String>,
+    /// ABI type string (e.g., "uint64", "address", "byte[]").
+    #[serde(rename = "type")]
+    pub type_str: String,
+    /// Optional argument description (parsed but not currently used).
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub desc: Option<String>,
+}
+
+/// Return type specification.
+#[derive(Debug, Deserialize, Default)]
+pub struct ReturnJson {
+    /// ABI type string for the return value.
+    #[serde(rename = "type", default = "default_void")]
+    pub type_str: String,
+    /// Optional description (parsed but not currently used).
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub desc: Option<String>,
+}
+
+fn default_void() -> String {
+    "void".to_owned()
+}
+
+/// Network-specific deployment info.
+#[derive(Debug, Deserialize)]
+pub struct NetworkInfo {
+    /// Application ID on this network.
+    #[serde(rename = "appID")]
+    pub app_id: u64,
+}
+
+impl MethodJson {
+    /// Reconstruct the ARC-4 method signature string (e.g., "add(uint64,uint64)uint64").
+    pub fn signature(&self) -> String {
+        let arg_types: Vec<&str> = self.args.iter().map(|a| a.type_str.as_str()).collect();
+        format!(
+            "{}({}){}",
+            self.name,
+            arg_types.join(","),
+            self.returns.type_str
+        )
+    }
+}
+
+/// Known genesis hashes mapped to network names.
+pub fn genesis_to_network(genesis_hash: &str) -> Option<&'static str> {
+    match genesis_hash {
+        "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=" => Some("testnet"),
+        "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=" => Some("mainnet"),
+        "mFgazF+2uRS1tMiL9dsj01hJGySEmPN28B/TjjvpVW0=" => Some("betanet"),
+        _ => None,
+    }
+}
+
+/// Parse an ARC-4 contract JSON string.
+pub fn parse_contract_json(json_str: &str) -> Result<ContractJson, String> {
+    serde_json::from_str(json_str).map_err(|e| format!("failed to parse ABI JSON: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_signature_reconstruction() {
+        let method = MethodJson {
+            name: "add".to_owned(),
+            desc: None,
+            args: vec![
+                ArgJson {
+                    name: Some("a".to_owned()),
+                    type_str: "uint64".to_owned(),
+                    desc: None,
+                },
+                ArgJson {
+                    name: Some("b".to_owned()),
+                    type_str: "uint64".to_owned(),
+                    desc: None,
+                },
+            ],
+            returns: ReturnJson {
+                type_str: "uint64".to_owned(),
+                desc: None,
+            },
+        };
+        assert_eq!(method.signature(), "add(uint64,uint64)uint64");
+    }
+
+    #[test]
+    fn test_parse_minimal_contract() {
+        let json = r#"{
+            "name": "Calculator",
+            "methods": [
+                {
+                    "name": "add",
+                    "args": [
+                        {"name": "a", "type": "uint64"},
+                        {"name": "b", "type": "uint64"}
+                    ],
+                    "returns": {"type": "uint64"}
+                }
+            ]
+        }"#;
+        let contract = parse_contract_json(json).unwrap();
+        assert_eq!(contract.name, "Calculator");
+        assert_eq!(contract.methods.len(), 1);
+        assert_eq!(contract.methods[0].signature(), "add(uint64,uint64)uint64");
+    }
+
+    #[test]
+    fn test_genesis_to_network() {
+        assert_eq!(
+            genesis_to_network("wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8="),
+            Some("testnet")
+        );
+        assert_eq!(
+            genesis_to_network("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="),
+            Some("mainnet")
+        );
+        assert_eq!(genesis_to_network("unknown-hash"), None);
+    }
+}

--- a/algonaut_abi_macros/src/contract/parse.rs
+++ b/algonaut_abi_macros/src/contract/parse.rs
@@ -1,139 +1,21 @@
-//! Minimal JSON parsing for ARC-4 ABI contract files.
+//! Reads ARC-4 ABI contract JSON into the shared [`algonaut_abi_model`] types.
 //!
-//! We define our own minimal structs here rather than depending on algonaut_abi
-//! to avoid circular dependencies (algonaut_abi re-exports macros from this crate).
+//! The data model itself lives in [`algonaut_abi_model`] — a dependency-light
+//! leaf crate shared with the runtime `algonaut_abi` — so the macro and the
+//! runtime agree on the JSON shape by construction, rather than by keeping
+//! parallel structs in sync. This module only adds the compile-time
+//! file-parsing entry point.
 
-use serde::Deserialize;
-use std::collections::HashMap;
+pub use algonaut_abi_model::{AbiContract, AbiMethod, genesis_to_network};
 
-/// Top-level ARC-4 contract JSON structure.
-#[derive(Debug, Deserialize)]
-pub struct ContractJson {
-    /// Contract name (used to derive the generated struct name).
-    pub name: String,
-    /// Optional contract description (parsed but not currently used).
-    #[serde(default)]
-    #[allow(dead_code)]
-    pub desc: Option<String>,
-    /// Method definitions.
-    #[serde(default)]
-    pub methods: Vec<MethodJson>,
-    /// Network deployments mapping genesis hash to app info.
-    #[serde(default)]
-    pub networks: HashMap<String, NetworkInfo>,
-}
-
-/// A method definition in the ARC-4 ABI.
-#[derive(Debug, Deserialize)]
-pub struct MethodJson {
-    /// Method name.
-    pub name: String,
-    /// Optional method description.
-    #[serde(default)]
-    pub desc: Option<String>,
-    /// Method arguments.
-    #[serde(default)]
-    pub args: Vec<ArgJson>,
-    /// Return type (ABI type string).
-    #[serde(default)]
-    pub returns: ReturnJson,
-}
-
-/// An argument definition in a method.
-#[derive(Debug, Deserialize)]
-pub struct ArgJson {
-    /// Argument name (optional per ARC-4).
-    #[serde(default)]
-    pub name: Option<String>,
-    /// ABI type string (e.g., "uint64", "address", "byte[]").
-    #[serde(rename = "type")]
-    pub type_str: String,
-    /// Optional argument description (parsed but not currently used).
-    #[serde(default)]
-    #[allow(dead_code)]
-    pub desc: Option<String>,
-}
-
-/// Return type specification.
-#[derive(Debug, Deserialize, Default)]
-pub struct ReturnJson {
-    /// ABI type string for the return value.
-    #[serde(rename = "type", default = "default_void")]
-    pub type_str: String,
-    /// Optional description (parsed but not currently used).
-    #[serde(default)]
-    #[allow(dead_code)]
-    pub desc: Option<String>,
-}
-
-fn default_void() -> String {
-    "void".to_owned()
-}
-
-/// Network-specific deployment info.
-#[derive(Debug, Deserialize)]
-pub struct NetworkInfo {
-    /// Application ID on this network.
-    #[serde(rename = "appID")]
-    pub app_id: u64,
-}
-
-impl MethodJson {
-    /// Reconstruct the ARC-4 method signature string (e.g., "add(uint64,uint64)uint64").
-    pub fn signature(&self) -> String {
-        let arg_types: Vec<&str> = self.args.iter().map(|a| a.type_str.as_str()).collect();
-        format!(
-            "{}({}){}",
-            self.name,
-            arg_types.join(","),
-            self.returns.type_str
-        )
-    }
-}
-
-/// Known genesis hashes mapped to network names.
-pub fn genesis_to_network(genesis_hash: &str) -> Option<&'static str> {
-    match genesis_hash {
-        "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=" => Some("testnet"),
-        "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=" => Some("mainnet"),
-        "mFgazF+2uRS1tMiL9dsj01hJGySEmPN28B/TjjvpVW0=" => Some("betanet"),
-        _ => None,
-    }
-}
-
-/// Parse an ARC-4 contract JSON string.
-pub fn parse_contract_json(json_str: &str) -> Result<ContractJson, String> {
+/// Parse an ARC-4 contract JSON string into the shared model.
+pub fn parse_contract_json(json_str: &str) -> Result<AbiContract, String> {
     serde_json::from_str(json_str).map_err(|e| format!("failed to parse ABI JSON: {e}"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_signature_reconstruction() {
-        let method = MethodJson {
-            name: "add".to_owned(),
-            desc: None,
-            args: vec![
-                ArgJson {
-                    name: Some("a".to_owned()),
-                    type_str: "uint64".to_owned(),
-                    desc: None,
-                },
-                ArgJson {
-                    name: Some("b".to_owned()),
-                    type_str: "uint64".to_owned(),
-                    desc: None,
-                },
-            ],
-            returns: ReturnJson {
-                type_str: "uint64".to_owned(),
-                desc: None,
-            },
-        };
-        assert_eq!(method.signature(), "add(uint64,uint64)uint64");
-    }
 
     #[test]
     fn test_parse_minimal_contract() {
@@ -153,19 +35,15 @@ mod tests {
         let contract = parse_contract_json(json).unwrap();
         assert_eq!(contract.name, "Calculator");
         assert_eq!(contract.methods.len(), 1);
-        assert_eq!(contract.methods[0].signature(), "add(uint64,uint64)uint64");
+        assert_eq!(
+            contract.methods[0].get_signature(),
+            "add(uint64,uint64)uint64"
+        );
     }
 
     #[test]
-    fn test_genesis_to_network() {
-        assert_eq!(
-            genesis_to_network("wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8="),
-            Some("testnet")
-        );
-        assert_eq!(
-            genesis_to_network("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="),
-            Some("mainnet")
-        );
-        assert_eq!(genesis_to_network("unknown-hash"), None);
+    fn test_parse_reports_error() {
+        let err = parse_contract_json("{ not json").unwrap_err();
+        assert!(err.contains("failed to parse ABI JSON"));
     }
 }

--- a/algonaut_abi_macros/src/contract/type_map.rs
+++ b/algonaut_abi_macros/src/contract/type_map.rs
@@ -1,0 +1,78 @@
+//! Maps ABI type strings to Rust types for generated method parameters.
+//!
+//! The initial implementation covers scalar types that have canonical Rust
+//! representations. Unsupported types (transaction/reference args, compound
+//! types) return an error with guidance to use the dynamic path.
+
+use algonaut_abi_sig::SigType;
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// Maps an ABI type to the Rust type to use in generated method parameters.
+/// Returns the type as a TokenStream for use in code generation.
+pub fn rust_param_type(ty: &SigType) -> Result<TokenStream, String> {
+    match ty {
+        SigType::UInt { bit_size } => uint_to_rust(*bit_size),
+        SigType::Byte => Ok(quote! { u8 }),
+        SigType::Bool => Ok(quote! { bool }),
+        SigType::Address => Ok(quote! { ::algonaut_core::Address }),
+        SigType::String => Ok(quote! { ::std::string::String }),
+        // byte[] is the one compound type with a canonical Rust representation
+        SigType::DynamicArray { child_type } if matches!(**child_type, SigType::Byte) => {
+            Ok(quote! { ::std::vec::Vec<u8> })
+        }
+        SigType::UFixed {
+            bit_size,
+            precision,
+        } => Err(format!(
+            "ufixed{bit_size}x{precision} (no canonical Rust type)"
+        )),
+        SigType::StaticArray { .. } => Err("static array".to_owned()),
+        SigType::DynamicArray { .. } => Err("dynamic array".to_owned()),
+        SigType::Tuple { .. } => Err("tuple".to_owned()),
+    }
+}
+
+/// Maps a uint bit size to the appropriate Rust unsigned integer type.
+fn uint_to_rust(bit_size: u16) -> Result<TokenStream, String> {
+    match bit_size {
+        8 => Ok(quote! { u8 }),
+        16 => Ok(quote! { u16 }),
+        32 => Ok(quote! { u32 }),
+        64 => Ok(quote! { u64 }),
+        128 => Ok(quote! { u128 }),
+        // uint256+ uses BigUint
+        n if n > 128 && n <= 512 => Ok(quote! { ::num_bigint::BigUint }),
+        n => Err(format!("uint{n} (unsupported bit size)")),
+    }
+}
+
+/// Maps an ABI type to the marker type for use with AbiArg trait bounds.
+/// This is used to generate the encoding call for method arguments.
+pub fn abi_marker_type(ty: &SigType) -> Result<TokenStream, String> {
+    match ty {
+        SigType::UInt { bit_size } => {
+            let bits = proc_macro2::Literal::u16_unsuffixed(*bit_size);
+            Ok(quote! { ::algonaut_abi::macro_support::Uint<#bits> })
+        }
+        SigType::Byte => Ok(quote! { ::algonaut_abi::macro_support::Byte }),
+        SigType::Bool => Ok(quote! { ::algonaut_abi::macro_support::Bool }),
+        SigType::Address => Ok(quote! { ::algonaut_abi::macro_support::Address }),
+        SigType::String => Ok(quote! { ::algonaut_abi::macro_support::AbiString }),
+        SigType::DynamicArray { child_type } if matches!(**child_type, SigType::Byte) => {
+            Ok(quote! { ::algonaut_abi::macro_support::Bytes })
+        }
+        other => Err(unsupported_type_message(other)),
+    }
+}
+
+fn unsupported_type_message(ty: &SigType) -> String {
+    let type_name = match ty {
+        SigType::UFixed { .. } => "ufixed",
+        SigType::StaticArray { .. } => "static array",
+        SigType::DynamicArray { .. } => "dynamic array",
+        SigType::Tuple { .. } => "tuple",
+        _ => "unsupported type",
+    };
+    format!("{type_name}; use MethodCall::builder().invoke(Invocation::new(...)) for this method")
+}

--- a/algonaut_abi_macros/src/lib.rs
+++ b/algonaut_abi_macros/src/lib.rs
@@ -12,11 +12,16 @@
 //!   a per-type `AbiArg<T>` bound, expanding to an `algonaut_abi::MethodInvocation`.
 //! - [`macro@abi_method`] — `abi_method!("add(uint64,uint64)uint64")` is the
 //!   signature-only base: validate the literal and expand to an `AbiMethod`.
+//! - [`macro@contract`] — `contract!("path/to/contract.json")` reads an ARC-4
+//!   ABI JSON file and generates a typed struct with methods for each ABI
+//!   method.
 //!
-//! Both are re-exported from `algonaut_abi`, so call sites write
+//! All macros are re-exported from `algonaut_abi`, so call sites write
 //! `algonaut_abi::abi_call!` (or `algonaut::abi::abi_call!`). The grammar is
 //! the one in [`algonaut_abi_sig`], the same crate `from_signature` parses
 //! with at run time — so the macros and the runtime parser cannot disagree.
+
+mod contract;
 
 use algonaut_abi_sig::{ArgClass, SigType};
 use proc_macro::TokenStream;
@@ -210,4 +215,59 @@ fn plural(n: usize) -> &'static str {
 
 fn were_was(n: usize) -> &'static str {
     if n == 1 { "was" } else { "were" }
+}
+
+/// `contract!("path/to/contract.json")`: generate a typed contract client from
+/// an ARC-4 ABI JSON file.
+///
+/// The macro reads the ABI JSON at compile time and generates a struct named
+/// after the contract (PascalCase) with methods for each ABI method. The path
+/// is resolved relative to `CARGO_MANIFEST_DIR`, matching `include_str!` behavior.
+///
+/// # Example
+///
+/// ```ignore
+/// algonaut::contract!("contracts/calculator.json");
+///
+/// // Use the generated struct
+/// let client = Calculator::new(AppId(5), alice.address(), signer);
+/// let call = client.add(2u64, 3u64).build(&params);
+/// ```
+///
+/// # Generated Code
+///
+/// For a contract with methods `add(uint64,uint64)uint64` and `subtract(uint64,uint64)uint64`:
+///
+/// ```ignore
+/// pub struct Calculator {
+///     app_id: AppId,
+///     sender: Address,
+///     signer: Arc<dyn Signer>,
+/// }
+///
+/// impl Calculator {
+///     pub fn new(app_id, sender, signer) -> Self { ... }
+///     pub fn add(&self, a: u64, b: u64) -> CalculatorAddBuilder { ... }
+///     pub fn subtract(&self, a: u64, b: u64) -> CalculatorSubtractBuilder { ... }
+/// }
+/// ```
+///
+/// If the ABI JSON contains a `networks` field, named constructors are generated
+/// for known networks (testnet, mainnet, betanet).
+///
+/// # Supported Types
+///
+/// The initial implementation supports scalar types with canonical Rust
+/// representations: `uint8`-`uint512`, `bool`, `address`, `string`, `byte[]`.
+/// Methods with transaction args, reference args, or compound types (arrays,
+/// tuples) generate a compile error with guidance to use the dynamic path.
+///
+/// # Feature Requirements
+///
+/// The generated code uses `MethodCall` from the `algonaut::atomic` module,
+/// which requires the `algod` feature (included in default features). Ensure
+/// your `algonaut` dependency includes this feature.
+#[proc_macro]
+pub fn contract(input: TokenStream) -> TokenStream {
+    contract::expand(input)
 }

--- a/algonaut_abi_model/Cargo.toml
+++ b/algonaut_abi_model/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+authors = ["Manuel Mauro <manuel.mauro@protonmail.com>"]
+description = "Pure ARC-4 ABI JSON data model (contract/method/arg/return), shared by algonaut_abi and its compile-time macros."
+edition = "2024"
+keywords = ["Algorand", "sdk", "abi"]
+license = "MIT OR Apache-2.0"
+name = "algonaut_abi_model"
+repository = "https://github.com/manuelmauro/algonaut"
+version = "0.8.0"
+
+# The on-the-wire ARC-4 ABI/app-spec JSON shape, shared by the runtime parser
+# (algonaut_abi, which builds its richer types from these) and the proc-macros
+# (algonaut_abi_macros, which reads them at compile time). Kept to serde-derive
+# only — no I/O, no resolved types, no algonaut_core — so it can sit below both
+# without a cycle. See algonaut_abi_sig for the sibling signature/type grammar.
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/algonaut_abi_model/src/lib.rs
+++ b/algonaut_abi_model/src/lib.rs
@@ -1,0 +1,202 @@
+//! Pure ARC-4 ABI JSON data model.
+//!
+//! These structs mirror the on-the-wire ARC-4 ABI / app-spec JSON — contract,
+//! interface, method, argument, return, and per-network deployment info — and
+//! nothing more: no resolved [`AbiType`], no typed `AppId`, no method
+//! selectors. They are the single source of truth for the JSON shape, shared
+//! by two crates that must agree on it:
+//!
+//! - the runtime ([`algonaut_abi`]), whose richer `AbiContract`/`AbiMethod`/…
+//!   add a lazily-parsed type cache and typed identifiers and (de)serialize by
+//!   delegating here via `#[serde(from / into)]`;
+//! - the compile-time `contract!` macro ([`algonaut_abi_macros`]), which reads
+//!   these to generate a typed client.
+//!
+//! Keeping the model in a dependency-light leaf crate (serde-derive only, like
+//! the sibling [`algonaut_abi_sig`] grammar crate) is what breaks the cycle:
+//! `algonaut_abi` re-exports the macros, so `algonaut_abi_macros` cannot depend
+//! on `algonaut_abi` — but both can depend on this.
+//!
+//! [`AbiType`]: https://docs.rs/algonaut_abi
+//! [`algonaut_abi`]: https://docs.rs/algonaut_abi
+//! [`algonaut_abi_macros`]: https://docs.rs/algonaut_abi_macros
+//! [`algonaut_abi_sig`]: https://docs.rs/algonaut_abi_sig
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// An ARC-4 contract: a concrete set of methods implemented by a single app.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AbiContract {
+    /// Contract name (the generated client struct is named after it).
+    pub name: String,
+
+    /// Optional human-readable description.
+    #[serde(rename = "desc", skip_serializing_if = "Option::is_none")]
+    pub desc: Option<String>,
+
+    /// Per-network deployment info, keyed by genesis hash.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub networks: HashMap<String, AbiContractNetworkInfo>,
+
+    /// The contract's methods.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub methods: Vec<AbiMethod>,
+}
+
+/// An ARC-4 interface: a logical grouping of methods, with no deployment info.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AbiInterface {
+    /// Interface name.
+    pub name: String,
+
+    /// Optional human-readable description.
+    #[serde(rename = "desc", skip_serializing_if = "Option::is_none")]
+    pub desc: Option<String>,
+
+    /// The interface's methods.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub methods: Vec<AbiMethod>,
+}
+
+/// A single ABI method.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AbiMethod {
+    /// Method name.
+    pub name: String,
+
+    /// Optional human-readable description.
+    #[serde(rename = "desc", skip_serializing_if = "Option::is_none")]
+    pub desc: Option<String>,
+
+    /// The method's arguments, in order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<AbiMethodArg>,
+
+    /// The method's return type. Defaults to `void` when absent.
+    #[serde(default)]
+    pub returns: AbiReturn,
+}
+
+/// A single method argument.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AbiMethodArg {
+    /// Optional argument name (omitted by some ARC-4 producers).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// ABI type string (e.g. `"uint64"`, `"address"`, `"byte[]"`).
+    #[serde(rename = "type")]
+    pub type_: String,
+
+    /// Optional human-readable description.
+    #[serde(rename = "desc", skip_serializing_if = "Option::is_none")]
+    pub desc: Option<String>,
+}
+
+/// A method's return type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AbiReturn {
+    /// ABI type string for the return value (`"void"` for no return).
+    #[serde(rename = "type")]
+    pub type_: String,
+
+    /// Optional human-readable description.
+    #[serde(rename = "desc", skip_serializing_if = "Option::is_none")]
+    pub desc: Option<String>,
+}
+
+impl Default for AbiReturn {
+    fn default() -> Self {
+        Self {
+            type_: "void".to_owned(),
+            desc: None,
+        }
+    }
+}
+
+/// Per-network deployment info: which app ID hosts the contract on a network.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AbiContractNetworkInfo {
+    /// The application ID on this network.
+    #[serde(rename = "appID")]
+    pub app_id: u64,
+}
+
+impl AbiMethod {
+    /// Reconstruct the ARC-4 method signature (e.g. `"add(uint64,uint64)uint64"`).
+    pub fn get_signature(&self) -> String {
+        let arg_types: Vec<&str> = self.args.iter().map(|a| a.type_.as_str()).collect();
+        format!(
+            "{}({}){}",
+            self.name,
+            arg_types.join(","),
+            self.returns.type_
+        )
+    }
+}
+
+/// Map a known mainnet/testnet/betanet genesis hash to its network name.
+///
+/// Returns `None` for any other (or custom) network, leaving the caller to
+/// decide how to name it.
+pub fn genesis_to_network(genesis_hash: &str) -> Option<&'static str> {
+    match genesis_hash {
+        "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=" => Some("testnet"),
+        "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=" => Some("mainnet"),
+        "mFgazF+2uRS1tMiL9dsj01hJGySEmPN28B/TjjvpVW0=" => Some("betanet"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_signature_reconstructs_from_parts() {
+        let method = AbiMethod {
+            name: "add".to_owned(),
+            desc: None,
+            args: vec![
+                AbiMethodArg {
+                    name: Some("a".to_owned()),
+                    type_: "uint64".to_owned(),
+                    desc: None,
+                },
+                AbiMethodArg {
+                    name: Some("b".to_owned()),
+                    type_: "uint64".to_owned(),
+                    desc: None,
+                },
+            ],
+            returns: AbiReturn {
+                type_: "uint64".to_owned(),
+                desc: None,
+            },
+        };
+        assert_eq!(method.get_signature(), "add(uint64,uint64)uint64");
+    }
+
+    #[test]
+    fn returns_defaults_to_void() {
+        assert_eq!(AbiReturn::default().type_, "void");
+        // A method object without a `returns` field decodes to void.
+        let json = r#"{"name":"noop","args":[]}"#;
+        let method: AbiMethod = serde_json::from_str(json).unwrap();
+        assert_eq!(method.get_signature(), "noop()void");
+    }
+
+    #[test]
+    fn genesis_to_network_maps_known_hashes() {
+        assert_eq!(
+            genesis_to_network("wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8="),
+            Some("testnet")
+        );
+        assert_eq!(
+            genesis_to_network("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="),
+            Some("mainnet")
+        );
+        assert_eq!(genesis_to_network("unknown-hash"), None);
+    }
+}

--- a/docs/adr/abi-json-model-shared-leaf-crate.md
+++ b/docs/adr/abi-json-model-shared-leaf-crate.md
@@ -1,0 +1,111 @@
+---
+id: abi-json-model-shared-leaf-crate
+title: ABI JSON model in a shared leaf crate
+abstract: 'Extract the ARC-4 ABI JSON data model into a dependency-light leaf crate, algonaut_abi_model, shared by the runtime algonaut_abi (which keeps its richer types and delegates serde via #[serde(from/into)]) and the contract! proc-macro in algonaut_abi_macros. Single-sources the wire format and removes the macro''s duplicate structs, at the cost of one more published crate.'
+status: accepted
+date: 2026-05-25
+deciders: []
+tags: [abi, macros, codegen, crate-layout, serde]
+---
+
+# ABI JSON model in a shared leaf crate
+
+## Status
+
+Accepted. Implemented on the `feat/contract-macro` branch (PR #341): new crate
+`algonaut_abi_model`; `algonaut_abi`'s `AbiContract` / `AbiInterface` /
+`AbiMethod` / `AbiMethodArg` / `AbiReturn` / `AbiContractNetworkInfo` keep their
+fields and behaviour but carry `#[serde(from = "model::…", into = "model::…")]`
+plus `From` conversions; `algonaut_abi_macros` depends on the model and dropped
+its duplicate structs and its direct `serde` (derive) dependency.
+
+Amends decision **D5** of
+[`contract-macro-from-abi-json`](contract-macro-from-abi-json.md): the macro no
+longer defines its own minimal `ContractJson`/`MethodJson`/… structs.
+
+## Context
+
+The `contract!` macro
+([`contract-macro-from-abi-json`](contract-macro-from-abi-json.md)) needs to
+read an ARC-4 ABI/app-spec JSON file at compile time. `algonaut_abi` already
+defines a full serde model of that exact JSON — `AbiContract`, `AbiMethod`,
+`AbiMethodArg`, `AbiReturn`, `AbiContractNetworkInfo` — with the matching
+`#[serde(rename)]`s (`"desc"`, `"type"`, `"appID"`, …).
+
+The macro could not reuse those types directly: `algonaut_abi` re-exports the
+macros from `algonaut_abi_macros`, so the macro crate depending back on
+`algonaut_abi` is a dependency cycle Cargo rejects. D5 worked around this by
+having the macro define its own minimal duplicate structs. That left two
+hand-maintained definitions of the same wire format, free to drift.
+
+Two further facts shape the fix:
+
+- `algonaut_abi`'s types are **not** pure DTOs. `AbiContractNetworkInfo.app_id`
+  is a typed `AppId` (`algonaut_core`); `AbiMethodArg`/`AbiReturn` carry a
+  lazily-parsed `Option<AbiType>` cache; `AbiMethod` computes selectors via
+  `sha2`. Pulling any of that into a proc-macro's build graph would be wrong
+  and heavy. The macro only needs the raw strings.
+- The codebase already has the pattern for exactly this split:
+  [`abi-method-signature-macro`](abi-method-signature-macro.md) introduced
+  `algonaut_abi_sig`, a zero-I/O leaf crate holding the signature/type grammar
+  shared by the runtime parser and the macros. The JSON shape is the analogous
+  shared concern, with one extra dependency the grammar crate deliberately
+  avoids: serde.
+
+We considered three options (discussed in full before deciding):
+
+1. **Move the model into `algonaut_abi_sig`.** Zero new crates, but forces
+   `serde` into a crate whose charter is "pure grammar, no I/O, no heavy deps,"
+   and conflates "parse a signature string" with "deserialize a contract file."
+2. **Keep the duplicate, add a drift-guard test.** Lowest effort, but leaves
+   two definitions of the wire format.
+3. **A new shared leaf crate for the model.** Cleanest separation — each leaf
+   has one reason to change and its own dependency profile — at the cost of one
+   more published crate (see
+   [`publish-entire-workspace`](publish-entire-workspace.md)).
+
+## Decision
+
+Take option 3. Add `algonaut_abi_model`: a dependency-light leaf crate (serde
+derive only, no `serde_json`, no I/O, no `algonaut_core`) holding the canonical
+serde structs for the ARC-4 ABI JSON — `AbiContract`, `AbiInterface`,
+`AbiMethod`, `AbiMethodArg`, `AbiReturn`, `AbiContractNetworkInfo` — plus the
+pure helpers `AbiMethod::get_signature()` and `genesis_to_network()`. `appID`
+is modelled as a plain `u64`; the model carries no resolved types and no caches.
+
+This crate is the **single source of truth for the JSON shape**, sitting below
+both consumers so it breaks no cycle:
+
+- **`algonaut_abi_macros`** deserializes ABI files straight into the model and
+  generates code from it. Its own duplicate structs and its `serde`-derive
+  dependency are removed (`serde_json` stays, to parse).
+- **`algonaut_abi`** keeps its richer runtime types unchanged in fields and
+  public API, but delegates the wire format to the model via
+  `#[serde(from = "model::X", into = "model::X")]` and a set of total `From`
+  conversions. The runtime types add what the model deliberately omits: the
+  typed `AppId`, the lazily-parsed `AbiType` cache (reset to `None` on
+  conversion, filled on demand exactly as before), and selector hashing.
+
+The field-name mapping (`rename`, `skip_serializing_if`, `default`) now lives in
+exactly one place. The existing exact-JSON round-trip tests in
+`algonaut_abi` (`abi_json_tests.rs`) are the regression guard that the delegated
+format is byte-identical; they pass unchanged.
+
+## Consequences
+
+- **No drift.** The macro and the runtime cannot disagree about the JSON shape:
+  there is one definition, and `algonaut_abi`'s round-trip tests pin its bytes.
+- **Proc-macro build stays lean.** The macro pulls in `algonaut_abi_model` +
+  `serde_json`, not `algonaut_core`, `AbiType`, or `sha2`.
+- **One more published crate.** `algonaut_abi_model` is depended on by both
+  `algonaut_abi` and the (always-published) proc-macro crate, so it must be
+  published too. This is the unavoidable cost of option 3; the broader rationale
+  for accepting it lives in
+  [`publish-entire-workspace`](publish-entire-workspace.md).
+- **Slightly more lenient runtime decoding.** Routing through the model means a
+  method object with no `returns` now decodes to `void` (the model defaults it)
+  rather than erroring. This is a strict superset of prior behaviour and
+  spec-reasonable; no existing test relied on the stricter form.
+- **D5 of the contract-macro ADR is amended, not reversed.** The macro and its
+  user-facing behaviour are unchanged; only the internal source of the parsed
+  structs moved.

--- a/docs/adr/contract-macro-from-abi-json.md
+++ b/docs/adr/contract-macro-from-abi-json.md
@@ -1,0 +1,241 @@
+---
+id: contract-macro-from-abi-json
+title: Generate typed contract clients from ARC-4 ABI JSON files
+abstract: Add a contract!("path/to/contract.json") procedural macro that reads an ARC-4 ABI JSON file at compile time and generates a type-safe Rust struct with methods for each ABI method. The generated struct holds app_id, sender, and signer; each method returns a builder pre-configured with the method invocation. Integrates with the existing MethodCall::builder pattern and reuses the algonaut_abi_sig grammar for signature validation. Initial scope covers scalar value types (uint*, bool, address, string, byte[]); transaction and reference arguments route through the dynamic Invocation::new path.
+status: proposed
+date: 2026-05-24
+deciders: []
+tags: [api, abi, macros, codegen, ergonomics]
+---
+
+# Generate typed contract clients from ARC-4 ABI JSON files
+
+## Status
+
+Proposed.
+
+## Context
+
+[`abi-method-signature-macro`](abi-method-signature-macro.md) introduced
+`abi_call!` and `abi_method!` for compile-time checked method invocations,
+treating the ARC-4 signature literal as a format string. This eliminates
+signature typos and argument mismatches for *inline* method calls.
+
+However, when working with a deployed contract whose ABI is defined in a
+JSON file (the standard ARC-4 contract specification format), developers
+still face repetitive ceremony:
+
+```rust
+// Current pattern: manually transcribe each method signature
+let call = MethodCall::builder(AppId(123), alice.address(), signer)
+    .invoke(abi_call!("add(uint64,uint64)uint64", 2u64, 3u64))
+    .build(&params);
+
+let call2 = MethodCall::builder(AppId(123), alice.address(), signer)
+    .invoke(abi_call!("subtract(uint64,uint64)uint64", 5u64, 2u64))
+    .build(&params);
+```
+
+This pattern has several friction points:
+
+1. **Signature drift**: The ABI JSON is the source of truth, but signatures
+   are copied into Rust code by hand. A renamed method or changed argument
+   type in the JSON does not trigger a compile error in Rust.
+
+2. **Repetitive boilerplate**: Every call repeats `AppId(123)`,
+   `alice.address()`, `signer` — the contract-scoped context that should
+   be factored out.
+
+3. **No IDE discoverability**: Developers cannot autocomplete method names
+   or see parameter types without consulting the JSON file.
+
+4. **Network app IDs are manual**: The ARC-4 `networks` field maps genesis
+   hashes to app IDs, but developers must manually extract these.
+
+The Go SDK's `abi.Contract` and Python SDK's typed bindings (via
+`algokit-utils`) demonstrate the value of generating typed clients from
+ABI JSON. This ADR brings the same ergonomics to Rust via a proc-macro.
+
+## Decision
+
+### D1 — `contract!` macro: generate a typed client from ABI JSON
+
+```rust
+algonaut::contract!("contracts/calculator.json");
+
+// Expands to:
+pub struct Calculator { /* app_id, sender, signer */ }
+impl Calculator {
+    pub fn new(app_id, sender, signer) -> Self { ... }
+    pub fn add(&self, a: u64, b: u64) -> CalculatorAddBuilder { ... }
+    pub fn subtract(&self, a: u64, b: u64) -> CalculatorSubtractBuilder { ... }
+}
+```
+
+The macro:
+
+1. **Resolves the path** relative to `CARGO_MANIFEST_DIR` (same as
+   `include_str!`).
+2. **Parses the ARC-4 JSON** into `name`, `description`, `networks`, and
+   `methods`.
+3. **Validates each method signature** through `algonaut_abi_sig`, ensuring
+   the macro and runtime parser cannot disagree.
+4. **Generates a struct** named after the contract (PascalCase), holding
+   `AppId`, `Address`, and `Arc<dyn Signer>`.
+5. **Generates a method** for each ABI method, converting names to
+   snake_case for idiomatic Rust.
+
+### D2 — Method builders, not direct MethodCall
+
+Each generated method returns a per-method builder struct:
+
+```rust
+pub fn add(&self, a: u64, b: u64) -> CalculatorAddBuilder<'_> { ... }
+
+impl<'a> CalculatorAddBuilder<'a> {
+    pub fn build(self, params: &SuggestedParams) -> MethodCall { ... }
+}
+```
+
+This preserves the ability to set optional parameters (fee, note, boxes)
+before finalizing, matching the existing `MethodCall::builder` pattern:
+
+```rust
+let call = calculator.add(2u64, 3u64)
+    .note(b"calculation".to_vec())
+    .build(&params);
+```
+
+The builder internally constructs a `MethodInvocation` (the same type
+`abi_call!` produces) and feeds it to `MethodCall::builder().invoke()`.
+
+### D3 — Network-specific constructors
+
+If the ABI JSON contains a `networks` field:
+
+```json
+{
+  "networks": {
+    "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=": { "appID": 123 }
+  }
+}
+```
+
+The macro generates named constructors for known networks:
+
+```rust
+impl Calculator {
+    pub fn testnet(sender: Address, signer: Arc<dyn Signer>) -> Self {
+        Self::new(AppId(123), sender, signer)
+    }
+}
+```
+
+Genesis hash → network name mapping:
+- `wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=` → `testnet`
+- `SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=` → `mainnet`
+- `mFgazF+2uRS1tMiL9dsj01hJGySEmPN28B/TjjvpVW0=` → `betanet`
+
+Unknown genesis hashes generate a constructor with a sanitized name.
+
+### D4 — Type mapping for initial implementation
+
+The initial implementation maps scalar ABI types to Rust types, matching
+the coverage of `abi_call!`:
+
+| ABI Type | Rust Parameter Type |
+|----------|---------------------|
+| `uint8` | `u8` |
+| `uint16` | `u16` |
+| `uint32` | `u32` |
+| `uint64` | `u64` |
+| `uint128` | `u128` |
+| `uint256`+ | `num_bigint::BigUint` |
+| `bool` | `bool` |
+| `address` | `algonaut_core::Address` |
+| `string` | `String` |
+| `byte[]` | `Vec<u8>` |
+
+Methods containing unsupported argument types (transaction args, reference
+args, `ufixed`, compound arrays, tuples) generate a compile error with
+guidance to use the dynamic path:
+
+```text
+error: method `transfer` has unsupported argument type `pay`;
+       use MethodCall::builder().invoke(Invocation::new(...)) for this method
+```
+
+This is an honest scope boundary, not a silent fallback.
+
+### D5 — Placement in algonaut_abi_macros
+
+The macro lives in `algonaut_abi_macros`, alongside `abi_call!` and
+`abi_method!`. This:
+
+- Keeps ABI-related macros together
+- Reuses the existing `algonaut_abi_sig` dependency
+- Avoids adding another workspace crate
+
+New dependencies: `serde` and `serde_json` for JSON parsing. A minimal
+internal `ContractJson` struct is defined in the macro crate to avoid
+depending on `algonaut_abi` (which would create a circular dependency
+through re-exports).
+
+Re-export path: `algonaut::contract!` (via `algonaut_abi::contract!`).
+
+### D6 — Method name conversion
+
+ABI method names are converted to snake_case:
+
+- `addLiquidity` → `add_liquidity`
+- `getBalance` → `get_balance`
+- `add` → `add`
+
+Rust keywords are escaped with a raw identifier prefix (`r#`):
+
+- `type` → `r#type`
+
+### Alternatives considered
+
+- **Runtime loading**: Parse ABI JSON at runtime and return a dynamic
+  client. Rejected: loses compile-time type safety, the primary goal.
+
+- **Derive macro on a trait**: Require users to define a trait and derive
+  the implementation. Rejected: adds boilerplate; the file-based approach
+  is more ergonomic and matches how ABI files are typically used.
+
+- **Separate crate**: Create a new `algonaut_contract_macros` crate.
+  Rejected: fragments the macro ecosystem unnecessarily.
+
+- **Generate all types from day one**: Include transaction args, reference
+  args, arrays, tuples immediately. Rejected: incremental delivery
+  preferred; the scalar types cover the common case and match `abi_call!`
+  parity.
+
+## Consequences
+
+- **ABI JSON becomes the single source of truth.** Changing a method
+  signature in the JSON triggers recompilation and surfaces mismatches as
+  compile errors in Rust code.
+
+- **IDE discoverability.** Developers can autocomplete method names and
+  see parameter types directly in their editor.
+
+- **Reduced boilerplate.** Contract context (app ID, sender, signer) is
+  factored into the struct; each method call is a single line.
+
+- **New dependencies in algonaut_abi_macros.** `serde` and `serde_json`
+  add to the proc-macro build, but these are widely-used, well-optimized
+  crates.
+
+- **Partial type coverage by design.** Methods with unsupported argument
+  types produce a compile error rather than silently degrading. This is
+  consistent with `abi_call!`'s approach.
+
+- **File path resolution at compile time.** The ABI JSON must exist when
+  `cargo build` runs; missing files are compile errors. This matches
+  `include_str!` behavior.
+
+- **Recompilation on ABI changes.** The macro emits `include_str!` or
+  equivalent to establish a dependency on the JSON file, ensuring changes
+  trigger rebuilds.

--- a/docs/adr/contract-macro-from-abi-json.md
+++ b/docs/adr/contract-macro-from-abi-json.md
@@ -181,6 +181,16 @@ internal `ContractJson` struct is defined in the macro crate to avoid
 depending on `algonaut_abi` (which would create a circular dependency
 through re-exports).
 
+> **Amended** (see
+> [`abi-json-model-shared-leaf-crate`](abi-json-model-shared-leaf-crate.md)):
+> the minimal internal structs were replaced by a shared leaf crate,
+> `algonaut_abi_model`, that both the macro and `algonaut_abi` depend on, so the
+> ABI JSON shape has a single definition. The cycle is still avoided — the model
+> is a leaf below both — and the macro keeps only its `serde_json` dependency
+> (the `serde` derive moved to the model crate). The "avoids adding another
+> workspace crate" point above no longer holds; that trade-off is accepted in
+> [`publish-entire-workspace`](publish-entire-workspace.md).
+
 Re-export path: `algonaut::contract!` (via `algonaut_abi::contract!`).
 
 ### D6 — Method name conversion

--- a/docs/adr/publish-entire-workspace.md
+++ b/docs/adr/publish-entire-workspace.md
@@ -1,0 +1,90 @@
+---
+id: publish-entire-workspace
+title: Publish the entire workspace to crates.io
+abstract: 'Keep publishing every workspace crate to crates.io. Cargo features gate optional client crates rather than replacing them; the published-crate count cannot be reduced by features. Fewer published crates is only achievable by collapsing crates into feature-gated modules, and is bounded by a hard floor: the proc-macro crate algonaut_abi_macros plus its library dependencies must always be published separately.'
+status: accepted
+date: 2026-05-25
+deciders: []
+tags: [crate-layout, release, publishing, features]
+---
+
+# Publish the entire workspace to crates.io
+
+## Status
+
+Accepted. Records existing practice and settles a recurring question; no code
+change. Prompted by adding `algonaut_abi_model`
+([`abi-json-model-shared-leaf-crate`](abi-json-model-shared-leaf-crate.md)),
+which raised "do we really need to publish yet another crate?"
+
+## Context
+
+The workspace ships as ~12 crates, and the umbrella `algonaut` crate depends on
+the rest via `{ path = "…", version = "0.8.0" }`. A natural question keeps
+recurring: now that we have Cargo features
+([`client-feature-gates`](client-feature-gates.md)), can we publish fewer
+crates — or stop publishing the sub-crates and depend on them another way?
+
+The answer is constrained by Cargo, not preference:
+
+- **Features don't replace crates; here they gate them.** The optional clients
+  are wired as `algod = ["dep:algonaut_algod"]`, `indexer`, `kmd`, with
+  `feature?/tls` forwarding. Those features are *defined in terms of* separate
+  crates, so they make the multi-crate split more load-bearing, not less.
+- **A published crate cannot have path-only dependencies.** `cargo publish`
+  requires every normal/build dependency — including optional `dep:` ones — to
+  carry a `version` resolvable on the registry. So as long as `algonaut`
+  depends on the sub-crates by version, all of them must be published. There is
+  no `publish = false` route that keeps `algonaut` installable, and no
+  "depend on the local crate instead of the version" trick: the `version` is
+  the coordinate of the *published* copy, and the `path` is already used for
+  in-tree builds.
+- **`cargo yank` is not "unpublish."** It only stops a version from being
+  selected for *new* resolution; the code stays downloadable and existing
+  lockfiles keep using it. Yanking healthy versions to "tidy up" breaks
+  downstream reproducible builds and is an anti-pattern.
+
+The only mechanism that actually reduces the published-crate count is to make
+the crates stop being separate crates — collapse them into the umbrella as
+feature-gated modules. That has a hard floor: `algonaut_abi_macros` is
+`proc-macro = true` and can never be folded into a normal crate, and a published
+proc-macro crate needs its library dependencies (`algonaut_abi_sig`,
+`algonaut_abi_model`) published too. The macro also emits absolute paths
+(`::algonaut_core::…`), which a collapse would force rewriting through
+`::algonaut::…` re-exports. A maximal collapse therefore still publishes ~4
+crates, bought with a large, breaking refactor that also removes the ability to
+depend on a single piece (e.g. `algonaut_core`) standalone.
+
+## Decision
+
+Keep publishing the entire workspace, one version in lockstep. Treat the
+multi-crate layout as the intended structure: compile-enforced module
+boundaries and standalone reuse of the lower crates. Adding a focused leaf crate
+when a concern is genuinely shared by two or more crates (as with
+`algonaut_abi_model` and `algonaut_abi_sig`) is acceptable and expected; the
+extra published artifact is the price of the cleaner layering, not a reason to
+avoid it.
+
+Do **not** attempt to cut published crates via features, path-only
+dependencies, or yanking — none of them can. If reducing published artifacts
+ever becomes a real goal, the only valid path is a deliberate, breaking
+consolidation release that collapses crates into modules, accepting the
+proc-macro floor above; that would warrant its own ADR.
+
+If the felt pain is release *friction* rather than crate *count*, the lever is
+release automation (`release-plz` / `cargo-release` / `cargo workspaces`) that
+publishes the graph in dependency order from one command — not a change to the
+architecture.
+
+## Consequences
+
+- **Predictable, settled policy.** New shared leaf crates are evaluated on
+  cohesion and dependency-isolation merits; "but it's another published crate"
+  is not a blocker, because the count is structural, not discretionary.
+- **Lockstep versioning continues.** Every crate moves to the same version each
+  release; automation is the answer to the ceremony, not consolidation.
+- **Granular consumption preserved.** Downstreams may depend on `algonaut_core`,
+  `algonaut_transaction`, etc. directly.
+- **A consolidation escape hatch exists but is costly.** It is documented here
+  so the trade-off (one breaking refactor, a ~4-crate floor, loss of standalone
+  reuse) doesn't have to be rediscovered next time the question comes up.

--- a/examples/contract_client.rs
+++ b/examples/contract_client.rs
@@ -1,0 +1,111 @@
+//! Generate a type-safe contract client from an ARC-4 ABI JSON file using
+//! the [`contract!`] macro.
+//!
+//! This example demonstrates how `contract!` simplifies contract interaction
+//! compared to manually using `MethodCall::builder()` with `abi_call!`. The
+//! macro reads the ABI JSON at compile time and generates a struct with
+//! typed methods for each ABI method.
+//!
+//! # Comparison
+//!
+//! **Before (manual):**
+//! ```ignore
+//! let call = MethodCall::builder(AppId(123), alice.address(), signer)
+//!     .invoke(abi_call!("add(uint64,uint64)uint64", 2u64, 3u64))
+//!     .build(&params);
+//! ```
+//!
+//! **After (with contract!):**
+//! ```ignore
+//! let calculator = Calculator::new(AppId(123), alice.address(), signer);
+//! let call = calculator.add(2u64, 3u64).build(&params);
+//! ```
+//!
+//! The generated struct also provides network-specific constructors if the
+//! ABI JSON contains a `networks` field.
+
+use algonaut::Algod;
+use algonaut::atomic::AtomicGroupBuilder;
+use algonaut::core::AppId;
+use algonaut::transaction::Signer;
+use algonaut::transaction::account::Account;
+use dotenv::dotenv;
+use std::env;
+use std::error::Error;
+use std::sync::Arc;
+
+#[macro_use]
+extern crate log;
+
+// Generate a typed Calculator client from the ABI JSON.
+// The macro reads the file at compile time and generates:
+//   - A `Calculator` struct holding app_id, sender, and signer
+//   - Methods for each ABI method (add, subtract, etc.)
+//   - Builder structs for each method (CalculatorAddBuilder, etc.)
+//   - Network constructors (testnet, mainnet) if networks are defined
+algonaut::contract!("tests/fixtures/calculator.json");
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    dotenv().ok();
+    env_logger::init();
+
+    info!("creating algod client");
+    let algod = Algod::new(&env::var("ALGOD_URL")?, &env::var("ALGOD_TOKEN")?)?;
+
+    info!("creating account for alice");
+    let alice = Account::from_mnemonic(&env::var("ALICE_MNEMONIC")?)?;
+    // The signer must be typed as Arc<dyn Signer> to work with the generated contract client
+    let signer: Arc<dyn Signer> = Arc::new(alice.clone());
+
+    info!("retrieving suggested params");
+    let params = algod.suggested_params().await?;
+
+    // Create a Calculator client with explicit app ID.
+    // The struct name comes from the "name" field in the ABI JSON.
+    info!("creating calculator client");
+    let calculator = Calculator::new(AppId(123), alice.address(), Arc::clone(&signer));
+
+    // Alternatively, use a network-specific constructor if the ABI JSON
+    // contains a "networks" field with known genesis hashes:
+    //   let calculator = Calculator::testnet(alice.address(), signer);
+    //   let calculator = Calculator::mainnet(alice.address(), signer);
+
+    // Build a method call using the typed interface.
+    // The method signature is validated at compile time from the ABI JSON.
+    // Argument types are also checked — passing a String where u64 is
+    // expected would be a compile error.
+    info!("building add(2, 3) method call");
+    let add_call = calculator.add(2u64, 3u64).build(&params);
+
+    // Multiple calls can be composed into an atomic group.
+    info!("building subtract(10, 4) method call");
+    let subtract_call = Calculator::new(AppId(123), alice.address(), Arc::clone(&signer))
+        .subtract(10u64, 4u64)
+        .build(&params);
+
+    // Execute the atomic group.
+    info!("composing and executing atomic group");
+    let result = AtomicGroupBuilder::new()
+        .add_method_call(add_call)
+        .add_method_call(subtract_call)
+        .build()?
+        .sign()
+        .await?
+        .execute(&algod)
+        .await?;
+
+    info!("confirmed in round {:?}", result.confirmed_round);
+    for (i, r) in result.method_results.iter().enumerate() {
+        info!("method {} return: {:?}", i, r.return_value);
+    }
+
+    // Other supported method types:
+    // - Methods with no arguments: calculator.noop()
+    // - Boolean arguments: calculator.echo_bool(true)
+    // - String arguments: calculator.echo_string("hello".to_string())
+    // - Byte array arguments: calculator.echo_bytes(vec![1, 2, 3])
+    // - Address arguments: calculator.echo_address(alice.address())
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,10 @@
 // Re-exports
 
 pub use algonaut_abi as abi;
+/// Generate a typed contract client from an ARC-4 ABI JSON file.
+///
+/// See [`algonaut_abi::contract`] for full documentation.
+pub use algonaut_abi::contract;
 pub use algonaut_core as core;
 pub use algonaut_crypto as crypto;
 pub use algonaut_model as model;

--- a/tests/fixtures/calculator.json
+++ b/tests/fixtures/calculator.json
@@ -1,0 +1,77 @@
+{
+    "name": "Calculator",
+    "desc": "A simple calculator contract for testing",
+    "methods": [
+        {
+            "name": "add",
+            "desc": "Add two numbers",
+            "args": [
+                {"name": "a", "type": "uint64"},
+                {"name": "b", "type": "uint64"}
+            ],
+            "returns": {"type": "uint64"}
+        },
+        {
+            "name": "subtract",
+            "desc": "Subtract two numbers",
+            "args": [
+                {"name": "a", "type": "uint64"},
+                {"name": "b", "type": "uint64"}
+            ],
+            "returns": {"type": "uint64"}
+        },
+        {
+            "name": "multiply",
+            "args": [
+                {"name": "a", "type": "uint64"},
+                {"name": "b", "type": "uint64"}
+            ],
+            "returns": {"type": "uint128"}
+        },
+        {
+            "name": "divide",
+            "args": [
+                {"name": "dividend", "type": "uint64"},
+                {"name": "divisor", "type": "uint64"}
+            ],
+            "returns": {"type": "uint64"}
+        },
+        {
+            "name": "echo_bool",
+            "args": [
+                {"name": "value", "type": "bool"}
+            ],
+            "returns": {"type": "bool"}
+        },
+        {
+            "name": "echo_string",
+            "args": [
+                {"name": "value", "type": "string"}
+            ],
+            "returns": {"type": "string"}
+        },
+        {
+            "name": "echo_bytes",
+            "args": [
+                {"name": "data", "type": "byte[]"}
+            ],
+            "returns": {"type": "byte[]"}
+        },
+        {
+            "name": "echo_address",
+            "args": [
+                {"name": "addr", "type": "address"}
+            ],
+            "returns": {"type": "address"}
+        },
+        {
+            "name": "noop",
+            "args": [],
+            "returns": {"type": "void"}
+        }
+    ],
+    "networks": {
+        "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=": {"appID": 123},
+        "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=": {"appID": 456}
+    }
+}

--- a/tests/fixtures/calculator_unsupported.json
+++ b/tests/fixtures/calculator_unsupported.json
@@ -1,0 +1,40 @@
+{
+    "name": "CalculatorWithUnsupported",
+    "desc": "A contract with methods containing unsupported types for testing error messages",
+    "methods": [
+        {
+            "name": "add",
+            "desc": "Add two numbers (supported)",
+            "args": [
+                {"name": "a", "type": "uint64"},
+                {"name": "b", "type": "uint64"}
+            ],
+            "returns": {"type": "uint64"}
+        },
+        {
+            "name": "transfer",
+            "desc": "Transfer with payment (has transaction arg - unsupported)",
+            "args": [
+                {"name": "payment", "type": "pay"},
+                {"name": "amount", "type": "uint64"}
+            ],
+            "returns": {"type": "void"}
+        },
+        {
+            "name": "opt_in_asset",
+            "desc": "Opt into an asset (has reference arg - unsupported)",
+            "args": [
+                {"name": "asset", "type": "asset"}
+            ],
+            "returns": {"type": "void"}
+        },
+        {
+            "name": "batch_add",
+            "desc": "Add multiple numbers (has array arg - unsupported)",
+            "args": [
+                {"name": "numbers", "type": "uint64[]"}
+            ],
+            "returns": {"type": "uint64"}
+        }
+    ]
+}

--- a/tests/test_contract_macro.rs
+++ b/tests/test_contract_macro.rs
@@ -1,0 +1,89 @@
+//! Integration tests for the `contract!` macro.
+
+use algonaut::contract;
+use algonaut_core::AppId;
+use algonaut_transaction::account::Account;
+use std::sync::Arc;
+
+// Generate the Calculator contract client
+contract!("tests/fixtures/calculator.json");
+
+#[test]
+fn test_generated_struct_exists() {
+    let alice = Account::generate();
+    let address = alice.address();
+    let signer = Arc::new(alice);
+
+    // Test that the generated struct can be created
+    let calculator = Calculator::new(AppId(123), address, signer);
+
+    // Test that accessor methods work
+    assert_eq!(calculator.app_id(), AppId(123));
+    assert_eq!(calculator.sender(), address);
+}
+
+#[test]
+fn test_network_constructors() {
+    use algonaut_transaction::Signer;
+
+    let alice = Account::generate();
+    let address = alice.address();
+    let signer: Arc<dyn Signer> = Arc::new(alice);
+
+    // Test testnet constructor (app ID 123 from the JSON)
+    let testnet_calculator = Calculator::testnet(address, Arc::clone(&signer));
+    assert_eq!(testnet_calculator.app_id(), AppId(123));
+
+    // Test mainnet constructor (app ID 456 from the JSON)
+    let mainnet_calculator = Calculator::mainnet(address, signer);
+    assert_eq!(mainnet_calculator.app_id(), AppId(456));
+}
+
+#[test]
+fn test_method_builders_exist() {
+    let alice = Account::generate();
+    let address = alice.address();
+    let signer = Arc::new(alice);
+    let calculator = Calculator::new(AppId(123), address, signer);
+
+    // Test that method builders can be created
+    // These calls don't actually build or execute, just verify the methods exist
+    // and accept the correct argument types
+    let _add_builder = calculator.add(2u64, 3u64);
+    let _subtract_builder = calculator.subtract(5u64, 2u64);
+    let _multiply_builder = calculator.multiply(4u64, 5u64);
+    let _divide_builder = calculator.divide(10u64, 2u64);
+    let _bool_builder = calculator.echo_bool(true);
+    let _string_builder = calculator.echo_string("hello".to_string());
+    let _bytes_builder = calculator.echo_bytes(vec![1, 2, 3]);
+    let _address_builder = calculator.echo_address(address);
+    let _noop_builder = calculator.noop();
+}
+
+#[test]
+fn test_method_builder_returns_method_call() {
+    use algonaut_crypto::HashDigest;
+    use algonaut_model::algod::SuggestedParams;
+
+    let alice = Account::generate();
+    let address = alice.address();
+    let signer = Arc::new(alice);
+    let calculator = Calculator::new(AppId(123), address, signer);
+
+    // Create mock suggested params
+    let params = SuggestedParams {
+        consensus_version: "test".to_string(),
+        fee: algonaut_core::MicroAlgos(0),
+        genesis_hash: HashDigest([0u8; 32]),
+        genesis_id: "test".to_string(),
+        last_round: algonaut_core::Round(1000),
+        min_fee: algonaut_core::MicroAlgos(1000),
+    };
+
+    // Build a method call
+    let method_call = calculator.add(2u64, 3u64).build(&params);
+
+    // Verify the method call is configured correctly
+    // (We can't easily inspect the internals, but at least we verify it compiles)
+    let _ = method_call;
+}


### PR DESCRIPTION
## Summary

- Add `contract!("path/to/contract.json")` procedural macro that reads an ARC-4 ABI JSON file at compile time and generates a type-safe Rust struct with methods for each ABI method
- The generated struct holds `app_id`, `sender`, and `signer`; each method returns a builder that produces a `MethodCall`
- Network-specific constructors (`testnet()`, `mainnet()`, `betanet()`) are generated if the ABI JSON contains a `networks` field

## Example

**Before (manual approach):**
```rust
use algonaut::abi::abi_call;
use algonaut::atomic::MethodCall;

// Manually specify the signature for each call
let call = MethodCall::builder(AppId(123), alice.address(), signer)
    .invoke(abi_call!("add(uint64,uint64)uint64", 2u64, 3u64))
    .build(&params);
```

**After (with contract!):**
```rust
// Generate typed client from ABI JSON
algonaut::contract!("contracts/calculator.json");

// Create client instance
let calculator = Calculator::new(AppId(123), alice.address(), signer);

// Call methods with full type safety and IDE autocompletion
let add_call = calculator.add(2u64, 3u64).build(&params);
let sub_call = calculator.subtract(10u64, 4u64).build(&params);

// Execute as atomic group
let result = AtomicGroupBuilder::new()
    .add_method_call(add_call)
    .add_method_call(sub_call)
    .build()?
    .sign()
    .await?
    .execute(&algod)
    .await?;
```

**Network-specific constructors:**
```rust
// If the ABI JSON contains a "networks" field with known genesis hashes,
// named constructors are generated automatically
let calculator = Calculator::testnet(alice.address(), signer);
let calculator = Calculator::mainnet(alice.address(), signer);
```

## Supported Types

| ABI Type | Rust Type |
|----------|-----------|
| `uint8/16/32/64/128` | `u8/u16/u32/u64/u128` |
| `uint256+` | `num_bigint::BigUint` |
| `bool` | `bool` |
| `address` | `algonaut_core::Address` |
| `string` | `String` |
| `byte[]` | `Vec<u8>` |

Methods with unsupported types (transaction/reference args, arrays, tuples) generate compile errors with guidance to use the dynamic path. See #342 for tracking remaining type support.

## Test plan

- [x] Unit tests for JSON parsing, type mapping, and code generation helpers
- [x] Integration tests verifying generated struct, methods, and builders
- [x] Example demonstrating full usage (`examples/contract_client.rs`)
- [x] All existing tests pass