### PR TITLE
test(cucumber): fund payment and rekey senders from a funded account

### DIFF
--- a/tests/cucumber/step_defs/integration/rekey.rs
+++ b/tests/cucumber/step_defs/integration/rekey.rs
@@ -1,3 +1,4 @@
+use crate::step_defs::integration::general::pick_funded_account;
 use crate::step_defs::integration::world::World;
 use algonaut_core::{Address, MicroAlgos};
 use algonaut_transaction::{Pay, account::Account};
@@ -17,9 +18,10 @@ async fn i_generate_a_key_using_kmd_for_rekeying_and_fund_it(
     let key_resp = kmd.generate_key(handle).await?;
     let new_addr: Address = key_resp.address.parse()?;
 
-    // Fund the freshly-generated account from the first wallet account so
-    // it can pay fees and serve as the rekey sender.
-    let funder = accounts[0];
+    // Fund the freshly-generated account from a funded wallet account so it
+    // can pay fees and serve as the rekey sender. kmd's list_keys ordering is
+    // unstable, so `accounts[0]` is not reliably funded.
+    let funder = pick_funded_account(algod, accounts).await?;
     let funder_key = kmd.export_key(handle, password, &funder).await?;
     let funder_account = Account::from_seed(funder_key.private_key[0..32].try_into()?);
     let params = algod.suggested_params().await?;

--- a/tests/cucumber/step_defs/integration/send.rs
+++ b/tests/cucumber/step_defs/integration/send.rs
@@ -1,4 +1,7 @@
-use crate::step_defs::{integration::world::World, util::account_from_kmd_response};
+use crate::step_defs::{
+    integration::general::pick_funded_account, integration::world::World,
+    util::account_from_kmd_response,
+};
 use algonaut_core::{
     MicroAlgos, MultisigAddress, Round, StateProofPk, TransactionId, VotePk, VrfPk,
 };
@@ -14,7 +17,6 @@ const TEST_STATE_PROOF_PK: &str =
 
 async fn build_default_payment(
     w: &mut World,
-    sender_index: usize,
     receiver_index: usize,
     amt: u64,
     note_b64: &str,
@@ -28,11 +30,14 @@ async fn build_default_payment(
         BASE64.decode(note_b64.as_bytes())?
     };
 
-    let mut tx_builder = Pay::new(
-        accounts[sender_index],
-        accounts[receiver_index],
-        MicroAlgos(amt),
-    );
+    // kmd's list_keys ordering is unstable, so `accounts[0]` is not reliably the
+    // pre-funded creator — a payment from it would overspend. Use the funded
+    // account as the sender; "I get the private key" exports `tx.sender()`'s key
+    // to sign, so sender and signer stay consistent.
+    let sender = pick_funded_account(algod, accounts).await?;
+    let receiver = accounts[receiver_index];
+
+    let mut tx_builder = Pay::new(sender, receiver, MicroAlgos(amt));
     if !note.is_empty() {
         tx_builder = tx_builder.note(note.clone());
     }
@@ -47,7 +52,7 @@ async fn default_transaction_with_parameters(
     amt: u64,
     note_b64: String,
 ) -> Result<(), Box<dyn Error>> {
-    build_default_payment(w, 0, 1, amt, &note_b64).await
+    build_default_payment(w, 1, amt, &note_b64).await
 }
 
 #[given(regex = r#"^default multisig transaction with parameters (\d+) "([^"]*)"$"#)]


### PR DESCRIPTION
## Problem

Several integration step-defs used `accounts[0]` as the payment / funding sender, but kmd's `list_keys` ordering is unstable — `accounts[0]` is **not reliably the pre-funded creator** (the harness even documents this in `pick_funded_account`). On harness instances where it lands on an unfunded account, the simulated/submitted payments overspend (`account … MicroAlgos:0, tried to spend …`), cascading into `overspend`, `should have been authorized by …`, and `tx id not set` failures across `simulate`, `send`, and `rekey`. Because the failure depends on account ordering, it was deterministic per-harness but varied across harness instances.

## Fix

Use `pick_funded_account` (the highest-balance wallet account) as the sender in `build_default_payment` and the rekey funding step. The sign step exports `tx.sender()`'s key, so **sender and signer stay consistent**.

## Result

On a fresh harness this drops the suite from **13 → 6** failing. The remaining six are **distinct** root causes, each a follow-up:

| Feature | Scenario | Cause |
|---|---|---|
| simulate | duplicate/overspending | `composer-clone` World state machine (`no composer in progress`) |
| simulate | bad inner ATC | `(byte,byte[17])` ABI-return decode (`unwrap` on `None`) |
| simulate | unsigned ATC | `expected a failure message but the group did not fail` |
| send | key registration | keyreg sender (registering the funded creator risks stalling the sandbox) |
| assets | reconfigure | asset-index tracking (`asset does not exist`) |
| kmd | wallet handle | scenario needs its own `I create a wallet` (`created wallet id not set`) |

## CI note

`cargo-test-integration` now runs the suite for real (#366), so this PR's integration check will still be **red** (6 failures) — but a strictly smaller red than before. It goes green once the follow-ups land.