### PR TITLE
chore: add coderabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+reviews:
+  path_filters:
+    - "!openapi/generated/**"
+    - "!openapi/specs/**"
+    - "!**/Cargo.lock"
+  auto_review:
+    enabled: true
+    drafts: false
+  commit_status: true
+  enable_prompt_for_ai_agents: true
+  high_level_summary: false
+  poem: false
+  profile: "chill"
+  review_status: true
+  review_details: false
+  request_changes_workflow: true
+chat:
+  auto_reply: true


### PR DESCRIPTION
## Summary
- Adds `.coderabbit.yaml` mirroring the moonbeam setup: chill profile, auto-review on non-draft PRs, AI-agent prompts, request-changes workflow, chat auto-reply.
- Excludes `openapi/generated/**`, `openapi/specs/**` (vendored upstream), and `**/Cargo.lock` from review.

## Test plan
- [ ] CodeRabbit picks up the config on this PR (auto-review fires, no review on excluded paths).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code review integration configuration to streamline the review process with auto-review functionality and commit status reporting enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manuelmauro/algonaut/pull/358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->