### PR TITLE
fix(transaction): omit sgnr from non-rekeyed signed transactions

### DIFF
--- a/algonaut_model/src/transaction.rs
+++ b/algonaut_model/src/transaction.rs
@@ -199,14 +199,18 @@ pub struct ApiSignedTransaction {
     #[serde(rename = "msig", skip_serializing_if = "Option::is_none")]
     pub msig: Option<MultisigSignature>,
 
+    // `sgnr` (the auth address) sorts before `sig` in canonical msgpack
+    // ('g' < 'i') and, like every other optional, must be omitted when absent —
+    // otherwise a stray `sgnr` makes the encoding differ byte-for-byte from the
+    // node's / kmd's canonical signed transaction.
+    #[serde(rename = "sgnr", skip_serializing_if = "Option::is_none")]
+    pub auth_address: Option<Address>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sig: Option<Signature>,
 
     #[serde(rename = "txn")]
     pub transaction: ApiTransaction,
-
-    #[serde(rename = "sgnr")]
-    pub auth_address: Option<Address>,
 
     #[serde(skip)]
     pub transaction_id: TransactionId,

--- a/algonaut_transaction/src/api_model.rs
+++ b/algonaut_transaction/src/api_model.rs
@@ -798,6 +798,51 @@ mod tests {
         assert_eq!(round_tripped.auth_address(), Some(&bob.address()));
     }
 
+    /// The top-level msgpack map keys of an encoded value, decoded
+    /// structurally (each value skipped) so an address that happens to contain
+    /// the bytes `sgnr` can't produce a false positive.
+    fn top_level_keys(bytes: &[u8]) -> std::collections::BTreeSet<String> {
+        let map: std::collections::BTreeMap<String, serde::de::IgnoredAny> =
+            rmp_serde::from_slice(bytes).unwrap();
+        map.into_keys().collect()
+    }
+
+    /// Algorand's canonical msgpack omits absent fields. A non-rekeyed signed
+    /// transaction must therefore drop the `sgnr` (auth address) key entirely;
+    /// emitting `sgnr: null` makes `to_msg_pack()` differ byte-for-byte from
+    /// kmd's / the node's signed transaction (the kmd "sign both ways"
+    /// acceptance scenarios). The rekeyed counterpart still carries it.
+    #[test]
+    fn signed_transaction_encodes_sgnr_only_when_rekeyed() {
+        let params = StubParams {
+            genesis_id: "testnet-v1.0".to_owned(),
+        };
+        let alice = Account::generate();
+        let bob = Account::generate();
+
+        // Sender signs its own transaction: no rekey, so `auth_address` is None.
+        let tx = Pay::new(alice.address(), alice.address(), MicroAlgos(1_000))
+            .build(&params)
+            .unwrap();
+        let signed = alice.sign(tx).unwrap();
+        assert_eq!(signed.auth_address(), None);
+        assert!(
+            !top_level_keys(&signed.to_msg_pack().unwrap()).contains("sgnr"),
+            "a non-rekeyed signed transaction must not encode a `sgnr` key"
+        );
+
+        // A different signer rekeys the transaction, so `sgnr` reappears.
+        let tx = Pay::new(alice.address(), alice.address(), MicroAlgos(1_000))
+            .build(&params)
+            .unwrap();
+        let rekeyed = bob.sign(tx).unwrap();
+        assert_eq!(rekeyed.auth_address(), Some(&bob.address()));
+        assert!(
+            top_level_keys(&rekeyed.to_msg_pack().unwrap()).contains("sgnr"),
+            "a rekeyed signed transaction must encode a `sgnr` key"
+        );
+    }
+
     struct DummyAppCall {
         app_id: Option<AppId>,
         foreign_apps: Option<Vec<AppId>>,


### PR DESCRIPTION
## Bug

`ApiSignedTransaction.auth_address` (the `sgnr` auth-address field) was the only optional field **without** `skip_serializing_if`, so every non-rekeyed signed transaction encoded a spurious `sgnr: null`. Algorand's canonical msgpack omits absent fields, so `SignedTransaction::to_msg_pack()` differed **byte-for-byte** from kmd's (and the node's) signed transaction.

Surfaced by the kmd *"sign both ways"* acceptance scenarios:

```
assertion `left == right` failed: sdk signed tx != kmd signed tx
```

## Fix

- Add `skip_serializing_if = "Option::is_none"` to `sgnr` so it is dropped when there is no rekey.
- Move `sgnr` to its canonical sorted position — it sorts before `sig` (`'g' < 'i'`) — so rekeyed transactions also encode canonically (the struct already documents that fields must be alphabetically ordered).

## Test

Adds `signed_transaction_encodes_sgnr_only_when_rekeyed`, which decodes the msgpack map keys structurally and asserts `sgnr` is absent for a self-signed transaction and present for a rekeyed one. The existing round-trip test still passes; full workspace unit suite green (225 tests).

The two kmd `sign both ways` scenarios are part of the broader integration-suite cleanup (#331); they are verified end-to-end alongside the resource-path fix (#363) on a fresh harness.