### PR TITLE
fix(cucumber): fail the test run when scenarios fail

### DIFF
--- a/tests/cucumber/main.rs
+++ b/tests/cucumber/main.rs
@@ -24,6 +24,7 @@
 //! reference.
 
 use cucumber::World;
+use cucumber::writer::Stats;
 use step_defs::{integration, unit};
 
 mod step_defs;
@@ -303,45 +304,67 @@ fn scenario_enabled(
     true
 }
 
+/// Report a feature run's failures and return whether it had any.
+///
+/// `cucumber`'s `filter_run` *reports* failed/errored steps but never fails the
+/// process, so without this check `cargo test --test cucumber` exits 0 even when
+/// scenarios fail — and CI lights green on a red suite.
+fn run_had_failures<Wld, Wr: Stats<Wld>>(path: &str, writer: &Wr) -> bool {
+    if writer.execution_has_failed() {
+        eprintln!(
+            "FAILED {path}: {} failed step(s), {} parsing error(s), {} hook error(s)",
+            writer.failed_steps(),
+            writer.parsing_errors(),
+            writer.hook_errors(),
+        );
+        true
+    } else {
+        false
+    }
+}
+
 async fn run_integration(
     path: &str,
     excluded_tags: &'static [&'static str],
     excluded_scenarios: &'static [&'static str],
-) {
-    integration::world::World::cucumber()
+) -> bool {
+    let writer = integration::world::World::cucumber()
         .max_concurrent_scenarios(1)
         .filter_run(path, move |_, _, sc| {
             scenario_enabled(sc, excluded_tags, excluded_scenarios)
         })
         .await;
+    run_had_failures(path, &writer)
 }
 
 async fn run_unit(
     path: &str,
     excluded_tags: &'static [&'static str],
     excluded_scenarios: &'static [&'static str],
-) {
-    unit::world::UnitWorld::cucumber()
+) -> bool {
+    let writer = unit::world::UnitWorld::cucumber()
         .max_concurrent_scenarios(1)
         .filter_run(path, move |_, _, sc| {
             scenario_enabled(sc, excluded_tags, excluded_scenarios)
         })
         .await;
+    run_had_failures(path, &writer)
 }
 
 #[tokio::main]
 async fn main() {
     let mut skipped: Vec<(&str, &str)> = Vec::new();
+    let mut any_failed = false;
 
     for feature in INTEGRATION_FEATURES {
         match feature.gate {
             None => {
-                run_integration(
+                any_failed |= run_integration(
                     feature.path,
                     feature.excluded_tags,
                     feature.excluded_scenarios,
                 )
-                .await
+                .await;
             }
             Some(reason) => skipped.push((feature.path, reason)),
         }
@@ -350,12 +373,12 @@ async fn main() {
     for feature in UNIT_FEATURES {
         match feature.gate {
             None => {
-                run_unit(
+                any_failed |= run_unit(
                     feature.path,
                     feature.excluded_tags,
                     feature.excluded_scenarios,
                 )
-                .await
+                .await;
             }
             Some(reason) => skipped.push((feature.path, reason)),
         }
@@ -366,5 +389,13 @@ async fn main() {
         for (path, reason) in skipped {
             eprintln!("  - {path}\n      {reason}");
         }
+    }
+
+    // `filter_run` reports failures but does not fail the process; propagate a
+    // non-zero exit so `cargo test --test cucumber` (and the CI job) goes red
+    // when any scenario fails, instead of lighting green on a red suite.
+    if any_failed {
+        eprintln!("\nintegration suite FAILED — see the FAILED lines above");
+        std::process::exit(1);
     }
 }


### PR DESCRIPTION
## Bug

The `cargo-test-integration` CI job **runs** the acceptance suite (`cargo test --test cucumber --`, ~12 min — not `--no-run`), but the runner called cucumber's `filter_run(...)` and **discarded the returned writer**. `filter_run` reports failed/errored steps without failing the process, and the suite is `harness = false` (so `main()`'s exit code is the test result) — so `main()` always returned success and the job **lit green even on a red suite**.

## Fix

`tests/cucumber/main.rs`: capture each feature run's writer, check `writer.execution_has_failed()` (cucumber 0.23 `writer::Stats` — failed steps / parsing errors / hook errors), print a `FAILED <feature>` line, accumulate across all features, and `std::process::exit(1)` at the end if any failed. Every feature still runs first, so the full failure picture is reported.

Verified locally: `cargo test --test cucumber` now exits non-zero on a failing suite.

## ⚠️ Expected consequence

This makes `cargo-test-integration` **honestly red** while the suite has its current known failures — so this PR's own integration check will go red. That's the point (it was masking them). On a fresh harness the suite shows ~13 failures, which are deterministic-per-harness and trace to:

- **Unstable kmd account ordering + sender/signer/funder conflation** in the harness step-defs (`build_default_payment` hardcodes the sender to `accounts[0]`, which isn't guaranteed funded; the sign step signs with the funder) → overspend / `should have been authorized by …`.
- `composer-clone` (a World state-machine gap) and the `(byte,byte[17])` ABI-return decode.

Suite **stabilization is tracked as separate work** — this PR only makes CI tell the truth. Treat the `cargo-test-integration` check accordingly (e.g. not a required merge gate) until the suite is green.