### PR TITLE
test(cucumber): restore resource path broken by suite relocation (#344)

### DIFF
--- a/tests/cucumber/step_defs/integration/compile.rs
+++ b/tests/cucumber/step_defs/integration/compile.rs
@@ -6,8 +6,8 @@ use data_encoding::BASE64;
 use std::fs;
 
 fn read_resource(name: &str) -> Vec<u8> {
-    fs::read(format!("tests/features/resources/{name}"))
-        .unwrap_or_else(|e| panic!("failed to read tests/features/resources/{name}: {e}"))
+    fs::read(format!("tests/cucumber/features/resources/{name}"))
+        .unwrap_or_else(|e| panic!("failed to read tests/cucumber/features/resources/{name}: {e}"))
 }
 
 fn parse_status_from_error(err: &str) -> u16 {

--- a/tests/cucumber/step_defs/integration/dryrun.rs
+++ b/tests/cucumber/step_defs/integration/dryrun.rs
@@ -17,8 +17,8 @@ const NONEXISTENT_SENDER: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 const SECONDARY_ACCOUNT: &str = "6Z3C3LDVWGMX23BMSYMANACQOSINPFIRF77H7N3AWJZYV6OH6GWTJKVMXY";
 
 fn read_program(name: &str) -> Vec<u8> {
-    fs::read(format!("tests/features/resources/{name}"))
-        .unwrap_or_else(|e| panic!("failed to read tests/features/resources/{name}: {e}"))
+    fs::read(format!("tests/cucumber/features/resources/{name}"))
+        .unwrap_or_else(|e| panic!("failed to read tests/cucumber/features/resources/{name}: {e}"))
 }
 
 #[derive(Debug, Clone)]

--- a/tests/cucumber/step_defs/unit/v2_client_responses.rs
+++ b/tests/cucumber/step_defs/unit/v2_client_responses.rs
@@ -3,7 +3,7 @@
 //!
 //! These are fixture-driven response-deserialization unit tests. A canned
 //! HTTP response body (a base64-decoded fixture from
-//! `tests/features/resources/`) is loaded into a local
+//! `tests/cucumber/features/resources/`) is loaded into a local
 //! [`ResponseMockServer`]; the SDK is pointed at it, a high-level
 //! `Algod`/`Indexer` call is made, and the *parsed* response is asserted on.
 //!
@@ -44,7 +44,7 @@ fn placeholder_transaction_id() -> TransactionId {
 /// `*.base64` fixtures hold a base64-encoded body (msgpack or otherwise) and
 /// are decoded; every other fixture (`*.json`, …) is served verbatim.
 fn load_body(directory: &str, file: &str) -> Vec<u8> {
-    let path = Path::new("tests/features/resources")
+    let path = Path::new("tests/cucumber/features/resources")
         .join(directory)
         .join(file);
     let raw = fs::read(&path).unwrap_or_else(|e| panic!("reading fixture {path:?}: {e}"));

--- a/tests/cucumber/step_defs/util.rs
+++ b/tests/cucumber/step_defs/util.rs
@@ -51,7 +51,7 @@ pub fn account_from_kmd_response(key_res: &ExportKeyResponse) -> Result<Account,
 }
 
 pub async fn read_teal(algod: &Algod, file_name: &str) -> CompiledTeal {
-    let file_bytes = fs::read(&format!("tests/features/resources/{file_name}")).unwrap();
+    let file_bytes = fs::read(&format!("tests/cucumber/features/resources/{file_name}")).unwrap();
 
     if file_name.ends_with(".teal") {
         algod


### PR DESCRIPTION
## What

PR #344 relocated the cucumber suite to `tests/cucumber/`, moving the resource files to `tests/cucumber/features/resources/`, but four step-def helpers kept reading from the old `tests/features/resources/` path. Every scenario that reads a TEAL program or a JSON response fixture panicked with `NotFound`, taking down whole features.

Points the four helpers at the relocated directory:
- `tests/cucumber/step_defs/util.rs` (`read_teal`)
- `tests/cucumber/step_defs/integration/compile.rs`
- `tests/cucumber/step_defs/integration/dryrun.rs`
- `tests/cucumber/step_defs/unit/v2_client_responses.rs`

## Impact

Measured on a fresh sandbox (`make harness && make cucumber`), before vs after:

| | Failing |
|---|---|
| before | ~93 / ~290 |
| after | **10** |

78 scenarios flip green — ABI (17), Compile (8), Dryrun (4), Dryrun Testing (22), Algod v2 Responses (14), Indexer v2 Responses (13). Applications' 4 move from *failed* to *skipped* (a downstream step-def gap, separate work).

The residual 10 are pre-existing real clusters tracked in #331 (kmd↔SDK msgpack mismatch ×2, simulate response ×4, composer-clone ×1, setup cascades ×3) and are out of scope here.

## Notes

CI only runs `check-cucumber` (`--no-run`), so this breakage never gated merges. Verified locally against a fresh dockerized harness.